### PR TITLE
Add download buttons to fraction visualizer

### DIFF
--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -23,6 +23,11 @@
       box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;display:flex;
       flex-direction:column;gap:10px;
     }
+    .side{display:flex;flex-direction:column;gap:var(--gap);}
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
+    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
+    .btn:active{transform:translateY(1px);}
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
     .figure{border-radius:10px;background:#fff;overflow:visible;border:none;}
     .figure #box{
@@ -45,30 +50,39 @@
           <div id="box"></div>
         </div>
       </div>
-      <div class="card">
-        <h2>Innstillinger</h2>
-        <div class="settings">
-          <label>Form
-            <select id="shape">
-              <option value="circle">sirkel</option>
-              <option value="rectangle">rektangel</option>
-              <option value="triangle">trekant</option>
-            </select>
-          </label>
-          <label>Antall deler
-            <input id="parts" type="number" min="1" value="4" />
-          </label>
-          <label>Delt
-            <select id="division">
-              <option value="horizontal">horisontalt</option>
-              <option value="vertical">vertikalt</option>
-              <option value="diagonal">diagonalt</option>
-            </select>
-          </label>
-          <label>Fylte deler (kommaseparert)
-            <input id="filled" type="text" value="0" />
-          </label>
-          <label class="row"><input id="allowWrong" type="checkbox" /> Tillat gale illustrasjoner</label>
+      <div class="side">
+        <div class="card">
+          <h2>Nedlasting</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Innstillinger</h2>
+          <div class="settings">
+            <label>Form
+              <select id="shape">
+                <option value="circle">sirkel</option>
+                <option value="rectangle">rektangel</option>
+                <option value="triangle">trekant</option>
+              </select>
+            </label>
+            <label>Antall deler
+              <input id="parts" type="number" min="1" value="4" />
+            </label>
+            <label>Delt
+              <select id="division">
+                <option value="horizontal">horisontalt</option>
+                <option value="vertical">vertikalt</option>
+                <option value="diagonal">diagonalt</option>
+              </select>
+            </label>
+            <label>Fylte deler (kommaseparert)
+              <input id="filled" type="text" value="0" />
+            </label>
+            <label class="row"><input id="allowWrong" type="checkbox" /> Tillat gale illustrasjoner</label>
+          </div>
         </div>
       </div>
     </div>

--- a/brøkvisualiseringer.js
+++ b/brøkvisualiseringer.js
@@ -4,6 +4,8 @@
   const divSel   = document.getElementById('division');
   const filledInp= document.getElementById('filled');
   const wrongInp = document.getElementById('allowWrong');
+  const btnSvg   = document.getElementById('btnSvg');
+  const btnPng   = document.getElementById('btnPng');
   let board;
 
   function initBoard(){
@@ -201,11 +203,69 @@
     }
   }
 
+  function svgToString(svgEl){
+    const clone = svgEl.cloneNode(true);
+    const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
+    const style = document.createElement('style');
+    style.textContent = css;
+    clone.insertBefore(style, clone.firstChild);
+    clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
+    clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
+  }
+  function downloadSVG(svgEl, filename){
+    const data = svgToString(svgEl);
+    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename.endsWith('.svg') ? filename : filename + '.svg';
+    document.body.appendChild(a); a.click(); a.remove();
+    setTimeout(()=>URL.revokeObjectURL(url), 1000);
+  }
+  function downloadPNG(svgEl, filename, scale=2, bg='#fff'){
+    const vb = svgEl.viewBox?.baseVal;
+    const w = vb?.width  || svgEl.clientWidth  || 900;
+    const h = vb?.height || svgEl.clientHeight || 560;
+    const data = svgToString(svgEl);
+    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const url  = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = ()=>{
+      const canvas = document.createElement('canvas');
+      canvas.width  = Math.round(w * scale);
+      canvas.height = Math.round(h * scale);
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = bg;
+      ctx.fillRect(0,0,canvas.width,canvas.height);
+      ctx.drawImage(img,0,0,canvas.width,canvas.height);
+      URL.revokeObjectURL(url);
+      canvas.toBlob(blob=>{
+        const urlPng = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = urlPng;
+        a.download = filename.endsWith('.png') ? filename : filename + '.png';
+        document.body.appendChild(a); a.click(); a.remove();
+        setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
+      }, 'image/png');
+    };
+    img.src = url;
+  }
+
   shapeSel.addEventListener('change', draw);
   partsInp.addEventListener('input', draw);
   divSel.addEventListener('change', draw);
   filledInp.addEventListener('input', draw);
   wrongInp.addEventListener('change', draw);
+
+  btnSvg?.addEventListener('click', ()=>{
+    const svg = board?.renderer?.svgRoot;
+    if(svg) downloadSVG(svg, 'brokvisualisering.svg');
+  });
+  btnPng?.addEventListener('click', ()=>{
+    const svg = board?.renderer?.svgRoot;
+    if(svg) downloadPNG(svg, 'brokvisualisering.png', 2);
+  });
 
   draw();
 })();


### PR DESCRIPTION
## Summary
- add SVG/PNG download buttons and styles to brøkvisualiseringer page
- implement download helpers and button listeners in brøkvisualiseringer.js

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1509c4ed88324b8b5c9c0ef89c43d