### PR TITLE
Ensure bar chart bars render fully opaque

### DIFF
--- a/diagram.html
+++ b/diagram.html
@@ -52,7 +52,7 @@
     .yLabel{fill:#333;font-size:18px}
 
     /* Søyler + vurderingsrammer */
-    .bar{fill:#800080;stroke:#000;stroke-width:4}
+    .bar{fill:#800080;stroke:#000;stroke-width:4;opacity:1;fill-opacity:1}
     .bar.badge-ok{stroke:#2e7d32;stroke-width:4}
     .bar.badge-no{stroke:#c62828;stroke-width:4}
 


### PR DESCRIPTION
## Summary
- Force bar elements in diagram to render at full opacity.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c134e1e57c83248ec769d92b447d35