### PR TITLE
Add purple fill to diagram bars

### DIFF
--- a/diagram.html
+++ b/diagram.html
@@ -52,7 +52,7 @@
     .yLabel{fill:#333;font-size:18px}
 
     /* Søyler + vurderingsrammer */
-    .bar{fill:none;stroke:#000;stroke-width:4}
+    .bar{fill:#800080;stroke:#000;stroke-width:4}
     .bar.badge-ok{stroke:#2e7d32;stroke-width:4}
     .bar.badge-no{stroke:#c62828;stroke-width:4}
 


### PR DESCRIPTION
## Summary
- Color diagram bars purple for clearer visuals

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c0268e388324a2f09c47c651bec3