### PR TITLE
Allow screen input without brackets

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -425,7 +425,8 @@ function parseDomainInput(s){
 }
 function parseScreenInput(s){
   var t=String(s||"").trim(); if(!t) return null;
-  var m=t.match(/^\[\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*\]$/);
+  // Allow both "[a,b,c,d]" and "a,b,c,d" syntaxes
+  var m=t.match(/^\[?\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*\]?$/);
   if(!m) return null; return [ +m[1], +m[2], +m[3], +m[4] ];
 }
 function readUIOverrides(){


### PR DESCRIPTION
## Summary
- Allow Graftegner's screen input parser to accept values without surrounding brackets

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c097f045f08324b1a7c27c08642282