### PR TITLE
Add bar locking and layout fixes

### DIFF
--- a/diagram.html
+++ b/diagram.html
@@ -31,7 +31,12 @@
     }
     .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
     .btn:active { transform: translateY(1px); }
-    .status { min-height: 1.8em; font-size: 16px; }
+    .status {
+      position: absolute;
+      width: 1px; height: 1px; margin: -1px;
+      padding: 0; overflow: hidden; clip: rect(0,0,0,0);
+      white-space: nowrap; border: 0;
+    }
     .settings { display: flex; flex-direction: column; gap: 8px; }
     .settings label { display: flex; flex-direction: column; font-size: 13px; color: #4b5563; }
     .settings input { padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 10px; font-size: 14px; background: #fff; }
@@ -55,9 +60,16 @@
     /* Verdi‐tekst over søyle (ikke-interaktiv) */
     .value{fill:#111;font-size:16px;text-anchor:middle;paint-order:stroke fill;stroke:#fff;stroke-width:6;pointer-events:none}
 
+    /* Låsing */
+    .bar.locked{fill:#d1d5db;cursor:not-allowed}
+    .handle.locked{fill:#e5e7eb;cursor:not-allowed}
+    .lock{cursor:pointer;font-size:20px;user-select:none}
+
     /* Fokus + tastatur (A11y-overlay) */
-    .a11y{cursor:ns-resize}
+    .a11y{cursor:ns-resize;fill:transparent;stroke:none}
     .a11y:focus{outline:none;stroke:#1e88e5;stroke-width:3}
+
+    .xAxisLabel{fill:#333;font-size:18px;text-anchor:middle}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Hide live status text to remove stray values from interface while keeping screen reader updates
- Center the x-axis label and clean up overlay styling to avoid stray grid lines
- Add lock icons and logic so individual bars can be frozen against changes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a21c599c8324b770fcea3051afeb