### PR TITLE
Allow bracketed screen settings in graftegner

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -16,7 +16,8 @@ function paramStr(id, def=''){ const v=params.get(id); return v==null?def:v; }
 function paramBool(id){ return params.get(id)==='1'; }
 function parseScreen(str){
   if(!str) return null;
-  const parts=str.split(',').map(s=>+s.trim());
+  const cleaned = str.replace(/^[\s\[]+|[\]\s]+$/g, '');
+  const parts = cleaned.split(',').map(s=>+s.trim());
   return parts.length===4 && parts.every(Number.isFinite) ? parts : null;
 }
 function buildSimple(){


### PR DESCRIPTION
## Summary
- accept screen coordinates provided with or without square brackets so authors can override autozoom in graftegner

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c14ba9f20483248bef5c06aaa95a47