### PR TITLE
feat: add side settings for area model

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -8,23 +8,33 @@
   <style>
     html,body{height:100%;margin:0;}
     body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;background:#fff;}
-    #box{width:100%;height:calc(100vh - 56px);}
+    .grid{display:flex;height:100%;}
+    .left{flex:1;display:flex;flex-direction:column;}
+    #box{flex:1;}
     .toolbar{display:flex;gap:8px;padding:8px;}
-    .settings-menu{display:flex;gap:8px;padding:8px;}
+    .settings{width:220px;padding:8px;display:flex;flex-direction:column;gap:8px;}
+    .settings h2{margin:0 0 4px;font-size:16px;}
+    .settings-menu{display:flex;flex-direction:column;gap:8px;}
   </style>
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
 </head>
 <body>
-  <div id="box" class="jxgbox" aria-label="Arealmodell rektangel"></div>
-  <div class="toolbar">
-    <button id="btnReset" type="button">Reset</button>
-    <button id="btnSvg" type="button">Last ned SVG</button>
-    <button id="btnSvgInteractive" type="button">Last ned interaktiv SVG</button>
-    <button id="btnHtml" type="button">Last ned interaktiv HTML</button>
-    <button id="btnSettings" type="button">Innstillinger</button>
-  </div>
-  <div id="settingsMenu" class="settings-menu" hidden>
-    <label><input type="checkbox" id="chkGrid" checked> Vis rutenett</label>
+  <div class="grid">
+    <div class="left">
+      <div id="box" class="jxgbox" aria-label="Arealmodell rektangel"></div>
+      <div class="toolbar">
+        <button id="btnReset" type="button">Reset</button>
+        <button id="btnSvg" type="button">Last ned SVG</button>
+        <button id="btnSvgInteractive" type="button">Last ned interaktiv SVG</button>
+        <button id="btnHtml" type="button">Last ned interaktiv HTML</button>
+      </div>
+    </div>
+    <div class="settings">
+      <h2>Innstillinger</h2>
+      <div id="settingsMenu" class="settings-menu">
+        <label><input type="checkbox" id="chkGrid" checked> Vis rutenett</label>
+      </div>
+    </div>
   </div>
   <script src="arealmodell0.js"></script>
 </body>

--- a/arealmodell0.js
+++ b/arealmodell0.js
@@ -562,12 +562,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if(S.ch.enabled && S.ch.N) S.ch.allPairs=factorPairsSorted(S.ch.N);
   createBoard();
 
-  const btnSettings=document.getElementById("btnSettings");
-  const menu=document.getElementById("settingsMenu");
   const chkGrid=document.getElementById("chkGrid");
-  if(btnSettings && menu){
-    btnSettings.addEventListener("click",()=>{menu.hidden=!menu.hidden;});
-  }
   if(chkGrid){
     chkGrid.checked = CFG.SIMPLE.showGrid;
     chkGrid.addEventListener("change",()=>{


### PR DESCRIPTION
## Summary
- display area model settings in a panel to the right of the visualization
- simplify initialization by removing the toggle button and wiring grid checkbox directly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c05c82a0c4832493bb05a58b301357