### PR TITLE
Refine Graftegner settings layout

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -33,6 +33,7 @@
     .settings input[type="text"], .settings input[type="number"]{ padding:8px 10px; border:1px solid #d1d5db; border-radius:10px; font-size:14px; background:#fff; width:100%; }
     .settings-row{ display:flex; gap:8px; }
     .settings-row label{ flex:1; }
+    .checkbox-label{ flex-direction:row; align-items:center; gap:6px; }
   </style>
 </head>
 <body>
@@ -57,25 +58,25 @@
             <label>Funksjon 1
               <input id="cfgFun1" type="text" value="f(x)=x^2-2">
             </label>
-            <label>Definisjonsmengde funksjon 1 (Valgfritt. Skriv [start, stopp])
-              <input id="cfgDom1" type="text" value="">
+            <label>Definisjonsmengde funksjon 1 (valgfritt)
+              <input id="cfgDom1" type="text" value="" placeholder="[start, stopp]">
             </label>
           </div>
-          <label>Punkter (På funksjon 1)
+          <label>Punkter (på funksjon 1)
             <input id="cfgPoints" type="number" value="0">
           </label>
           <div class="settings-row">
-            <label>Funksjon 2 (Valgfritt)
+            <label>Funksjon 2 (valgfritt)
               <input id="cfgFun2" type="text" value="">
             </label>
-            <label>Definisjonsmengde funksjon 2 (Valgfritt. Skriv [start, stopp])
-              <input id="cfgDom2" type="text" value="">
+            <label>Definisjonsmengde funksjon 2 (valgfritt)
+              <input id="cfgDom2" type="text" value="" placeholder="[start, stopp]">
             </label>
           </div>
-          <label>Screen (Overstyrer autozoom hvis satt. Skriv minX, maxX, minY, maxY)
-            <input id="cfgScreen" type="text" value="">
+          <label>Screen (overstyrer autozoom hvis satt)
+            <input id="cfgScreen" type="text" value="" placeholder="minX, maxX, minY, maxY">
           </label>
-          <label><input id="cfgLock" type="checkbox"> Lås forhold 1:1 (krever screen)</label>
+          <label class="checkbox-label"><input id="cfgLock" type="checkbox"> Lås forhold 1:1 (krever screen)</label>
           <div class="settings-row">
             <label>Navn på x-akse (valgfritt)
               <input id="cfgAxisX" type="text" value="x">
@@ -84,7 +85,7 @@
               <input id="cfgAxisY" type="text" value="y">
             </label>
           </div>
-          <label><input id="cfgPan" type="checkbox"> Tillat pan</label>
+          <label class="checkbox-label"><input id="cfgPan" type="checkbox"> Tillat pan</label>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Simplify function domain and screen labels with placeholders
- Add checkbox layout class for clearer alignment

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c11e7671d88324b40424ddad9745b1