### PR TITLE
Fix export colors and remove handles

### DIFF
--- a/diagram.js
+++ b/diagram.js
@@ -448,10 +448,23 @@ function isCorrect(vs, ans, tol){
 
 function svgToString(svgEl){
   const clone = svgEl.cloneNode(true);
-  const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
+
+  // hent alle tilgjengelige stilregler (inkluderer linkede stilark)
+  let css = '';
+  for(const sheet of document.styleSheets){
+    try{
+      css += [...sheet.cssRules].map(r=>r.cssText).join('\n');
+    }catch(e){
+      // ignorer stilark som ikke kan leses pga. CORS
+    }
+  }
   const style = document.createElement('style');
   style.textContent = css;
   clone.insertBefore(style, clone.firstChild);
+
+  // fjern interaktive håndtak før eksport
+  clone.querySelectorAll('.handle, .handleShadow').forEach(el=>el.remove());
+
   clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
   clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
   return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);


### PR DESCRIPTION
## Summary
- Embed all available CSS rules when exporting diagrams so colors appear in SVG and PNG downloads
- Strip interactive handles from exported SVG before conversion or download

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b44ff6ac8324b62060af295c5bc1