### PR TITLE
feat: separate download controls

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -18,6 +18,7 @@
     }
     .wrap{max-width:1200px;margin:0 auto;}
     .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    .side{display:flex;flex-direction:column;gap:var(--gap);}
     @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
@@ -52,15 +53,21 @@
         <div id="box" class="jxgbox" aria-label="Arealmodell rektangel"></div>
         <div class="toolbar">
           <button id="btnReset" class="btn" type="button">Reset</button>
-          <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-          <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-          <button id="btnSvgInteractive" class="btn" type="button">Last ned interaktiv SVG</button>
-          <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
         </div>
       </div>
-      <div class="card">
-        <h2>Innstillinger</h2>
-        <div id="settingsMenu" class="settings">
+      <div class="side">
+        <div class="card">
+          <h2>Nedlasting</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSvgInteractive" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Innstillinger</h2>
+          <div id="settingsMenu" class="settings">
           <div class="row">
             <label>Lengde (celler)
               <input id="lenCells" type="number" value="1" min="1">
@@ -93,6 +100,7 @@
         </div>
       </div>
     </div>
+  </div>
   </div>
   <script src="arealmodell0.js"></script>
 </body>

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -17,6 +17,7 @@
     }
     .wrap { max-width: 1200px; margin: 0 auto; }
     .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 360px; align-items: start; }
