### PR TITLE
Improve graph settings layout

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -30,11 +30,11 @@
     .status--err{ color:#b91c1c; background:#fef2f2; border-color:#fecaca; }
     .status--info{ color:#1f2937; background:#f3f4f6; border-color:#e5e7eb; }
     .settings{ display:flex; flex-direction:column; gap:8px; }
-    .settings label{ display:flex; flex-direction:column; font-size:13px; color:#4b5563; max-width:160px; }
-    .settings input[type="text"], .settings input[type="number"], .settings select{ padding:8px 10px; border:1px solid #d1d5db; border-radius:10px; font-size:14px; background:#fff; width:100%; max-width:160px; }
-    .settings-row{ display:flex; gap:8px; flex-wrap:wrap; }
-    .settings-row label{ flex:0 0 160px; }
-    .settings-row label.points{ flex:0 0 80px; }
+    .settings label{ display:flex; flex-direction:column; font-size:13px; color:#4b5563; white-space:nowrap; }
+    .settings input[type="text"], .settings input[type="number"], .settings select{ padding:8px 10px; border:1px solid #d1d5db; border-radius:10px; font-size:14px; background:#fff; width:100%; }
+    .settings-row{ display:flex; gap:8px; flex-wrap:nowrap; }
+    .settings-row label{ flex:1; }
+    .settings-row label.points{ flex:0 0 70px; }
     .checkbox-label{ flex-direction:row; align-items:center; gap:6px; }
   </style>
 </head>
@@ -67,7 +67,10 @@
             <label>Funksjon 1
               <input id="cfgFun1" type="text" value="f(x)=x^2-2">
             </label>
-            <label class="points">punkter
+            <label>Definisjon (valgfritt)
+              <input id="cfgDom1" type="text" value="" placeholder="[start, stopp]">
+            </label>
+            <label class="points">Punkter
               <select id="cfgPoints">
                 <option value="0">0</option>
                 <option value="1">1</option>
@@ -78,15 +81,12 @@
                 <option value="6">6</option>
               </select>
             </label>
-            <label>Definisjonsmengde (valgfritt)
-              <input id="cfgDom1" type="text" value="" placeholder="[start, stopp]">
-            </label>
           </div>
           <div class="settings-row">
             <label>Funksjon 2 (valgfritt)
               <input id="cfgFun2" type="text" value="">
             </label>
-            <label>Definisjonsmengde (valgfritt)
+            <label>Definisjon (valgfritt)
               <input id="cfgDom2" type="text" value="" placeholder="[start, stopp]">
             </label>
           </div>


### PR DESCRIPTION
## Summary
- Align first row inputs (Funksjon 1, Definisjon, Punkter) on a single line
- Simplify and shorten definition labels
- Tweak CSS widths and flex behavior for a cleaner layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c137cdf02083249a57d151f5acb36e