### PR TITLE
Standardize Arealmodell B controls

### DIFF
--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -28,15 +28,15 @@
     svg { width: 100%; height: auto; background: #fff; display: block; }
     .settings { display: flex; flex-direction: column; gap: 10px; }
     .toolbar { display:flex; gap:10px; justify-content:flex-end; }
+    .btn { appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px; padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s; }
+    .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
+    .btn:active { transform:translateY(1px); }
     .settings label { font-size: 13px; color: #4b5563; display: flex; flex-direction: column; }
-    .settings input, .settings button {
-      border: 1px solid #d1d5db; border-radius: 10px;
-      padding: 8px 10px; font-size: 14px; background: #fff;
-    }
-    .settings button { cursor: pointer; }
+    .settings input { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; }
 
     .settings .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
-    .settings .row label { flex: 1; }
+    .settings .row label { flex: 0; }
+    .settings .row label input[type="number"] { width: 80px; }
     .settings .row label.chk { flex: 0; flex-direction: row; align-items: center; }
     .settings .row label.chk input { margin-right: 6px; }
 
@@ -66,10 +66,10 @@
         <div class="card">
           <h2>Nedlasting</h2>
           <div class="toolbar">
-            <button id="btnSvgStatic" type="button">Last ned SVG</button>
-            <button id="btnPng" type="button">Last ned PNG</button>
-            <button id="btnSvg" type="button">Last ned interaktiv SVG</button>
-            <button id="btnHtml" type="button">Last ned interaktiv HTML</button>
+            <button id="btnSvgStatic" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSvg" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
           </div>
         </div>
         <div class="card">
@@ -95,10 +95,7 @@
             </div>
             <label><input id="grid" type="checkbox"> Vis rutenett</label>
             <label><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
-            <label>Forfatter
-              <input id="author" type="text" />
-            </label>
-            <button id="btnReset" type="button">Reset</button>
+            <button id="btnReset" class="btn" type="button">Reset</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Match download and reset buttons to other visualizations with shared `.btn` styling
- Shorten numeric inputs so length/start/visibility and height/start/visibility sit on one line
- Remove unused `Forfatter` field from settings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c139ff0188832481b590d320874c47