### PR TITLE
Support two-angle quadrilateral specs in nkant

### DIFF
--- a/nkant.html
+++ b/nkant.html
@@ -52,8 +52,8 @@
 
         <label for="inpSpecs">SPECS (skriv 1–2 linjer, én figur per linje)</label>
         <textarea id="inpSpecs" rows="4" spellcheck="false">a=3, b=5, c=5
-a=5, b=5, c=5, d=5, B=90</textarea>
-        <div class="small">Eksempler: "a=3, b=5, c=4" (trekant), "a=5, b=5, c=5, d=5, B=90" (firkant – må ha d og én vinkel A/B/C/D).</div>
+a=5, b=5, c=5, B=90, D=110</textarea>
+        <div class="small">Eksempler: "a=3, b=5, c=4" (trekant), "a=5, b=5, c=5, d=5, B=90" (firkant – d og én vinkel), "a=5, b=5, c=5, B=90, D=110" (firkant – tre sider og to vinkler B og D).</div>
         <div class="sep"></div>
 
         <!-- Figur 1 -->


### PR DESCRIPTION
## Summary
- Allow quadrilateral specs with sides a,b,c and angles B & D, computing missing side automatically
- Detect quadrilaterals when angle D is provided
- Document new capability in nkant UI examples

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c09dffafa48324a3c16f42156f5b42