### PR TITLE
feat: add option to hide denominator value

### DIFF
--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -132,6 +132,7 @@
             <label for="p1N">Nevner (n)</label>
             <input id="p1N" type="number" value="10" min="1">
             <div class="checkbox-row"><input id="p1LockN" type="checkbox"><label for="p1LockN">Lås nevner</label></div>
+            <div class="checkbox-row"><input id="p1HideNVal" type="checkbox"><label for="p1HideNVal">Skjul n-verdi</label></div>
             <div class="checkbox-row"><input id="p1LockT" type="checkbox"><label for="p1LockT">Lås teller</label></div>
             <label for="p1Text">Tekst</label>
             <select id="p1Text">
@@ -154,6 +155,7 @@
             <label for="p2N">Nevner (n)</label>
             <input id="p2N" type="number" value="10" min="1">
             <div class="checkbox-row"><input id="p2LockN" type="checkbox" checked><label for="p2LockN">Lås nevner</label></div>
+            <div class="checkbox-row"><input id="p2HideNVal" type="checkbox"><label for="p2HideNVal">Skjul n-verdi</label></div>
             <div class="checkbox-row"><input id="p2LockT" type="checkbox"><label for="p2LockT">Lås teller</label></div>
             <label for="p2Text">Tekst</label>
             <select id="p2Text">


### PR DESCRIPTION
## Summary
- allow authors to hide the denominator display in brøkpizza
- propagate hidden-denominator setting through interactive SVG exports
- add demo controls for toggling denominator visibility

## Testing
- `node --check brøkpizza.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1173c1f3c8324a336c31f315a2f3e