### PR TITLE
Add shared download buttons for fraction circles

### DIFF
--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -113,6 +113,10 @@
             </div>
           </div>
         </div>
+        <div class="toolbar">
+          <button id="btnStaticAll" class="btn" type="button">Last ned SVG</button>
+          <button id="btnInteractiveAll" class="btn" type="button">Last ned interaktiv SVG</button>
+        </div>
       </div>
 
       <div class="card">


### PR DESCRIPTION
## Summary
- Replace per-circle download buttons with a single toolbar for the fraction circles
- Export functions now combine all visible circles into one SVG, including interactive variant
- Inline script updated to work when multiple SVGs are embedded

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c063d833188324acbf8a0070e5f0c7