### PR TITLE
Ensure colors persist in exported diagrams

### DIFF
--- a/diagram.js
+++ b/diagram.js
@@ -343,6 +343,10 @@ function isCorrect(vs, ans, tol){
 
 function svgToString(svgEl){
   const clone = svgEl.cloneNode(true);
+  const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
+  const style = document.createElement('style');
+  style.textContent = css;
+  clone.insertBefore(style, clone.firstChild);
   clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
   clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
   return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);

--- a/nkant.js
+++ b/nkant.js
@@ -441,6 +441,10 @@ function collectJobsFromSpecs(text){
 
 function svgToString(svgEl){
   const clone = svgEl.cloneNode(true);
+  const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
+  const style = document.createElement('style');
+  style.textContent = css;
+  clone.insertBefore(style, clone.firstChild);
   clone.setAttribute("xmlns","http://www.w3.org/2000/svg");
   clone.setAttribute("xmlns:xlink","http://www.w3.org/1999/xlink");
   return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);

--- a/perlesnor.js
+++ b/perlesnor.js
@@ -389,6 +389,10 @@ function pt(e){ const p=svg.createSVGPoint(); p.x=e.clientX; p.y=e.clientY; retu
 
 function svgToString(svgEl){
   const clone = svgEl.cloneNode(true);
+  const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
+  const style = document.createElement('style');
+  style.textContent = css;
+  clone.insertBefore(style, clone.firstChild);
   clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
   clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
   return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -135,6 +135,10 @@ function clientToSvg(clientX, clientY){
 
 function svgToString(svgEl){
   const clone = svgEl.cloneNode(true);
+  const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
+  const style = document.createElement('style');
+  style.textContent = css;
+  clone.insertBefore(style, clone.firstChild);
   clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
   clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
   return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);


### PR DESCRIPTION
## Summary
- inline `<style>` tags into downloaded SVGs so exported PNG/SVG files keep their colors
- apply fix across diagram, nkant, perlesnor, and tenkeblokker tools

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c11a1bf65c8324b73509bed61ed832