### PR TITLE
Add missing widgets to navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@
     <ul>
       <li><a href="nkant.html" target="content">nKant</a></li>
       <li><a href="graftegner.html" target="content">Graftegner</a></li>
+      <li><a href="brøkpizza.html" target="content">Brøkpizza</a></li>
+      <li><a href="perlesnor.html" target="content">Perlesnor</a></li>
+      <li><a href="tenkeblokker.html" target="content">Tenkeblokker</a></li>
     </ul>
   </nav>
   <iframe name="content" src="nkant.html" title="Innhold"></iframe>


### PR DESCRIPTION
## Summary
- Expand index page navigation to link new widgets Brøkpizza, Perlesnor, and Tenkeblokker.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c04a2c1a188324853a99a4d6315578