### PR TITLE
Move diagram settings into side card layout

### DIFF
--- a/diagram.html
+++ b/diagram.html
@@ -6,8 +6,35 @@
   <title>Interaktivt stolpediagram (UU)</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <style>
-    .wrap{display:grid;place-items:center;gap:12px;padding:16px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
-    svg{width:min(900px,95vw);height:auto;background:#fff}
+    :root { --gap: 18px; }
+    html,body { height: 100%; }
+    body {
+      margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
+      color: #111827; background: #f7f8fb; padding: 20px;
+    }
+    .wrap { max-width: 1200px; margin: 0 auto; }
+    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
+    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
+    .card {
+      background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
+      box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 14px; display: flex;
+      flex-direction: column; gap: 10px;
+    }
+    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+    .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
+    .figure svg { width: 100%; height: auto; display: block; background: #fff; }
+    .toolbar { display: flex; gap: 10px; justify-content: flex-end; }
+    .btn {
+      appearance: none; border: 1px solid #d1d5db; background: #fff; border-radius: 10px;
+      padding: 8px 12px; font-size: 14px; cursor: pointer;
+      transition: box-shadow .2s, transform .02s;
+    }
+    .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
+    .btn:active { transform: translateY(1px); }
+    .status { min-height: 1.8em; font-size: 16px; }
+    .settings { display: flex; flex-direction: column; gap: 8px; }
+    .settings label { display: flex; flex-direction: column; font-size: 13px; color: #4b5563; }
+    .settings input { padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 10px; font-size: 14px; background: #fff; }
 
     /* Akser og rutenett */
     .axis{stroke:#222;stroke-width:3;fill:none}
@@ -31,68 +58,57 @@
     /* Fokus + tastatur (A11y-overlay) */
     .a11y{cursor:ns-resize}
     .a11y:focus{outline:none;stroke:#1e88e5;stroke-width:3}
-
-    /* Knapper/status */
-    .btn{padding:8px 12px;border:1px solid #cfcfcf;border-radius:10px;background:#fff;cursor:pointer;font-size:14px;
-         box-shadow:0 2px 10px rgba(0,0,0,.06)}
-    .btn:hover{background:#f7f7f7}
-    .toolbar{display:flex;gap:10px}
-    .status{min-height:1.8em;font-size:16px}
-
-    /* Innstillinger */
-    details{margin-top:16px;width:100%}
-    details[open]{display:block}
-    details summary{cursor:pointer;font-weight:600;font-size:16px}
-    .settings{display:flex;flex-direction:column;gap:8px;margin-top:8px}
-    .settings label{display:flex;flex-direction:column;font-size:14px}
-    .settings input{padding:6px;border:1px solid #cfcfcf;border-radius:8px;font-size:14px}
   </style>
 </head>
 <body>
   <div class="wrap">
-    <svg id="barsvg" viewBox="0 0 900 560" aria-label="Interaktivt stolpediagram"></svg>
-
-    <div class="toolbar">
-      <button id="btnCheck" class="btn">Sjekk</button>
-      <button id="btnReset" class="btn">Nullstill</button>
-      <button id="btnShow"  class="btn">Vis fasit</button>
-    </div>
-
-    <div id="status" class="status" role="status" aria-live="polite"></div>
-
-    <details>
-      <summary>Innstillinger</summary>
-      <div class="settings">
-        <label>Etiketter (kommaseparert)
-          <input id="cfgLabels" type="text" value="1,2,4,6,Ingen">
-        </label>
-        <label>Startverdier
-          <input id="cfgStart" type="text" value="8,0,7,0,0">
-        </label>
-        <label>Fasitverdier
-          <input id="cfgAnswer" type="text" value="10,6,3,1,4">
-        </label>
-        <label>Maks y (valgfritt)
-          <input id="cfgYMax" type="text" value="15">
-        </label>
-        <label>Navn på x-akse
-          <input id="cfgAxisXLabel" type="text" value="Ant. bøker">
-        </label>
-        <label>Navn på y-akse
-          <input id="cfgAxisYLabel" type="text" value="Antall elever">
-        </label>
-        <label>Steg (snap)
-          <input id="cfgSnap" type="text" value="1">
-        </label>
-        <label>Toleranse
-          <input id="cfgTolerance" type="text" value="0">
-        </label>
-        <button id="btnApplyCfg" class="btn" type="button">Bruk innstillinger</button>
+    <div class="grid">
+      <div class="card">
+        <h2>Diagram</h2>
+        <div class="figure">
+          <svg id="barsvg" viewBox="0 0 900 560" aria-label="Interaktivt stolpediagram"></svg>
+        </div>
+        <div class="toolbar">
+          <button id="btnCheck" class="btn">Sjekk</button>
+          <button id="btnReset" class="btn">Nullstill</button>
+          <button id="btnShow" class="btn">Vis fasit</button>
+        </div>
+        <div id="status" class="status" role="status" aria-live="polite"></div>
       </div>
-    </details>
+
+      <div class="card">
+        <h2>Innstillinger</h2>
+        <div class="settings">
+          <label>Etiketter (kommaseparert)
+            <input id="cfgLabels" type="text" value="1,2,4,6,Ingen">
+          </label>
+          <label>Startverdier
+            <input id="cfgStart" type="text" value="8,0,7,0,0">
+          </label>
+          <label>Fasitverdier
+            <input id="cfgAnswer" type="text" value="10,6,3,1,4">
+          </label>
+          <label>Maks y (valgfritt)
+            <input id="cfgYMax" type="text" value="15">
+          </label>
+          <label>Navn på x-akse
+            <input id="cfgAxisXLabel" type="text" value="Ant. bøker">
+          </label>
+          <label>Navn på y-akse
+            <input id="cfgAxisYLabel" type="text" value="Antall elever">
+          </label>
+          <label>Steg (snap)
+            <input id="cfgSnap" type="text" value="1">
+          </label>
+          <label>Toleranse
+            <input id="cfgTolerance" type="text" value="0">
+          </label>
+          <button id="btnApplyCfg" class="btn" type="button">Bruk innstillinger</button>
+        </div>
+      </div>
+    </div>
   </div>
 
-  <!-- Legg JS i egen fil eller her: -->
   <script src="diagram.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Align diagram page layout with other visualizations by moving settings into a right-side card
- Adopt shared card/grid styling for diagram interface

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c05b122804832482e768cd865391b7