### PR TITLE
Set default bar chart to favorite sports

### DIFF
--- a/diagram.html
+++ b/diagram.html
@@ -78,7 +78,7 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <h2 id="chartTitle">Diagram</h2>
+        <h2 id="chartTitle">Favorittidretter i 5B</h2>
         <div class="figure">
           <svg id="barsvg" viewBox="0 0 900 560" aria-label="Interaktivt stolpediagram"></svg>
         </div>
@@ -96,11 +96,11 @@
         <h2>Innstillinger</h2>
         <div class="settings">
           <label>Overskrift
-            <input id="cfgTitle" type="text" value="Diagram">
+            <input id="cfgTitle" type="text" value="Favorittidretter i 5B">
           </label>
           <div class="settings-row">
             <label>Etiketter (kommaseparert)
-              <input id="cfgLabels" type="text" value="1,2,4,6,Ingen">
+              <input id="cfgLabels" type="text" value="Klatring,Fotball,Håndball,Basket,Tennis,Bowling">
             </label>
             <label>Fjern håndtak (0/1, kommaseparert)
               <input id="cfgLocked" type="text" value="">
@@ -108,18 +108,18 @@
           </div>
           <div class="settings-row">
             <label>Startverdier
-              <input id="cfgStart" type="text" value="8,0,7,0,0">
+              <input id="cfgStart" type="text" value="6,7,3,5,8,2">
             </label>
             <label>Fasitverdier
-              <input id="cfgAnswer" type="text" value="10,6,3,1,4">
+              <input id="cfgAnswer" type="text" value="6,7,3,5,8,2">
             </label>
           </div>
           <div class="settings-row">
             <label>Maks y (valgfritt)
-              <input id="cfgYMax" type="text" value="15">
+              <input id="cfgYMax" type="text" value="8">
             </label>
             <label>Navn på x-akse
-              <input id="cfgAxisXLabel" type="text" value="Ant. bøker">
+              <input id="cfgAxisXLabel" type="text" value="Idrett">
             </label>
             <label>Navn på y-akse
               <input id="cfgAxisYLabel" type="text" value="Antall elever">

--- a/diagram.js
+++ b/diagram.js
@@ -2,16 +2,16 @@
    KONFIG – forfatter styrer alt her
    ========================================================= */
 const CFG = {
-  title: 'Diagram',
-  labels: ['1','2','4','6','Ingen'],      // x-etiketter
-  start:  [8,0,7,0,0],                    // startverdier
-  answer: [10,6,3,1,4],                   // fasit
-  yMax:   15,                             // maks på y-aksen (valgfritt; auto hvis utelatt)
-  snap:   1,                              // trinn-størrelse
-  tolerance: 0,                           // tillatt avvik per søyle ved "Sjekk"
-  axisXLabel: 'Ant. bøker',
+  title: 'Favorittidretter i 5B',
+  labels: ['Klatring','Fotball','Håndball','Basket','Tennis','Bowling'],
+  start:  [6,7,3,5,8,2],
+  answer: [6,7,3,5,8,2],
+  yMax:   8,
+  snap:   1,
+  tolerance: 0,
+  axisXLabel: 'Idrett',
   axisYLabel: 'Antall elever',
-  locked: []                              // søyler uten håndtak (1=låst)
+  locked: []
 };
 
 /* =========================================================


### PR DESCRIPTION
## Summary
- default Diagram page now preloads a bar chart of favorite sports in class 5B
- update labels, values, and axis titles to match sports dataset

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0af183eb083248ad99d2b45024c14