### PR TITLE
Enable interactive coloring in fraction visualizations

### DIFF
--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -65,7 +65,7 @@
               <option value="diagonal">diagonalt</option>
             </select>
           </label>
-          <label>Fylte deler (kommaseparert)
+          <label>Fylte deler (kommaseparert, klikk på figuren for å fargelegge)
             <input id="filled" type="text" value="0" />
           </label>
           <label class="row"><input id="allowWrong" type="checkbox" /> Tillat gale illustrasjoner</label>


### PR DESCRIPTION
## Summary
- Allow clicking on shapes to toggle filled sectors in the fraction visualizer
- Update filled parts input automatically when sectors are toggled
- Add hint in UI that shapes can be colored by clicking

## Testing
- `npm test` *(fails: no test specified)*
- `node --check brøkvisualiseringer.js`


------
https://chatgpt.com/codex/tasks/task_e_68c15100211483248d92c9d25088ae09