### PR TITLE
Add configurable visibility options for Tenkeblokker

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -7,9 +7,32 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
 
   <style>
-    .tb-wrap{display:grid;place-items:center;gap:16px;padding:20px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
+    :root { --gap:18px; }
+    html,body { height:100%; }
+    body {
+      margin:0;
+      font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+      color:#111827; background:#f7f8fb; padding:20px;
+    }
+    .wrap { max-width:1200px; margin:0 auto; }
+    .grid { display:grid; gap:var(--gap); grid-template-columns:1fr 360px; align-items:start; }
+    @media (max-width:980px){ .grid { grid-template-columns:1fr; } }
+    .card {
+      background:#fff; border:1px solid #e5e7eb; border-radius:14px;
+      box-shadow:0 1px 2px rgba(0,0,0,.04); padding:14px;
+      display:flex; flex-direction:column; gap:10px;
+    }
+    .card h2 { margin:0 0 6px 2px; font-size:16px; font-weight:600; color:#374151; }
+    label { font-size:13px; color:#4b5563; }
+    input[type="number"] {
+      border:1px solid #d1d5db; border-radius:10px;
+      padding:8px 10px; font-size:14px; background:#fff;
+      width:100%; box-sizing:border-box;
+    }
+    .checkbox-row { display:flex; align-items:center; gap:6px; }
+
     /* SVG */
-    #thinkBlocks{width:min(900px,92vw);height:auto;background:#fff}
+    #thinkBlocks{width:100%;height:auto;background:#fff}
     .tb-rect{fill:#e8eedf}
     .tb-rect-empty{fill:#ffffff}
     .tb-frame{fill:none;stroke:#333;stroke-width:6}
@@ -25,27 +48,33 @@
     .tb-stepper button{width:64px;height:48px;border:0;background:#fff;font-size:28px;cursor:pointer}
     .tb-stepper button:active{transform:translateY(1px)}
     .tb-divider{width:1px;height:36px;background:#d6d6e3;margin:0 6px}
-    #settings{margin-bottom:16px}
-    #settings label{display:block;margin:4px 0}
-    #settings input{width:4rem;margin-left:8px}
   </style>
 </head>
 <body>
-  <div class="tb-wrap">
-    <details id="settings">
-      <summary>⚙️ Innstillinger</summary>
-      <label>Totalt<input id="cfg-total" type="number" min="1"></label>
-      <label>Start blokker<input id="cfg-startN" type="number" min="1"></label>
-      <label>Fylte blokker<input id="cfg-startK" type="number" min="0"></label>
-      <label>Min blokker<input id="cfg-minN" type="number" min="1"></label>
-      <label>Maks blokker<input id="cfg-maxN" type="number" min="1"></label>
-    </details>
-    <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker"></svg>
+  <div class="wrap">
+    <div class="grid">
+      <div class="card">
+        <h2>Tenkeblokker</h2>
+        <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker"></svg>
 
-    <div class="tb-stepper" aria-label="Antall blokker">
-      <button id="tbMinus" type="button" aria-label="Færre blokker">−</button>
-      <div class="tb-divider"></div>
-      <button id="tbPlus"  type="button" aria-label="Flere blokker">+</button>
+        <div class="tb-stepper" aria-label="Antall blokker">
+          <button id="tbMinus" type="button" aria-label="Færre blokker">−</button>
+          <div class="tb-divider"></div>
+          <button id="tbPlus"  type="button" aria-label="Flere blokker">+</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <h2>Innstillinger</h2>
+        <label>Totalt<input id="cfg-total" type="number" min="1"></label>
+        <label>Start blokker<input id="cfg-startN" type="number" min="1"></label>
+        <label>Fylte blokker<input id="cfg-startK" type="number" min="0"></label>
+        <label>Min blokker<input id="cfg-minN" type="number" min="1"></label>
+        <label>Maks blokker<input id="cfg-maxN" type="number" min="1"></label>
+        <div class="checkbox-row"><input id="cfg-showWhole" type="checkbox" checked><label for="cfg-showWhole">Vis «hele»</label></div>
+        <div class="checkbox-row"><input id="cfg-showStepper" type="checkbox" checked><label for="cfg-showStepper">Vis pluss/minus</label></div>
+        <div class="checkbox-row"><input id="cfg-showHandle" type="checkbox" checked><label for="cfg-showHandle">Vis håndtak</label></div>
+      </div>
     </div>
   </div>
 

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -6,7 +6,10 @@ const SIMPLE = {
   startN: 5,       // antall blokker (nevner)
   startK: 4,       // antall fylte blokker (teller)
   minN: 2,
-  maxN: 12
+  maxN: 12,
+  showWhole: true,    // vis parentes + total
+  showStepper: true,  // vis pluss/minus-knapper
+  showHandle: true    // vis håndtak
 };
 
 /* ============ ADV KONFIG (VALGFRITT) ============ */
@@ -21,7 +24,10 @@ let CFG = {
   minN: SIMPLE.minN,
   maxN: SIMPLE.maxN,
   bracketTick: ADV.bracketTick,
-  labelOffsetY: ADV.labelOffsetY
+  labelOffsetY: ADV.labelOffsetY,
+  showWhole: SIMPLE.showWhole,
+  showStepper: SIMPLE.showStepper,
+  showHandle: SIMPLE.showHandle
 };
 
 let n = clamp(SIMPLE.startN, CFG.minN, CFG.maxN);
@@ -54,6 +60,7 @@ addTo(gFrame,'rect',{x:L,y:TOP,width:R-L,height:BOT-TOP,class:'tb-frame'});
 // Håndtak
 const handleShadow = addTo(gHandle,'circle',{cx:R, cy:(TOP+BOT)/2+2, r:20, class:'tb-handle-shadow'});
 const handle       = addTo(gHandle,'circle',{cx:R, cy:(TOP+BOT)/2,   r:18, class:'tb-handle'});
+const stepper      = document.querySelector('.tb-stepper');
 
 // ---------- Interaksjon ----------
 document.getElementById('tbMinus').addEventListener('click', ()=> setN(n-1));
@@ -122,12 +129,23 @@ function applyConfig(){
     minN: SIMPLE.minN,
     maxN: SIMPLE.maxN,
     bracketTick: ADV.bracketTick,
-    labelOffsetY: ADV.labelOffsetY
+    labelOffsetY: ADV.labelOffsetY,
+    showWhole: SIMPLE.showWhole,
+    showStepper: SIMPLE.showStepper,
+    showHandle: SIMPLE.showHandle
   };
   n = clamp(SIMPLE.startN, CFG.minN, CFG.maxN);
   k = clamp(SIMPLE.startK, 0, n);
-  drawBracketSquare(L, R, BRACE_Y, CFG.bracketTick);
-  addTo(gBrace,'text',{x:(L+R)/2, y:BRACE_Y - CFG.labelOffsetY, class:'tb-total'}).textContent = CFG.total;
+  gBrace.innerHTML = '';
+  if(CFG.showWhole){
+    drawBracketSquare(L, R, BRACE_Y, CFG.bracketTick);
+    addTo(gBrace,'text',{x:(L+R)/2, y:BRACE_Y - CFG.labelOffsetY, class:'tb-total'}).textContent = CFG.total;
+    gBrace.style.display = '';
+  } else {
+    gBrace.style.display = 'none';
+  }
+  stepper.style.display = CFG.showStepper ? '' : 'none';
+  gHandle.style.display  = CFG.showHandle ? '' : 'none';
   redraw();
 }
 
@@ -178,13 +196,19 @@ function setupSettingsUI(){
   const kInput = document.getElementById('cfg-startK');
   const minInput = document.getElementById('cfg-minN');
   const maxInput = document.getElementById('cfg-maxN');
-  if(!totalInput || !nInput || !kInput || !minInput || !maxInput) return;
+  const showWholeInput = document.getElementById('cfg-showWhole');
+  const showStepperInput = document.getElementById('cfg-showStepper');
+  const showHandleInput = document.getElementById('cfg-showHandle');
+  if(!totalInput || !nInput || !kInput || !minInput || !maxInput || !showWholeInput || !showStepperInput || !showHandleInput) return;
 
   totalInput.value = SIMPLE.total;
   nInput.value = SIMPLE.startN;
   kInput.value = SIMPLE.startK;
   minInput.value = SIMPLE.minN;
   maxInput.value = SIMPLE.maxN;
+  showWholeInput.checked = SIMPLE.showWhole;
+  showStepperInput.checked = SIMPLE.showStepper;
+  showHandleInput.checked = SIMPLE.showHandle;
 
   function update(){
     SIMPLE.total = parseInt(totalInput.value) || SIMPLE.total;
@@ -192,6 +216,9 @@ function setupSettingsUI(){
     SIMPLE.startK = parseInt(kInput.value) || SIMPLE.startK;
     SIMPLE.minN = parseInt(minInput.value) || SIMPLE.minN;
     SIMPLE.maxN = parseInt(maxInput.value) || SIMPLE.maxN;
+    SIMPLE.showWhole = showWholeInput.checked;
+    SIMPLE.showStepper = showStepperInput.checked;
+    SIMPLE.showHandle = showHandleInput.checked;
     applyConfig();
   }
 
@@ -200,6 +227,9 @@ function setupSettingsUI(){
   kInput.addEventListener('change', update);
   minInput.addEventListener('change', update);
   maxInput.addEventListener('change', update);
+  showWholeInput.addEventListener('change', update);
+  showStepperInput.addEventListener('change', update);
+  showHandleInput.addEventListener('change', update);
 }
 
 // init


### PR DESCRIPTION
## Summary
- Move Tenkeblokker settings to a right-hand card layout
- Add checkboxes to toggle whole total, stepper buttons and handle
- Wire up JavaScript to hide/show these elements based on settings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c08f5572b88324bb0a144ae5ebebd4