### PR TITLE
Enhance bar chart styling and allow configurable title

### DIFF
--- a/diagram.html
+++ b/diagram.html
@@ -38,13 +38,13 @@
 
     /* Akser og rutenett */
     .axis{stroke:#222;stroke-width:3;fill:none}
-    .grid{stroke:#999;stroke-dasharray:6 6;stroke-width:1;opacity:.6}
+    .grid{stroke:#999;stroke-width:1;opacity:.6}
     .yTickText{fill:#333;font-size:14px;text-anchor:end}
     .xLabel{fill:#333;font-size:18px;text-anchor:middle}
     .yLabel{fill:#333;font-size:18px}
 
     /* Søyler + vurderingsrammer */
-    .bar{fill:#5B2AA5;fill-opacity:1;opacity:1}
+    .bar{fill:#7c3aed;fill-opacity:1;opacity:1}
     .bar.badge-ok{stroke:#2e7d32;stroke-width:4}
     .bar.badge-no{stroke:#c62828;stroke-width:4}
 
@@ -64,7 +64,7 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <h2>Diagram</h2>
+        <h2 id="chartTitle">Diagram</h2>
         <div class="figure">
           <svg id="barsvg" viewBox="0 0 900 560" aria-label="Interaktivt stolpediagram"></svg>
         </div>
@@ -79,6 +79,9 @@
       <div class="card">
         <h2>Innstillinger</h2>
         <div class="settings">
+          <label>Overskrift
+            <input id="cfgTitle" type="text" value="Diagram">
+          </label>
           <label>Etiketter (kommaseparert)
             <input id="cfgLabels" type="text" value="1,2,4,6,Ingen">
           </label>

--- a/diagram.js
+++ b/diagram.js
@@ -2,6 +2,7 @@
    KONFIG – forfatter styrer alt her
    ========================================================= */
 const CFG = {
+  title: 'Diagram',
   labels: ['1','2','4','6','Ingen'],      // x-etiketter
   start:  [8,0,7,0,0],                    // startverdier
   answer: [10,6,3,1,4],                   // fasit
@@ -56,6 +57,7 @@ function initFromCfg(){
   barW  = xBand * 0.6;
   yMax  = CFG.yMax ?? niceMax([...CFG.start, ...CFG.answer]);
   lastFocusIndex = null;
+  document.getElementById('chartTitle').textContent = CFG.title || '';
   drawAxesAndGrid();
   drawBars();
 }
@@ -239,6 +241,7 @@ document.getElementById('btnApplyCfg').addEventListener('click', ()=>{
   const starts = parseNumList(document.getElementById('cfgStart').value);
   const answers = parseNumList(document.getElementById('cfgAnswer').value);
   const yMaxVal = parseFloat(document.getElementById('cfgYMax').value);
+  CFG.title = document.getElementById('cfgTitle').value;
   CFG.labels = lbls;
   CFG.start  = alignLength(starts, lbls.length, 0);
   CFG.answer = alignLength(answers, lbls.length, 0);


### PR DESCRIPTION
## Summary
- Intensify bar colors and switch grid lines to solid styling for clearer visuals
- Allow users to set a custom chart title via new settings field

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c09f1930088324a42deb5e55924227