### PR TITLE
Remove focus outline from fraction sectors

### DIFF
--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -34,6 +34,7 @@
     .settings label{display:flex;flex-direction:column;font-size:13px;color:#4b5563;}
     .settings label.row{flex-direction:row;align-items:center;gap:8px;}
     .settings input,.settings select{padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;}
+    #box svg *:focus{outline:none;}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Hide default focus outline on interactive SVG elements in brøkvisualiseringer

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c17e9cd71c8324b5f68935e3fe6d14