### PR TITLE
Add lock aspect setting bound to screen availability

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -105,7 +105,14 @@
             </div>
           </div>
 
-          <!-- Rad 4: Aksenavn – smalere felt -->
+          <!-- Rad 4: Lås aspekt -->
+          <div class="row single">
+            <div>
+              <label><input id="lockAspect" type="checkbox" checked disabled> Lås forhold 1:1 (krever screen)</label>
+            </div>
+          </div>
+
+          <!-- Rad 5: Aksenavn – smalere felt -->
           <div class="row axes">
             <div>
               <label for="axisXLabel">Navn på x-akse (valgfritt)</label>
@@ -117,7 +124,7 @@
             </div>
           </div>
 
-          <!-- Rad 5: Interaksjoner -->
+          <!-- Rad 6: Interaksjoner -->
           <div class="row single">
             <div>
               <label><input id="panEnabled" type="checkbox"> Tillat pan</label>

--- a/graftegner.js
+++ b/graftegner.js
@@ -11,7 +11,7 @@ var ADV = {
     grid:   { majorX: 1, majorY: 1, labelPrecision: 0 }
   },
   screen: null,
-  lockAspect: true,
+  lockAspect: false,
   interactions: {
     pan:  { enabled: false, needShift: false },
     zoom: { enabled: true,  wheel: true, needShift: false, factorX: 1.2, factorY: 1.2 }
@@ -434,6 +434,9 @@ function readUIOverrides(){
   var fn2 = document.getElementById("fn2").value.trim();
   var dom2 = parseDomainInput(document.getElementById("dom2").value);
   var screen = parseScreenInput(document.getElementById("screen").value);
+  var lockAspectEl = document.getElementById("lockAspect");
+  lockAspectEl.disabled = !screen;
+  ADV.lockAspect = !!screen && lockAspectEl.checked;
   var pointsCount = +document.getElementById("pointsCount").value;
   ADV.interactions.pan.enabled = document.getElementById("panEnabled").checked;
 


### PR DESCRIPTION
## Summary
- add lock aspect ratio checkbox that activates when a custom screen is provided
- wire up logic so the graph locks aspect ratio only when screen is set and option checked

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c099719b208324857e7d46d0ada750