### PR TITLE
Remember last visualization selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,17 @@
         <li><a href="perlesnor.html" target="content">Perlesnor</a></li>
     </ul>
   </nav>
-  <iframe name="content" src="nkant.html" title="Innhold"></iframe>
+    <iframe name="content" title="Innhold"></iframe>
+    <script>
+      const iframe = document.querySelector('iframe');
+      const links = document.querySelectorAll('nav a');
+      const saved = localStorage.getItem('currentPage') || 'nkant.html';
+      iframe.src = saved;
+      links.forEach(link => {
+        link.addEventListener('click', () => {
+          localStorage.setItem('currentPage', link.getAttribute('href'));
+        });
+      });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Save the currently viewed visualization in `localStorage` and load it on page start.
- Remove default `iframe` source so reloads return to the last visited visual.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ead407c08324a1aa5701f816065e