+    .side { display:flex; flex-direction:column; gap:var(--gap); }
     @media (max-width:980px){ .grid { grid-template-columns: 1fr; } }
     .card {
       background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
@@ -26,6 +27,7 @@
     .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
     svg { width: 100%; height: auto; background: #fff; display: block; }
     .settings { display: flex; flex-direction: column; gap: 10px; }
+    .toolbar { display:flex; gap:10px; justify-content:flex-end; }
     .settings label { font-size: 13px; color: #4b5563; display: flex; flex-direction: column; }
     .settings input, .settings button {
       border: 1px solid #d1d5db; border-radius: 10px;
@@ -60,37 +62,44 @@
         <h2>Arealmodell</h2>
         <svg id="area" preserveAspectRatio="xMidYMid meet" aria-label="Arealmodell"></svg>
       </div>
-      <div class="card">
-        <h2>Innstillinger</h2>
-        <div class="settings">
-          <div class="row">
-            <label>Lengde
-              <input id="length" type="number" value="17" min="2">
-            </label>
-            <label>Startposisjon
-              <input id="lengthStart" type="number" value="3" min="1">
-            </label>
-            <label class="chk"><input id="showLengthHandle" type="checkbox" checked> Vis håndtak</label>
+      <div class="side">
+        <div class="card">
+          <h2>Nedlasting</h2>
+          <div class="toolbar">
+            <button id="btnSvgStatic" type="button">Last ned SVG</button>
+            <button id="btnPng" type="button">Last ned PNG</button>
+            <button id="btnSvg" type="button">Last ned interaktiv SVG</button>
+            <button id="btnHtml" type="button">Last ned interaktiv HTML</button>
           </div>
-          <div class="row">
-            <label>Høyde
-              <input id="height" type="number" value="16" min="2">
+        </div>
+        <div class="card">
+          <h2>Innstillinger</h2>
+          <div class="settings">
+            <div class="row">
+              <label>Lengde
+                <input id="length" type="number" value="17" min="2">
+              </label>
+              <label>Startposisjon
+                <input id="lengthStart" type="number" value="3" min="1">
+              </label>
+              <label class="chk"><input id="showLengthHandle" type="checkbox" checked> Vis håndtak</label>
+            </div>
+            <div class="row">
+              <label>Høyde
+                <input id="height" type="number" value="16" min="2">
+              </label>
+              <label>Startposisjon
+                <input id="heightStart" type="number" value="5" min="1">
+              </label>
+              <label class="chk"><input id="showHeightHandle" type="checkbox" checked> Vis håndtak</label>
+            </div>
+            <label><input id="grid" type="checkbox"> Vis rutenett</label>
+            <label><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
+            <label>Forfatter
+              <input id="author" type="text" />
             </label>
-            <label>Startposisjon
-              <input id="heightStart" type="number" value="5" min="1">
-            </label>
-            <label class="chk"><input id="showHeightHandle" type="checkbox" checked> Vis håndtak</label>
+            <button id="btnReset" type="button">Reset</button>
           </div>
-          <label><input id="grid" type="checkbox"> Vis rutenett</label>
-          <label><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
-          <label>Forfatter
-            <input id="author" type="text" />
-          </label>
-          <button id="btnReset" type="button">Reset</button>
-          <button id="btnSvgStatic" type="button">Last ned SVG</button>
-          <button id="btnPng" type="button">Last ned PNG</button>
-          <button id="btnSvg" type="button">Last ned interaktiv SVG</button>
-          <button id="btnHtml" type="button">Last ned interaktiv HTML</button>
         </div>
       </div>
     </div>

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -15,6 +15,7 @@
     }
     .wrap { max-width:1200px; margin:0 auto; }
     .grid { display:grid; gap:var(--gap); grid-template-columns:1fr 360px; align-items:start; }
+    .side { display:flex; flex-direction:column; gap:var(--gap); }
     @media (max-width:980px){ .grid { grid-template-columns:1fr; } }
     .card {
       background:#fff; border:1px solid #e5e7eb; border-radius:14px;
@@ -114,16 +115,21 @@
             </div>
           </div>
         </div>
-        <div class="toolbar">
-          <button id="btnStaticAll" class="btn" type="button">Last ned SVG</button>
-          <button id="btnInteractiveAll" class="btn" type="button">Last ned interaktiv SVG</button>
-          <button id="btnPngAll" class="btn" type="button">Last ned PNG</button>
-        </div>
       </div>
 
-      <div class="card">
-        <h2>Innstillinger</h2>
-        <div class="settings">
+      <div class="side">
+        <div class="card">
+          <h2>Nedlasting</h2>
+          <div class="toolbar">
+            <button id="btnStaticAll" class="btn" type="button">Last ned SVG</button>
+            <button id="btnInteractiveAll" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnPngAll" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Innstillinger</h2>
+          <div class="settings">
           <fieldset>
             <legend>Pizza 1</legend>
             <div class="checkbox-row"><input id="p1Show" type="checkbox" checked><label for="p1Show">Vis</label></div>
@@ -169,12 +175,13 @@
             <label for="p2MaxN">Maks n</label>
             <input id="p2MaxN" type="number" value="24" min="1">
           </fieldset>
+          </div>
         </div>
+
       </div>
-
     </div>
-  </div>
+    </div>
 
-  <script src="brøkpizza.js"></script>
-</body>
-</html>
+    <script src="brøkpizza.js"></script>
+  </body>
+  </html>

--- a/diagram.html
+++ b/diagram.html
@@ -14,6 +14,7 @@
     }
     .wrap { max-width: 1200px; margin: 0 auto; }
     .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
+    .side { display:flex; flex-direction:column; gap:var(--gap); }
     @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
     .card {
       background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
@@ -86,15 +87,22 @@
           <button id="btnCheck" class="btn">Sjekk</button>
           <button id="btnReset" class="btn">Nullstill</button>
           <button id="btnShow" class="btn">Vis fasit</button>
-          <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-          <button id="btnPng" class="btn" type="button">Last ned PNG</button>
         </div>
         <div id="status" class="status" role="status" aria-live="polite"></div>
       </div>
 
-      <div class="card">
-        <h2>Innstillinger</h2>
-        <div class="settings">
+      <div class="side">
+        <div class="card">
+          <h2>Nedlasting</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Innstillinger</h2>
+          <div class="settings">
           <label>Overskrift
             <input id="cfgTitle" type="text" value="Favorittidretter i 5B">
           </label>
@@ -134,6 +142,7 @@
         </div>
       </div>
     </div>
+  </div>
   </div>
 
   <script src="diagram.js"></script>

--- a/graftegner.html
+++ b/graftegner.html
@@ -16,6 +16,7 @@
     }
     .wrap{ max-width:1200px; margin:0 auto; }
     .grid{ display:grid; gap:var(--gap); grid-template-columns:1fr 420px; align-items:start; }
+    .side{ display:flex; flex-direction:column; gap:var(--gap); }
     @media (max-width:980px){ .grid{ grid-template-columns:1fr; } }
     .card{ background:#fff; border:1px solid #e5e7eb; border-radius:14px; box-shadow:0 1px 2px rgba(0,0,0,.04); padding:14px; display:flex; flex-direction:column; gap:10px; }
     .card h2{ margin:0 0 6px 2px; font-size:16px; font-weight:600; color:#374151; }
@@ -48,13 +49,20 @@
         <div class="toolbar" id="toolbar">
           <div id="checkArea" class="checkbar"></div>
           <button id="btnReset" class="btn">Nullstill zoom/pan</button>
-          <button id="btnSvg" class="btn">Last ned SVG</button>
         </div>
       </div>
 
-      <div class="card">
-        <h2>Innstillinger</h2>
-        <div class="settings">
+      <div class="side">
+        <div class="card">
+          <h2>Nedlasting</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn">Last ned SVG</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Innstillinger</h2>
+          <div class="settings">
           <div class="settings-row">
             <label>Funksjon 1
               <input id="cfgFun1" type="text" value="f(x)=x^2-2">
@@ -98,6 +106,7 @@
         </div>
       </div>
     </div>
+  </div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>

--- a/nkant.html
+++ b/nkant.html
@@ -11,6 +11,7 @@
            color: #111827; background: #f7f8fb; padding: 20px; }
     .wrap { max-width: 1200px; margin: 0 auto; }
     .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
+    .side { display:flex; flex-direction:column; gap:var(--gap); }
     @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
     .card { background: #fff; border: 1px solid #e5e7eb; border-radius: 14px; box-shadow: 0 1px 2px rgba(0,0,0,.04);
             padding: 14px; display: flex; flex-direction: column; gap: 10px; }
@@ -43,13 +44,20 @@
         </div>
         <div class="toolbar">
           <button id="btnReset" class="btn" type="button">Reset</button>
-          <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-          <button id="btnPng" class="btn" type="button">Last ned PNG</button>
         </div>
       </div>
 
-      <div class="card">
-        <h2>Innstillinger</h2>
+      <div class="side">
+        <div class="card">
+          <h2>Nedlasting</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Innstillinger</h2>
 
         <label for="inpSpecs">SPECS (skriv 1–2 linjer, én figur per linje)</label>
         <textarea id="inpSpecs" rows="4" spellcheck="false">a=3, b=5, c=5
@@ -271,6 +279,7 @@ a=5, b=5, c=5, B=90, D=110</textarea>
         </div>
       </div>
     </div>
+  </div>
   </div>
 
   <script src="nkant.js"></script>

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -16,6 +16,7 @@
     }
     .wrap { max-width: 1200px; margin: 0 auto; }
     .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
+    .side { display:flex; flex-direction:column; gap:var(--gap); }
     @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
     .card {
       background: #fff;
@@ -61,17 +62,23 @@
         <div class="figure">
           <svg id="beadSVG" viewBox="0 0 1400 460" role="img" aria-label="Perlesnor med klype"></svg>
         </div>
-        <div class="toolbar">
-          <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-          <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-        </div>
       </div>
 
-      <div class="card">
-        <h2>Innstillinger</h2>
-        <label>Antall perler<input id="cfg-nBeads" type="number" min="1"></label>
-        <label>Startposisjon<input id="cfg-startIndex" type="number" min="0"></label>
-        <label>Fasit venstre<input id="cfg-correct" type="number" min="0"></label>
+      <div class="side">
+        <div class="card">
+          <h2>Nedlasting</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Innstillinger</h2>
+          <label>Antall perler<input id="cfg-nBeads" type="number" min="1"></label>
+          <label>Startposisjon<input id="cfg-startIndex" type="number" min="0"></label>
+          <label>Fasit venstre<input id="cfg-correct" type="number" min="0"></label>
+        </div>
       </div>
     </div>
   </div>

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -16,6 +16,7 @@
     }
     .wrap { max-width:1200px; margin:0 auto; }
     .grid { display:grid; gap:var(--gap); grid-template-columns:1fr 360px; align-items:start; }
+    .side { display:flex; flex-direction:column; gap:var(--gap); }
     @media (max-width:980px){ .grid { grid-template-columns:1fr; } }
     .card {
       background:#fff; border:1px solid #e5e7eb; border-radius:14px;
@@ -91,33 +92,39 @@
           <div class="tb-divider"></div>
           <button id="tbPlus"  type="button" aria-label="Flere blokker">+</button>
         </div>
+      </div>
 
-        <div class="tb-toolbar">
-          <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-          <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+      <div class="side">
+        <div class="card">
+          <h2>Nedlasting</h2>
+          <div class="tb-toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Innstillinger</h2>
+          <label>Totalt<input id="cfg-total" type="number" min="1"></label>
+          <label>Start blokker<input id="cfg-startN" type="number" min="1"></label>
+          <label>Fylte blokker<input id="cfg-startK" type="number" min="0"></label>
+          <label>Min blokker<input id="cfg-minN" type="number" min="1"></label>
+          <label>Maks blokker<input id="cfg-maxN" type="number" min="1"></label>
+          <div class="checkbox-row"><input id="cfg-showWhole" type="checkbox" checked><label for="cfg-showWhole">Vis «hele»</label></div>
+          <div class="checkbox-row"><input id="cfg-showStepper" type="checkbox" checked><label for="cfg-showStepper">Vis pluss/minus</label></div>
+          <div class="checkbox-row"><input id="cfg-showHandle" type="checkbox" checked><label for="cfg-showHandle">Vis håndtak</label></div>
+          <label>Tallformat
+            <select id="cfg-valMode">
+              <option value="rounded">Avrundet</option>
+              <option value="exact">Ikke avrundet</option>
+              <option value="fraction">Brøk</option>
+              <option value="percent">Prosent</option>
+            </select>
+          </label>
         </div>
       </div>
-
-      <div class="card">
-        <h2>Innstillinger</h2>
-        <label>Totalt<input id="cfg-total" type="number" min="1"></label>
-        <label>Start blokker<input id="cfg-startN" type="number" min="1"></label>
-        <label>Fylte blokker<input id="cfg-startK" type="number" min="0"></label>
-        <label>Min blokker<input id="cfg-minN" type="number" min="1"></label>
-        <label>Maks blokker<input id="cfg-maxN" type="number" min="1"></label>
-        <div class="checkbox-row"><input id="cfg-showWhole" type="checkbox" checked><label for="cfg-showWhole">Vis «hele»</label></div>
-        <div class="checkbox-row"><input id="cfg-showStepper" type="checkbox" checked><label for="cfg-showStepper">Vis pluss/minus</label></div>
-        <div class="checkbox-row"><input id="cfg-showHandle" type="checkbox" checked><label for="cfg-showHandle">Vis håndtak</label></div>
-        <label>Tallformat
-          <select id="cfg-valMode">
-            <option value="rounded">Avrundet</option>
-            <option value="exact">Ikke avrundet</option>
-            <option value="fraction">Brøk</option>
-            <option value="percent">Prosent</option>
-          </select>
-        </label>
-      </div>
     </div>
+  </div>
   </div>
 
   <script src="tenkeblokker.js"></script>


### PR DESCRIPTION
## Summary
- move download/PNG/SVG buttons into a dedicated 'Nedlasting' card
- add `.side` column container to stack download card above settings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c135787b988324ab067ad45d8449e7