### PR TITLE
style: align perlesnor settings with nkant layout

### DIFF
--- a/perlesnor.html
+++ b/perlesnor.html
@@ -4,36 +4,68 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Perlesnor</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
-
   <style>
-    body{ margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif; background:#fff; }
-    .wrap{ max-width:1100px; margin:24px auto; padding:0 16px; }
-    #beadSVG{ width:100%; height:auto; touch-action:none; display:block; }
+    :root { --gap: 18px; }
+    html, body { height: 100%; }
+    body {
+      margin: 0;
+      font-family: system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans";
+      color: #111827;
+      background: #f7f8fb;
+      padding: 20px;
+    }
+    .wrap { max-width: 1200px; margin: 0 auto; }
+    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
+    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
+    .card {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 14px;
+      box-shadow: 0 1px 2px rgba(0,0,0,.04);
+      padding: 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+    .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
+    .figure svg { width: 100%; height: 360px; display: block; touch-action: none; }
+    label { font-size: 13px; color: #4b5563; }
+    input[type="number"] {
+      border: 1px solid #d1d5db;
+      border-radius: 10px;
+      padding: 8px 10px;
+      font-size: 14px;
+      background: #fff;
+      width: 100%;
+      box-sizing: border-box;
+    }
 
     .beadShadow{ filter: drop-shadow(0 1px 1px rgba(0,0,0,.25)); }
     .beadFallback.red{ fill:#d24a2c; stroke:#b23d22; stroke-width:2; }
     .beadFallback.blue{ fill:#3f7dc0; stroke:#2a5e91; stroke-width:2; }
-
     .clip{ cursor:grab; }
     .clip:active{ cursor:grabbing; }
-
     .slider:focus{ outline:none; stroke:#1e88e5; stroke-width:3; }
-    #settings{ margin-bottom:16px; }
-    #settings label{ display:block; margin:4px 0; }
-    #settings input{ width:4rem; margin-left:8px; }
   </style>
 </head>
 <body>
   <div class="wrap">
-    <!-- Litt høyere arbeidsflate -->
-    <details id="settings">
-      <summary>⚙️ Innstillinger</summary>
-      <label>Antall perler<input id="cfg-nBeads" type="number" min="1"></label>
-      <label>Startposisjon<input id="cfg-startIndex" type="number" min="0"></label>
-      <label>Fasit venstre<input id="cfg-correct" type="number" min="0"></label>
-    </details>
-    <svg id="beadSVG" viewBox="0 0 1400 460" role="img" aria-label="Perlesnor med klype"></svg>
+    <div class="grid">
+      <div class="card">
+        <h2>Perlesnor</h2>
+        <div class="figure">
+          <svg id="beadSVG" viewBox="0 0 1400 460" role="img" aria-label="Perlesnor med klype"></svg>
+        </div>
+      </div>
+
+      <div class="card">
+        <h2>Innstillinger</h2>
+        <label>Antall perler<input id="cfg-nBeads" type="number" min="1"></label>
+        <label>Startposisjon<input id="cfg-startIndex" type="number" min="0"></label>
+        <label>Fasit venstre<input id="cfg-correct" type="number" min="0"></label>
+      </div>
+    </div>
   </div>
 
   <script src="perlesnor.js"></script>


### PR DESCRIPTION
## Summary
- style: introduce card/grid layout for Perlesnor similar to nKant
- style: move Perlesnor controls into right-side settings panel

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c060da22e083248333b22ff0e5e679