### PR TITLE
Simplify Arealmodell A settings

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -95,14 +95,10 @@
           </label>
           <label class="chk"><input type="checkbox" id="chkGrid" checked> Vis rutenett</label>
           <div class="row">
-            <label class="chk"><input type="checkbox" id="chkChallenge" checked> Oppgave-modus</label>
+            <label class="chk"><input type="checkbox" id="chkChallenge"> Oppgave-modus</label>
             <label>Oppgave-areal
               <input id="challengeArea" type="number" value="12" min="1">
             </label>
-          </div>
-          <div class="row">
-            <label class="chk"><input type="checkbox" id="chkDedupe" checked> To kolonner</label>
-            <label class="chk"><input type="checkbox" id="chkAutoExpand" checked> Auto maks</label>
           </div>
         </div>
       </div>

--- a/arealmodell0.js
+++ b/arealmodell0.js
@@ -12,7 +12,7 @@ const CFG = {
     areaLabel: "areal",
     // Oppgave-modus (tegn alle rektangler med areal N)
     challenge: {
-      enabled: true,
+      enabled: false,
       area: 12,
       dedupeOrderless: true,   // to kolonner (a · b og b · a)
       autoExpandMax: true      // øk max slik at N lar seg representere
@@ -116,8 +116,6 @@ function readConfigFromHtml(){
   CFG.SIMPLE.challenge.enabled = document.getElementById("chkChallenge")?.checked ?? false;
   const chArea = parseInt(document.getElementById("challengeArea")?.value,10);
   if(Number.isFinite(chArea)) CFG.SIMPLE.challenge.area = chArea;
-  CFG.SIMPLE.challenge.dedupeOrderless = document.getElementById("chkDedupe")?.checked ?? false;
-  CFG.SIMPLE.challenge.autoExpandMax = document.getElementById("chkAutoExpand")?.checked ?? false;
 }
 
 function applySimpleConfig(){


### PR DESCRIPTION
## Summary
- remove "To kolonner" and "Auto maks" settings from Arealmodell A
- default to not in oppgave-modus

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c189041db08324a6c5d30d99abca81