### PR TITLE
Scale down Arealmodell A figure

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -25,7 +25,7 @@
       display:flex;flex-direction:column;gap:10px;
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    #box{width:100%;aspect-ratio:1;}
+    #box{width:clamp(240px,60vw,420px);aspect-ratio:1;margin:0 auto;}
     .toolbar{display:flex;gap:10px;justify-content:flex-end;}
     .btn{
       appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;


### PR DESCRIPTION
## Summary
- Limit area model board to a max width of 420px
- Center and allow responsive scaling using CSS clamp

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1322df33c832495f491c5d668c5c9