### PR TITLE
Add keyboard slider overlay and live region

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -85,13 +85,16 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker"></svg>
+        <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker">
+          <rect id="tbOverlay" tabindex="0" role="slider" aria-label="Fylte blokker" aria-valuemin="0" fill="transparent" style="pointer-events:none"></rect>
+        </svg>
 
         <div class="tb-stepper" aria-label="Blokker">
           <button id="tbMinus" type="button" aria-label="Færre blokker">−</button>
           <div class="tb-divider"></div>
           <button id="tbPlus"  type="button" aria-label="Flere blokker">+</button>
         </div>
+        <div id="tbLive" aria-live="polite" style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;"></div>
       </div>
 
       <div class="side">

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -37,7 +37,8 @@ let k = clamp(SIMPLE.startK, 0, n);
 
 // ---------- SVG-oppsett ----------
 const svg = document.getElementById('thinkBlocks');
-svg.innerHTML = '';
+const overlay = document.getElementById('tbOverlay');
+const live = document.getElementById('tbLive');
 
 const VBW = 900, VBH = 420;                  // MÅ samsvare med viewBox i HTML
 const L = 70, R = VBW - 70;                  // venstre/høyre marg
@@ -52,6 +53,13 @@ const gVals   = add('g');     // tall i blokker
 const gFrame  = add('g');     // svart ramme
 const gHandle = add('g');     // håndtak
 const gBrace  = add('g');     // parentes + TOTAL
+if(overlay){
+  svg.appendChild(overlay);
+  overlay.setAttribute('x', L);
+  overlay.setAttribute('y', TOP);
+  overlay.setAttribute('width', R-L);
+  overlay.setAttribute('height', BOT-TOP);
+}
 
 // Bakgrunn + ramme
 addTo(gBase ,'rect',{x:L,y:TOP,width:R-L,height:BOT-TOP,class:'tb-rect-empty'});
@@ -73,6 +81,28 @@ btnSvg?.addEventListener('click', ()=> downloadSVG(svg, 'tenkeblokker.svg'));
 btnPng?.addEventListener('click', ()=> downloadPNG(svg, 'tenkeblokker.png', 2));
 
 handle.addEventListener('pointerdown', onDragStart);
+overlay?.addEventListener('keydown', e=>{
+  switch(e.key){
+    case 'ArrowRight':
+    case 'ArrowUp':
+      setK(k+1);
+      e.preventDefault();
+      break;
+    case 'ArrowLeft':
+    case 'ArrowDown':
+      setK(k-1);
+      e.preventDefault();
+      break;
+    case 'Home':
+      setK(0);
+      e.preventDefault();
+      break;
+    case 'End':
+      setK(n);
+      e.preventDefault();
+      break;
+  }
+});
 function onDragStart(e){
   handle.setPointerCapture(e.pointerId);
   const move = ev=>{
@@ -260,6 +290,16 @@ function redraw(){
   const hx = L + k*cellW;
   handle.setAttribute('cx', hx);
   handleShadow.setAttribute('cx', hx);
+  updateAria();
+}
+
+function updateAria(){
+  if(!overlay) return;
+  overlay.setAttribute('aria-valuenow', k);
+  overlay.setAttribute('aria-valuemax', n);
+  const text = `${k} av ${n} blokker fylt`;
+  overlay.setAttribute('aria-valuetext', text);
+  if(live) live.textContent = text;
 }
 
 // ---------- State ----------


### PR DESCRIPTION
## Summary
- Overlay the block area with a transparent slider rect
- Support Arrow/Home/End keys to adjust filled blocks
- Announce block counts via aria-valuenow, aria-valuetext, and a live region

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1804d37708324ac47c85229b6aba8