### PR TITLE
Add configurable settings for area models

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -32,7 +32,31 @@
     <div class="settings">
       <h2>Innstillinger</h2>
       <div id="settingsMenu" class="settings-menu">
+        <label>Lengde (celler)
+          <input id="lenCells" type="number" value="1" min="1">
+        </label>
+        <label>Maks lengde
+          <input id="lenMax" type="number" value="12" min="1">
+        </label>
+        <label>Høyde (celler)
+          <input id="heiCells" type="number" value="1" min="1">
+        </label>
+        <label>Maks høyde
+          <input id="heiMax" type="number" value="12" min="1">
+        </label>
+        <label>Snap
+          <input id="snap" type="number" value="1" min="1">
+        </label>
+        <label>Areal-tekst
+          <input id="areaLabel" type="text" value="areal">
+        </label>
         <label><input type="checkbox" id="chkGrid" checked> Vis rutenett</label>
+        <label><input type="checkbox" id="chkChallenge" checked> Oppgave-modus</label>
+        <label>Oppgave-areal
+          <input id="challengeArea" type="number" value="12" min="1">
+        </label>
+        <label><input type="checkbox" id="chkDedupe" checked> To kolonner</label>
+        <label><input type="checkbox" id="chkAutoExpand" checked> Auto maks</label>
       </div>
     </div>
   </div>

--- a/arealmodell0.js
+++ b/arealmodell0.js
@@ -97,6 +97,54 @@ const S = {
   kb: { btn: null, live: null, focused: false, origHandleSize: null }
 };
 
+/* ============================== Config fra HTML ============================== */
+function readConfigFromHtml(){
+  const len = parseInt(document.getElementById("lenCells")?.value,10);
+  if(Number.isFinite(len)) CFG.SIMPLE.length.cells = len;
+  const lenMax = parseInt(document.getElementById("lenMax")?.value,10);
+  if(Number.isFinite(lenMax)) CFG.SIMPLE.length.max = lenMax;
+  const hei = parseInt(document.getElementById("heiCells")?.value,10);
+  if(Number.isFinite(hei)) CFG.SIMPLE.height.cells = hei;
+  const heiMax = parseInt(document.getElementById("heiMax")?.value,10);
+  if(Number.isFinite(heiMax)) CFG.SIMPLE.height.max = heiMax;
+  CFG.SIMPLE.showGrid = document.getElementById("chkGrid")?.checked ?? CFG.SIMPLE.showGrid;
+  const snap = parseInt(document.getElementById("snap")?.value,10);
+  if(Number.isFinite(snap)) CFG.SIMPLE.snap = snap;
+  const areaLabel = document.getElementById("areaLabel")?.value;
+  if(areaLabel != null) CFG.SIMPLE.areaLabel = areaLabel;
+  if(!CFG.SIMPLE.challenge) CFG.SIMPLE.challenge = {};
+  CFG.SIMPLE.challenge.enabled = document.getElementById("chkChallenge")?.checked ?? false;
+  const chArea = parseInt(document.getElementById("challengeArea")?.value,10);
+  if(Number.isFinite(chArea)) CFG.SIMPLE.challenge.area = chArea;
+  CFG.SIMPLE.challenge.dedupeOrderless = document.getElementById("chkDedupe")?.checked ?? false;
+  CFG.SIMPLE.challenge.autoExpandMax = document.getElementById("chkAutoExpand")?.checked ?? false;
+}
+
+function applySimpleConfig(){
+  S.w = CFG.SIMPLE.length.cells;
+  S.h = CFG.SIMPLE.height.cells;
+  S.w0 = S.w;
+  S.h0 = S.h;
+  S.maxW = Math.max(
+    CFG.SIMPLE.length.max,
+    (CFG.SIMPLE.challenge?.enabled && CFG.SIMPLE.challenge?.autoExpandMax) ? (CFG.SIMPLE.challenge?.area || 0) : 0
+  );
+  S.maxH = Math.max(
+    CFG.SIMPLE.height.max,
+    (CFG.SIMPLE.challenge?.enabled && CFG.SIMPLE.challenge?.autoExpandMax) ? (CFG.SIMPLE.challenge?.area || 0) : 0
+  );
+  S.ch.enabled = !!(CFG.SIMPLE.challenge && CFG.SIMPLE.challenge.enabled);
+  S.ch.N = (CFG.SIMPLE.challenge && CFG.SIMPLE.challenge.area) || null;
+  S.ch.dedupeOrderless = !!(CFG.SIMPLE.challenge && CFG.SIMPLE.challenge.dedupeOrderless);
+}
+
+function initFromHtml(){
+  readConfigFromHtml();
+  applySimpleConfig();
+  if(S.board) JXG.JSXGraph.freeBoard(S.board);
+  createBoard();
+}
+
 /* ============================== Hjelpere ============================== */
 const clamp=(v,lo,hi)=>Math.max(lo,Math.min(hi,v));
 const quantize=(v,step)=>(step<=0?v:Math.round(v/step)*step);
