### PR TITLE
Fix function segment range closure in graftegner

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -275,8 +275,16 @@ function rebuildFunctionSegmentsFor(g){
   for(var i=0;i<xs.length-1;i++){
     var a=xs[i], b=xs[i+1], leftOpen=(i>0), rightOpen=(i<xs.length-2);
     if(leftOpen) a+=eps; if(rightOpen) b-=eps; if(b<=a) continue;
-    g.segs.push( brd.create("functiongraph",[safe, function(){return a;}, function(){return b;}],
-      {strokeColor:g.color, strokeWidth:4,fixed:true,highlight:false}) );
+    // Use numeric bounds for each segment to avoid capturing mutable
+    // variables in closures, which could cause the graph to disappear
+    // when the view changes.
+    g.segs.push(
+      brd.create(
+        "functiongraph",
+        [safe, a, b],
+        {strokeColor:g.color, strokeWidth:4, fixed:true, highlight:false}
+      )
+    );
   }
 }
 function updateAllBrackets(){


### PR DESCRIPTION
## Summary
- Avoid capturing mutable segment boundaries when generating function graphs
- Prevents graph segments from disappearing during view changes

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c097239f1083248616bf5f1c4bf7a7