### PR TITLE
Add grid division and optional incorrect circle splits

### DIFF
--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -80,6 +80,7 @@
               <option value="horizontal">horisontalt</option>
               <option value="vertical">vertikalt</option>
               <option value="diagonal">diagonalt</option>
+              <option value="grid">horisontalt og vertikalt</option>
             </select>
           </label>
           <label>Fylte deler (kommaseparert, klikk på figuren for å fargelegge)


### PR DESCRIPTION
## Summary
- add grid division option that factors parts into rows × columns
- allow circles to show vertical/horizontal/grid splits when "Tillat gale illustrasjoner" is enabled
- hide division options that don't apply and clip circle drawings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c182a3d92c8324b1422aa70fcac643