### PR TITLE
Add keyboard-accessible sliders for area model handles

### DIFF
--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -51,6 +51,9 @@
     .handle { fill: #ecebf6; stroke: #333; stroke-width: 2; cursor: grab; }
     .handle:active { cursor: grabbing; }
 
+    .handleOverlay rect { fill: transparent; pointer-events: none; }
+    .handleOverlay:focus rect { stroke: #2563eb; stroke-width: 2; }
+
     .labelCell { fill: #000; opacity: .7; font-size: 22px; font-family: "Segoe UI", system-ui, Arial, sans-serif; }
     .labelEdge { fill: #000; font-size: 28px; font-family: "Georgia", "Times New Roman", serif; }
   </style>


### PR DESCRIPTION
## Summary
- add focusable slider overlays for model handles
- enable keyboard control of split lines via arrow and Home/End keys
- keep aria-valuenow and aria-valuetext updated when dimensions change

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c180538eb083249d2a7217f0aee3fd