### PR TITLE
Improve diagram title and settings layout

### DIFF
--- a/diagram.html
+++ b/diagram.html
@@ -39,7 +39,10 @@
     }
     .settings { display: flex; flex-direction: column; gap: 8px; }
     .settings label { display: flex; flex-direction: column; font-size: 13px; color: #4b5563; }
-    .settings input { padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 10px; font-size: 14px; background: #fff; }
+    .settings input { padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 10px; font-size: 14px; background: #fff; width: 100%; }
+    .settings-row { display: flex; gap: 8px; }
+    .settings-row label { flex: 1; }
+    #chartTitle { text-align: center; font-size: 20px; margin: 0 0 6px; }
 
     /* Akser og rutenett */
     .axis{stroke:#222;stroke-width:3;fill:none}
@@ -93,32 +96,38 @@
           <label>Overskrift
             <input id="cfgTitle" type="text" value="Diagram">
           </label>
-          <label>Etiketter (kommaseparert)
-            <input id="cfgLabels" type="text" value="1,2,4,6,Ingen">
-          </label>
-          <label>Startverdier
-            <input id="cfgStart" type="text" value="8,0,7,0,0">
-          </label>
-          <label>Fasitverdier
-            <input id="cfgAnswer" type="text" value="10,6,3,1,4">
-          </label>
-          <label>Maks y (valgfritt)
-            <input id="cfgYMax" type="text" value="15">
-          </label>
-          <label>Navn på x-akse
-            <input id="cfgAxisXLabel" type="text" value="Ant. bøker">
-          </label>
-          <label>Navn på y-akse
-            <input id="cfgAxisYLabel" type="text" value="Antall elever">
-          </label>
+          <div class="settings-row">
+            <label>Etiketter (kommaseparert)
+              <input id="cfgLabels" type="text" value="1,2,4,6,Ingen">
+            </label>
+            <label>Fjern håndtak (0/1, kommaseparert)
+              <input id="cfgLocked" type="text" value="">
+            </label>
+          </div>
+          <div class="settings-row">
+            <label>Startverdier
+              <input id="cfgStart" type="text" value="8,0,7,0,0">
+            </label>
+            <label>Fasitverdier
+              <input id="cfgAnswer" type="text" value="10,6,3,1,4">
+            </label>
+          </div>
+          <div class="settings-row">
+            <label>Maks y (valgfritt)
+              <input id="cfgYMax" type="text" value="15">
+            </label>
+            <label>Navn på x-akse
+              <input id="cfgAxisXLabel" type="text" value="Ant. bøker">
+            </label>
+            <label>Navn på y-akse
+              <input id="cfgAxisYLabel" type="text" value="Antall elever">
+            </label>
+          </div>
           <label>Steg (snap)
             <input id="cfgSnap" type="text" value="1">
           </label>
           <label>Toleranse
             <input id="cfgTolerance" type="text" value="0">
-          </label>
-          <label>Fjern håndtak (0/1, kommaseparert)
-            <input id="cfgLocked" type="text" value="">
           </label>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Center the chart title above the diagram with a larger font
- Group related settings fields on shared rows for a cleaner layout

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c0abcaf2c48324b29c86aa01a0f2f8