### PR TITLE
Fix missing script link in graftegner

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -45,6 +45,6 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
-  <script defer src="app.js"></script>
+  <script defer src="graftegner.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Link graftegner HTML page to its JavaScript source instead of missing app.js

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b73d63108324af342710878981c7