### PR TITLE
Rename settings and download headings across visualizations

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -58,7 +58,7 @@
       </div>
       <div class="side">
         <div class="card">
-          <h2>Nedlasting</h2>
+          <h2>Last ned figurer</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
@@ -67,7 +67,7 @@
           </div>
         </div>
         <div class="card">
-          <h2>Innstillinger</h2>
+          <h2>Forfatters innstillinger</h2>
           <div id="settingsMenu" class="settings">
           <div class="row">
             <label>Lengde (celler)

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -64,7 +64,7 @@
       </div>
       <div class="side">
         <div class="card">
-          <h2>Nedlasting</h2>
+          <h2>Last ned figurer</h2>
           <div class="toolbar">
             <button id="btnSvgStatic" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
@@ -73,7 +73,7 @@
           </div>
         </div>
         <div class="card">
-          <h2>Innstillinger</h2>
+          <h2>Forfatters innstillinger</h2>
           <div class="settings">
             <div class="row">
               <label>Lengde

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -119,7 +119,7 @@
 
       <div class="side">
         <div class="card">
-          <h2>Nedlasting</h2>
+          <h2>Last ned figurer</h2>
           <div class="toolbar">
             <button id="btnStaticAll" class="btn" type="button">Last ned SVG</button>
             <button id="btnInteractiveAll" class="btn" type="button">Last ned interaktiv SVG</button>
@@ -128,7 +128,7 @@
         </div>
 
         <div class="card">
-          <h2>Innstillinger</h2>
+          <h2>Forfatters innstillinger</h2>
           <div class="settings">
           <fieldset>
             <legend>Pizza 1</legend>

--- a/brøkpizza.js
+++ b/brøkpizza.js
@@ -432,7 +432,7 @@ const INTERACTIVE_SVG_SCRIPT = `
 `;
 
 /* =======================
-   Nedlasting: statisk SVG
+   Last ned figurer: statisk SVG
    ======================= */
 function downloadSVG(svgEl, filename="pizza.svg") {
   if(!svgEl) return;
@@ -471,7 +471,7 @@ function downloadSVG(svgEl, filename="pizza.svg") {
 }
 
 /* =======================
-   Nedlasting: interaktiv SVG
+   Last ned figurer: interaktiv SVG
    – brøk OVER, +/− UNDER, pen spacing
    ======================= */
 function downloadInteractiveSVG(svgEl, filename="pizza-interaktiv.svg") {

--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -46,7 +46,7 @@
         </div>
       </div>
       <div class="card">
-        <h2>Innstillinger</h2>
+        <h2>Forfatters innstillinger</h2>
         <div class="settings">
           <label>Form
             <select id="shape">

--- a/diagram.html
+++ b/diagram.html
@@ -26,7 +26,7 @@
 
       <div class="side">
         <div class="card">
-          <h2>Nedlasting</h2>
+          <h2>Last ned figurer</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
@@ -34,7 +34,7 @@
         </div>
 
         <div class="card">
-          <h2>Innstillinger</h2>
+          <h2>Forfatters innstillinger</h2>
           <div class="settings">
           <label>Overskrift
             <input id="cfgTitle" type="text" value="Favorittidretter i 5B">

--- a/graftegner.html
+++ b/graftegner.html
@@ -55,14 +55,14 @@
 
       <div class="side">
         <div class="card">
-          <h2>Nedlasting</h2>
+          <h2>Last ned figurer</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn">Last ned SVG</button>
           </div>
         </div>
 
         <div class="card">
-          <h2>Innstillinger</h2>
+          <h2>Forfatters innstillinger</h2>
           <div class="settings">
           <div class="settings-row">
             <label>Funksjon 1

--- a/nkant.html
+++ b/nkant.html
@@ -50,7 +50,7 @@
 
       <div class="side">
         <div class="card">
-          <h2>Nedlasting</h2>
+          <h2>Last ned figurer</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
@@ -58,7 +58,7 @@
         </div>
 
         <div class="card">
-          <h2>Innstillinger</h2>
+          <h2>Forfatters innstillinger</h2>
 
         <label for="inpSpecs">SPECS (skriv 1–2 linjer, én figur per linje)</label>
         <textarea id="inpSpecs" rows="4" spellcheck="false">a=3, b=5, c=5

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -66,7 +66,7 @@
 
       <div class="side">
         <div class="card">
-          <h2>Nedlasting</h2>
+          <h2>Last ned figurer</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
@@ -74,7 +74,7 @@
         </div>
 
         <div class="card">
-          <h2>Innstillinger</h2>
+          <h2>Forfatters innstillinger</h2>
           <label>Antall perler<input id="cfg-nBeads" type="number" min="1"></label>
           <label>Startposisjon<input id="cfg-startIndex" type="number" min="0"></label>
           <label>Fasit venstre<input id="cfg-correct" type="number" min="0"></label>

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -96,7 +96,7 @@
 
       <div class="side">
         <div class="card">
-          <h2>Nedlasting</h2>
+          <h2>Last ned figurer</h2>
           <div class="tb-toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
@@ -104,7 +104,7 @@
         </div>
 
         <div class="card">
-          <h2>Innstillinger</h2>
+          <h2>Forfatters innstillinger</h2>
           <label>Totalt<input id="cfg-total" type="number" min="1"></label>
           <label>Start blokker<input id="cfg-startN" type="number" min="1"></label>
           <label>Fylte blokker<input id="cfg-startK" type="number" min="0"></label>


### PR DESCRIPTION
## Summary
- Rename "Innstillinger" headings to "Forfatters innstillinger" across visualization pages
- Replace "Nedlasting" headings with "Last ned figurer" and update related labels
- Adjust brøkpizza.js comments to match new download wording

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1732b83248324a818ffb3e8acae07