### PR TITLE
Add PNG download buttons to visualizations

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -25,6 +25,7 @@
       <div class="toolbar">
         <button id="btnReset" type="button">Reset</button>
         <button id="btnSvg" type="button">Last ned SVG</button>
+        <button id="btnPng" type="button">Last ned PNG</button>
         <button id="btnSvgInteractive" type="button">Last ned interaktiv SVG</button>
         <button id="btnHtml" type="button">Last ned interaktiv HTML</button>
       </div>

--- a/arealmodell0.js
+++ b/arealmodell0.js
@@ -374,6 +374,8 @@ function createBoard(){
   if(btnReset) btnReset.onclick=doReset;
   const btnSvg=document.getElementById("btnSvg");
   if(btnSvg) btnSvg.onclick=downloadSvg;
+  const btnPng=document.getElementById("btnPng");
+  if(btnPng) btnPng.onclick=downloadPng;
   const btnSvgInt=document.getElementById("btnSvgInteractive");
   if(btnSvgInt) btnSvgInt.onclick=downloadInteractiveSVG;
   const btnHtml=document.getElementById("btnHtml");
@@ -485,6 +487,41 @@ function downloadSvg(){
   } catch (e) {
     console.error(e);
     alert("Kunne ikke eksportere SVG: " + e.message);
+  }
+}
+
+function downloadPng(){
+  try {
+    const svgText = serializeSvgFromBoard(S.board);
+    const blob=new Blob([svgText],{type:"image/svg+xml;charset=utf-8"});
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => {
+      const w = img.width, h = img.height;
+      const canvas = document.createElement('canvas');
+      canvas.width = w; canvas.height = h;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = '#fff';
+      ctx.fillRect(0,0,w,h);
+      ctx.drawImage(img,0,0,w,h);
+      URL.revokeObjectURL(url);
+      canvas.toBlob(b => {
+        const urlPng = URL.createObjectURL(b);
+        const a=document.createElement('a');
+        if ("download" in HTMLAnchorElement.prototype) {
+          a.href=urlPng; a.download=CFG.ADV.fileName.replace(/\.svg$/i,'.png');
+          document.body.appendChild(a); a.click(); a.remove();
+          setTimeout(()=>URL.revokeObjectURL(urlPng),0);
+        } else {
+          window.open(urlPng, "_blank");
+          setTimeout(()=>URL.revokeObjectURL(urlPng),4000);
+        }
+      }, 'image/png');
+    };
+    img.src = url;
+  } catch(e) {
+    console.error(e);
+    alert("Kunne ikke eksportere PNG: " + e.message);
   }
 }
 

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -76,6 +76,8 @@
             <input id="author" type="text" />
           </label>
           <button id="btnReset" type="button">Reset</button>
+          <button id="btnSvgStatic" type="button">Last ned SVG</button>
+          <button id="btnPng" type="button">Last ned PNG</button>
           <button id="btnSvg" type="button">Last ned interaktiv SVG</button>
           <button id="btnHtml" type="button">Last ned interaktiv HTML</button>
         </div>

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -117,6 +117,7 @@
         <div class="toolbar">
           <button id="btnStaticAll" class="btn" type="button">Last ned SVG</button>
           <button id="btnInteractiveAll" class="btn" type="button">Last ned interaktiv SVG</button>
+          <button id="btnPngAll" class="btn" type="button">Last ned PNG</button>
         </div>
       </div>
 

--- a/brøkpizza.js
+++ b/brøkpizza.js
@@ -544,9 +544,9 @@ function getVisiblePizzas(){
     .filter(svg => svg && svg.closest(".pizzaPanel")?.style.display !== "none");
 }
 
