### PR TITLE
Add help text for bead navigation with ARIA and export support

### DIFF
--- a/perlesnor.html
+++ b/perlesnor.html
@@ -61,6 +61,10 @@
         <h2>Perlesnor</h2>
         <div class="figure">
           <svg id="beadSVG" viewBox="0 0 1400 460" role="img" aria-label="Perlesnor med klype"></svg>
+          <p id="beadHelp" hidden>
+            Bruk piltastene venstre og høyre for å flytte klypa. Pil opp og ned justerer høyden,
+            og Shift+piltast gir finjustering.
+          </p>
         </div>
       </div>
 

--- a/perlesnor.js
+++ b/perlesnor.js
@@ -86,7 +86,8 @@ const overlay = rect(0,0,VB_W,VB_H,{
   fill:"transparent", class:"slider", tabindex:0, role:"slider",
   "aria-valuemin":"0", "aria-valuemax":String(CFG.nBeads),
   "aria-valuenow":"0",
-  "aria-label": CFG.a11y?.ariaLabel || "Posisjon for klypa. Bruk piltastene eller dra."
+  "aria-label": CFG.a11y?.ariaLabel || "Posisjon for klypa. Bruk piltastene eller dra.",
+  "aria-describedby":"beadHelp"
 });
 overlay.style.cursor = "ew-resize";
 svg.appendChild(overlay);
@@ -393,6 +394,25 @@ function svgToString(svgEl){
   const style = document.createElement('style');
   style.textContent = css;
   clone.insertBefore(style, clone.firstChild);
+
+  // Kopier beskrivelser referert av aria-describedby inn i SVG-en
+  const ids = new Set();
+  clone.querySelectorAll('[aria-describedby]').forEach(el => {
+    el.getAttribute('aria-describedby')
+      ?.split(/\s+/)
+      .forEach(id => ids.add(id));
+  });
+  ids.forEach(id => {
+    if(!id || clone.getElementById(id)) return;
+    const src = document.getElementById(id);
+    if(src){
+      const desc = document.createElementNS('http://www.w3.org/2000/svg','desc');
+      desc.setAttribute('id', id);
+      desc.textContent = src.textContent;
+      clone.insertBefore(desc, style.nextSibling);
+    }
+  });
+
   clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
   clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
   return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);


### PR DESCRIPTION
## Summary
- add hidden `beadHelp` description explaining keyboard navigation
- reference `beadHelp` via `aria-describedby` on the interaction overlay
- include `aria-describedby` targets as `<desc>` elements when exporting SVG

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c180563c20832483f8240b4e27ce57