### PR TITLE
Fix area click handling for fraction shapes

### DIFF
--- a/brøkvisualiseringer.js
+++ b/brøkvisualiseringer.js
@@ -72,7 +72,9 @@
         strokeWidth:6,
         fillColor: filled.has(i)?'#5B2AA5':'#fff',
         fillOpacity:1,
-        highlight:false
+        highlight:false,
+        hasInnerPoints:true,
+        fixed:true
       });
       sector.on('down', () => togglePart(i, sector));
     }
@@ -99,7 +101,9 @@
           vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
           fillColor: filled.has(i)?'#5B2AA5':'#fff',
           fillOpacity:1,
-          highlight:false
+          highlight:false,
+          hasInnerPoints:true,
+          fixed:true
         });
         poly.on('down', () => togglePart(i, poly));
         board.create('segment', [c, corners[i]], {
@@ -121,7 +125,9 @@
           vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
           fillColor: filled.has(i)?'#5B2AA5':'#fff',
           fillOpacity:1,
-          highlight:false
+          highlight:false,
+          hasInnerPoints:true,
+          fixed:true
         });
         poly.on('down', () => togglePart(i, poly));
       }
@@ -176,7 +182,9 @@
         vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
         fillColor: filled.has(i)?'#5B2AA5':'#fff',
         fillOpacity:1,
-        highlight:false
+        highlight:false,
+        hasInnerPoints:true,
+        fixed:true
       });
       poly.on('down', () => togglePart(i, poly));
     }


### PR DESCRIPTION
## Summary
- allow filling shapes by clicking inside rectangular and triangular parts by enabling hit detection on polygons
- ensure circular sectors also handle interior clicks

## Testing
- ⚠️ `npm test` (no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c1768614d88324949cc8e6e193c75f