-function downloadAllPizzasSVG(filename="broksirkler.svg"){
+function buildAllPizzasSVG(){
   const svgs=getVisiblePizzas();
-  if(!svgs.length) return;
+  if(!svgs.length) return null;
   const gap=24, size=420;
   const w=size*svgs.length + gap*(svgs.length-1);
   const h=size;
@@ -566,12 +566,33 @@ function downloadAllPizzasSVG(filename="broksirkler.svg"){
     root.appendChild(clone);
   });
   const xml=new XMLSerializer().serializeToString(root);
-  const file=`<?xml version="1.0" encoding="UTF-8"?>\n`+xml;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n`+xml;
+}
+
+function downloadAllPizzasSVG(filename="broksirkler.svg"){
+  const file=buildAllPizzasSVG();
+  if(!file) return;
   const blob=new Blob([file],{type:"image/svg+xml;charset=utf-8"});
   const url=URL.createObjectURL(blob);
   const a=document.createElement("a");
   a.href=url; a.download=filename; document.body.appendChild(a); a.click(); a.remove();
   URL.revokeObjectURL(url);
+}
+
+function downloadAllPizzasPNG(filename="broksirkler.png"){
+  const file=buildAllPizzasSVG();
+  if(!file) return;
+  const blob=new Blob([file],{type:"image/svg+xml;charset=utf-8"});
+  const url=URL.createObjectURL(blob);
+  const img=new Image();
+  img.onload=()=>{
+    const w=img.width,h=img.height;
+    const canvas=document.createElement('canvas'); canvas.width=w; canvas.height=h;
+    const ctx=canvas.getContext('2d'); ctx.fillStyle='#fff'; ctx.fillRect(0,0,w,h); ctx.drawImage(img,0,0,w,h);
+    URL.revokeObjectURL(url);
+    canvas.toBlob(b=>{ const urlPng=URL.createObjectURL(b); const a=document.createElement('a'); a.href=urlPng; a.download=filename; document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(urlPng); },'image/png');
+  };
+  img.src=url;
 }
 
 function downloadAllPizzasInteractiveSVG(filename="broksirkler-interaktiv.svg"){
@@ -626,8 +647,10 @@ function downloadAllPizzasInteractiveSVG(filename="broksirkler-interaktiv.svg"){
 function setupGlobalDownloadButtons(){
   const btnStatic=document.getElementById("btnStaticAll");
   const btnInteractive=document.getElementById("btnInteractiveAll");
+  const btnPng=document.getElementById("btnPngAll");
   if(btnStatic) btnStatic.addEventListener("click",()=>downloadAllPizzasSVG());
   if(btnInteractive) btnInteractive.addEventListener("click",()=>downloadAllPizzasInteractiveSVG());
+  if(btnPng) btnPng.addEventListener("click",()=>downloadAllPizzasPNG());
 }
 
 /* =======================

--- a/diagram.html
+++ b/diagram.html
@@ -83,6 +83,8 @@
           <button id="btnCheck" class="btn">Sjekk</button>
           <button id="btnReset" class="btn">Nullstill</button>
           <button id="btnShow" class="btn">Vis fasit</button>
+          <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+          <button id="btnPng" class="btn" type="button">Last ned PNG</button>
         </div>
         <div id="status" class="status" role="status" aria-live="polite"></div>
       </div>

--- a/diagram.js
+++ b/diagram.js
@@ -38,6 +38,11 @@ let locked = [];
 let N = 0;
 
 let yMax = 0;
+
+const btnSvg = document.getElementById('btnSvg');
+const btnPng = document.getElementById('btnPng');
+btnSvg?.addEventListener('click', ()=> downloadSVG(svg, 'diagram.svg'));
+btnPng?.addEventListener('click', ()=> downloadPNG(svg, 'diagram.png', 2));
 const yMin = 0;
 
 // skalaer
@@ -334,4 +339,49 @@ function markCorrectness(){
 function isCorrect(vs, ans, tol){
   if(vs.length !== ans.length) return false;
   return vs.every((v,i)=> Math.abs(v-ans[i]) <= tol);
+}
+
+function svgToString(svgEl){
+  const clone = svgEl.cloneNode(true);
+  clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
+  clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
+  return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
+}
+function downloadSVG(svgEl, filename){
+  const data = svgToString(svgEl);
+  const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename.endsWith('.svg') ? filename : filename + '.svg';
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(()=>URL.revokeObjectURL(url), 1000);
+}
+function downloadPNG(svgEl, filename, scale=2, bg='#fff'){
+  const vb = svgEl.viewBox.baseVal;
+  const w = vb?.width  || svgEl.clientWidth  || 900;
+  const h = vb?.height || svgEl.clientHeight || 560;
+  const data = svgToString(svgEl);
+  const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+  const url  = URL.createObjectURL(blob);
+  const img = new Image();
+  img.onload = ()=>{
+    const canvas = document.createElement('canvas');
+    canvas.width  = Math.round(w * scale);
+    canvas.height = Math.round(h * scale);
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = bg;
+    ctx.fillRect(0,0,canvas.width,canvas.height);
+    ctx.drawImage(img,0,0,canvas.width,canvas.height);
+    URL.revokeObjectURL(url);
+    canvas.toBlob(blob=>{
+      const urlPng = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = urlPng;
+      a.download = filename.endsWith('.png') ? filename : filename + '.png';
+      document.body.appendChild(a); a.click(); a.remove();
+      setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
+    }, 'image/png');
+  };
+  img.src = url;
 }

--- a/graftegner.html
+++ b/graftegner.html
@@ -66,6 +66,7 @@
         <div class="toolbar">
           <button id="btnReset" class="btn" type="button">Nullstill zoom/pan</button>
           <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+          <button id="btnPng" class="btn" type="button">Last ned PNG</button>
         </div>
       </div>
 

--- a/graftegner.js
+++ b/graftegner.js
@@ -462,18 +462,39 @@ document.getElementById("btnReset").addEventListener("click", function(){
   updateAfterViewChange();
 });
 document.getElementById("btnSvg").addEventListener("click", function(){
-  var src=brd.renderer.svgRoot.cloneNode(true);
-  src.removeAttribute("style");
-  var w=brd.canvasWidth,h=brd.canvasHeight;
-  src.setAttribute("width",  String(w));
-  src.setAttribute("height", String(h));
-  src.setAttribute("viewBox","0 0 "+w+" "+h);
-  src.setAttribute("xmlns","http://www.w3.org/2000/svg");
-  src.setAttribute("xmlns:xlink","http://www.w3.org/1999/xlink");
-  var xml=new XMLSerializer().serializeToString(src).replace(/\swidth="[^"]*"\s(?=.*width=")/," ").replace(/\sheight="[^"]*"\s(?=.*height=")/," ");
+  var xml = getSvgString();
   var blob=new Blob([xml],{type:"image/svg+xml;charset=utf-8"});
   var a=document.createElement("a"); a.href=URL.createObjectURL(blob); a.download="graf.svg"; a.click(); URL.revokeObjectURL(a.href);
 });
+document.getElementById("btnPng").addEventListener("click", function(){
+  var xml = getSvgString();
+  var blob=new Blob([xml],{type:"image/svg+xml;charset=utf-8"});
+  var url=URL.createObjectURL(blob);
+  var img=new Image();
+  img.onload=function(){
+    var w=img.width,h=img.height;
+    var c=document.createElement("canvas"); c.width=w; c.height=h;
+    var ctx=c.getContext("2d"); ctx.fillStyle="#fff"; ctx.fillRect(0,0,w,h); ctx.drawImage(img,0,0,w,h);
+    URL.revokeObjectURL(url);
+    c.toBlob(function(b){
+      var urlPng=URL.createObjectURL(b); var a=document.createElement("a");
+      a.href=urlPng; a.download="graf.png"; a.click(); URL.revokeObjectURL(urlPng);
+    },"image/png");
+  };
+  img.src=url;
+});
+
+function getSvgString(){
+  var src=brd.renderer.svgRoot.cloneNode(true);
+  src.removeAttribute("style");
+  var w=brd.canvasWidth,h=brd.canvasHeight;
+  src.setAttribute("width",String(w));
+  src.setAttribute("height",String(h));
+  src.setAttribute("viewBox","0 0 "+w+" "+h);
+  src.setAttribute("xmlns","http://www.w3.org/2000/svg");
+  src.setAttribute("xmlns:xlink","http://www.w3.org/1999/xlink");
+  return new XMLSerializer().serializeToString(src).replace(/\swidth="[^"]*"\s(?=.*width=")/," ").replace(/\sheight="[^"]*"\s(?=.*height=")/," ");
+}
 
 /* ---------- UI → SIMPLE ---------- */
 function parseDomainInput(s){

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -30,6 +30,10 @@
     .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
     .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
     .figure svg { width: 100%; height: 360px; display: block; touch-action: none; }
+    .toolbar { display:flex; gap:10px; justify-content:flex-end; }
+    .btn { appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px; padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s; }
+    .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
+    .btn:active { transform:translateY(1px); }
     label { font-size: 13px; color: #4b5563; }
     input[type="number"] {
       border: 1px solid #d1d5db;
@@ -56,6 +60,10 @@
         <h2>Perlesnor</h2>
         <div class="figure">
           <svg id="beadSVG" viewBox="0 0 1400 460" role="img" aria-label="Perlesnor med klype"></svg>
+        </div>
+        <div class="toolbar">
+          <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+          <button id="btnPng" class="btn" type="button">Last ned PNG</button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add "Last ned PNG" and static SVG buttons across all visualizations
- implement reusable SVG→PNG conversion helpers
- enable full export options for Arealmodell, Brøkpizza, Diagram, Graftegner and Perlesnor

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a93c0ee88324bb8716359080b11a