@@ -559,16 +607,9 @@ function downloadInteractiveHTML(){
 
 /* ============================== Init ============================== */
 document.addEventListener("DOMContentLoaded", () => {
-  if(S.ch.enabled && S.ch.N) S.ch.allPairs=factorPairsSorted(S.ch.N);
-  createBoard();
-
-  const chkGrid=document.getElementById("chkGrid");
-  if(chkGrid){
-    chkGrid.checked = CFG.SIMPLE.showGrid;
-    chkGrid.addEventListener("change",()=>{
-      CFG.SIMPLE.showGrid = chkGrid.checked;
-      drawInnerGrid();
-      S.board.update();
-    });
-  }
+  initFromHtml();
+  document.querySelectorAll('#settingsMenu input, #settingsMenu select').forEach(el => {
+    el.addEventListener('change', initFromHtml);
+    el.addEventListener('input', initFromHtml);
+  });
 });

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -58,6 +58,20 @@
       <div class="card">
         <h2>Innstillinger</h2>
         <div class="settings">
+          <label>Rader
+            <input id="rows" type="number" value="16" min="2">
+          </label>
+          <label>Kolonner
+            <input id="cols" type="number" value="17" min="2">
+          </label>
+          <label>Håndtak rader
+            <input id="rowsHandle" type="number" value="5" min="1">
+          </label>
+          <label>Håndtak kolonner
+            <input id="colsHandle" type="number" value="3" min="1">
+          </label>
+          <label><input id="grid" type="checkbox"> Vis rutenett</label>
+          <label><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
           <label>Forfatter
             <input id="author" type="text" />
           </label>

--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -63,7 +63,20 @@ const CFG = {
 };
 /* ========================================================= */
 
-window.addEventListener("load", () => {
+function readConfigFromHtml(){
+  const rows = parseInt(document.getElementById("rows")?.value,10);
+  if(Number.isFinite(rows)) CFG.SIMPLE.height.cells = rows;
+  const cols = parseInt(document.getElementById("cols")?.value,10);
+  if(Number.isFinite(cols)) CFG.SIMPLE.length.cells = cols;
+  const rHandle = parseInt(document.getElementById("rowsHandle")?.value,10);
+  if(Number.isFinite(rHandle)) CFG.SIMPLE.height.handle = rHandle;
+  const cHandle = parseInt(document.getElementById("colsHandle")?.value,10);
+  if(Number.isFinite(cHandle)) CFG.SIMPLE.length.handle = cHandle;
+  CFG.ADV.grid = document.getElementById("grid")?.checked ?? CFG.ADV.grid;
+  CFG.ADV.splitLines = document.getElementById("splitLines")?.checked ?? CFG.ADV.splitLines;
+}
+
+function render(){
   const ADV = CFG.ADV, SV = CFG.SIMPLE;
 
   const UNIT = +ADV.unit || 40;
@@ -142,6 +155,7 @@ window.addEventListener("load", () => {
 
   // DOM
   const svg = document.getElementById(ADV.svgId);
+  svg.innerHTML = "";
   set(svg, "viewBox", `0 0 ${VBW} ${VBH}`);
   set(svg, "preserveAspectRatio", "xMidYMid meet");
   Object.assign(svg.style, {
@@ -406,14 +420,16 @@ window.addEventListener("load", () => {
   }
 
   // Reset
-  document.getElementById("btnReset")?.addEventListener("click", () => {
+  const btnReset = document.getElementById("btnReset");
+  if(btnReset) btnReset.onclick = () => {
     sx = clampInt(initLeftCols,   1, COLS-1) * UNIT;
     sy = clampInt(initBottomRows, 1, ROWS-1) * UNIT;
     scheduleRedraw();
-  });
+  };
 
   // ===== Eksporter interaktiv SVG =====
-  document.getElementById("btnSvg")?.addEventListener("click", () => {
+  const btnSvg = document.getElementById("btnSvg");
+  if(btnSvg) btnSvg.onclick = () => {
     const includeHandles = (showLeftHandle || showBottomHandle) || ADV.export?.includeHandlesIfHidden;
 
     const svgStr = buildInteractiveSvgString({
@@ -433,10 +449,11 @@ window.addEventListener("load", () => {
       safePad: ADV.fit?.safePad || {top:8,right:8,bottom:64,left:8}
     });
     downloadText(ADV.export?.filename || "arealmodell_interaktiv.svg", svgStr, "image/svg+xml");
-  });
+  };
 
   // ===== Eksporter interaktiv HTML =====
-  document.getElementById("btnHtml")?.addEventListener("click", () => {
+  const btnHtml = document.getElementById("btnHtml");
+  if(btnHtml) btnHtml.onclick = () => {
     const includeHandles = (showLeftHandle || showBottomHandle) || ADV.export?.includeHandlesIfHidden;
 
     const htmlStr = buildInteractiveHtmlString({
@@ -457,7 +474,7 @@ window.addEventListener("load", () => {
     });
     const fname = ADV.export?.filenameHtml || "arealmodell_interaktiv.html";
     downloadText(fname, htmlStr, "text/html;charset=utf-8");
-  });
+  };
 
   // ===== helpers =====
   function downloadText(filename, text, mime){
@@ -675,4 +692,17 @@ window.addEventListener("load", () => {
       "</body></html>"
     ].join("");
   }
+}
+
+function initFromHtml(){
+  readConfigFromHtml();
+  render();
+}
+
+window.addEventListener('load', () => {
+  initFromHtml();
+  document.querySelectorAll('.settings input').forEach(el => {
+    el.addEventListener('change', initFromHtml);
+    el.addEventListener('input', initFromHtml);
+  });
 });


### PR DESCRIPTION
## Summary
- Add settings menu in Arealmodell A for length, height, grid, and challenge options
- Allow Arealmodell A script to rebuild from user-specified defaults
- Introduce row/column configuration UI for Arealmodell B and hook script to refresh on changes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a2661aa48324a65c6fd4d3c4e965