### PR TITLE
Fix mode selection for graph rendering

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -74,8 +74,8 @@ function isExplicitRHS(rhs){
   return s.length===0;
 }
 function decideMode(parsed){
-  var hasExplicit = parsed.funcs.some(function(f){ return isExplicitRHS(f.rhs); });
-  return hasExplicit ? "functions" : "pointsOnly";
+  var hasPlaceholder = parsed.funcs.some(function(f){ return !isExplicitRHS(f.rhs); });
+  return hasPlaceholder ? "pointsOnly" : "functions";
 }
 var MODE = decideMode(SIMPLE_PARSED);
 


### PR DESCRIPTION
## Summary
- correct mode detection: switch to point-only mode only when function specs contain placeholders

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a7b49f508324b47c76db11f304ce