### PR TITLE
feat: auto apply diagram settings

### DIFF
--- a/diagram.html
+++ b/diagram.html
@@ -103,7 +103,6 @@
           <label>Toleranse
             <input id="cfgTolerance" type="text" value="0">
           </label>
-          <button id="btnApplyCfg" class="btn" type="button">Bruk innstillinger</button>
         </div>
       </div>
     </div>

--- a/diagram.js
+++ b/diagram.js
@@ -234,7 +234,9 @@ document.getElementById('btnCheck').addEventListener('click', ()=>{
   updateStatus(ok ? 'Riktig! 🎉' : 'Prøv igjen 🙂');
 });
 
-document.getElementById('btnApplyCfg').addEventListener('click', ()=>{
+document.querySelector('.settings').addEventListener('input', applyCfg);
+
+function applyCfg(){
   const lbls = parseList(document.getElementById('cfgLabels').value);
   const starts = parseNumList(document.getElementById('cfgStart').value);
   const answers = parseNumList(document.getElementById('cfgAnswer').value);
@@ -250,8 +252,7 @@ document.getElementById('btnApplyCfg').addEventListener('click', ()=>{
   const tolVal = parseFloat(document.getElementById('cfgTolerance').value);
   CFG.tolerance = isNaN(tolVal) ? 0 : tolVal;
   initFromCfg();
-  updateStatus('Innstillinger oppdatert.');
-});
+}
 
 /* =========================================================
    HJELPERE


### PR DESCRIPTION
## Summary
- remove "Bruk innstillinger" button from diagram settings
- auto-apply diagram configuration on input change

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c09f73d63883248163d6990f45b654