### PR TITLE
Ensure fraction visualizer accessible via directory path

### DIFF
--- a/brøkvisualiseringer/index.html
+++ b/brøkvisualiseringer/index.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="no">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Brøkvisualiseringer</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <!-- JSXGraph -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css">
+  <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
+  <style>
+    :root { --gap:18px; --purple:#5B2AA5; --rim:#333; --dash:#000; }
+    html,body{height:100%;}
+    body{
+      margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+      color:#111827; background:#f7f8fb; padding:20px;
+    }
+    .wrap{max-width:1200px;margin:0 auto;}
+    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
+    .grid2{
+      display:grid;
+      grid-template-columns:repeat(2,minmax(0,1fr));
+      gap:24px;
+      align-items:start;
+    }
+    .figurePanel{display:grid;place-items:center;gap:10px;}
+    @media(max-width:420px){
+      .grid2{grid-template-columns:1fr;gap:16px;}
+      .figure .box{width:clamp(240px,92vw,420px);}
+    }
+    .card{
+      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
+      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;display:flex;
+      flex-direction:column;gap:10px;
+    }
+    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    .figure{border-radius:10px;background:#fff;overflow:visible;border:none;}
+    .figure .box{
+      width:clamp(100px,40vw,420px);
+      aspect-ratio:1;
+      margin:0 auto;
+    }
+    .stepper{
+      display:flex;align-items:center;gap:12px;
+      padding:6px 10px;border:1px solid #cfcfcf;border-radius:12px;
+      box-shadow:0 2px 10px rgba(0,0,0,.06);background:#fff;
+      margin:0 auto;
+    }
+    .stepper button{
+      width:40px;height:36px;border:1px solid #cfcfcf;border-radius:8px;
+      background:#fff;font-size:20px;cursor:pointer;
+    }
+    .stepper span{min-width:32px;text-align:center;font-variant-numeric:tabular-nums;font-size:16px;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
+    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
+    .btn:active{transform:translateY(1px)}
+    .settings{display:flex;gap:var(--gap);}
+    .settings fieldset{flex:1;display:flex;flex-direction:column;gap:8px;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;}
+    legend{font-weight:600;font-size:13px;color:#374151;padding:0 4px;}
+    .settings label{display:flex;flex-direction:column;font-size:13px;color:#4b5563;}
+    .settings input,.settings select{padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;}
+    .checkbox-row{display:flex;align-items:center;gap:6px;}
+    .box svg *:focus{outline:none;}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="grid">
+      <div class="card">
+        <h2>Figurer</h2>
+        <div class="grid2">
+          <div id="panel1" class="figurePanel">
+            <div class="figure"><div id="box1" class="box"></div></div>
+            <div class="stepper" aria-label="Antall deler">
+              <button id="partsMinus1" type="button" aria-label="Færre deler">−</button>
+              <span id="partsVal1">4</span>
+              <button id="partsPlus1" type="button" aria-label="Flere deler">+</button>
+            </div>
+            <div class="toolbar">
+              <button id="btnSvg1" class="btn" type="button">Last ned SVG</button>
+              <button id="btnPng1" class="btn" type="button">Last ned PNG</button>
+            </div>
+          </div>
+          <div id="panel2" class="figurePanel">
+            <div class="figure"><div id="box2" class="box"></div></div>
+            <div class="stepper" aria-label="Antall deler">
+              <button id="partsMinus2" type="button" aria-label="Færre deler">−</button>
+              <span id="partsVal2">4</span>
+              <button id="partsPlus2" type="button" aria-label="Flere deler">+</button>
+            </div>
+            <div class="toolbar">
+              <button id="btnSvg2" class="btn" type="button">Last ned SVG</button>
+              <button id="btnPng2" class="btn" type="button">Last ned PNG</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="card">
+        <h2>Forfatters innstillinger</h2>
+        <div class="settings">
+          <fieldset>
+            <legend>Figur 1</legend>
+            <div class="checkbox-row"><input id="show1" type="checkbox" checked><label for="show1">Vis</label></div>
+            <label>Form
+              <select id="shape1">
+                <option value="circle">sirkel</option>
+                <option value="rectangle">rektangel</option>
+                <option value="triangle">trekant</option>
+              </select>
+            </label>
+            <label>Antall deler
+              <input id="parts1" type="number" min="1" value="4" />
+            </label>
+            <label>Delt
+              <select id="division1">
+                <option value="horizontal">horisontalt</option>
+                <option value="vertical">vertikalt</option>
+                <option value="diagonal">diagonalt</option>
+                <option value="grid">horisontalt og vertikalt</option>
+              </select>
+            </label>
+            <label>Fylte deler (kommaseparert, klikk på figuren for å fargelegge)
+              <input id="filled1" type="text" value="0" />
+            </label>
+            <div class="checkbox-row"><input id="allowWrong1" type="checkbox" /><label for="allowWrong1">Tillat gale illustrasjoner</label></div>
+          </fieldset>
+          <fieldset>
+            <legend>Figur 2</legend>
+            <div class="checkbox-row"><input id="show2" type="checkbox" checked><label for="show2">Vis</label></div>
+            <label>Form
+              <select id="shape2">
+                <option value="circle">sirkel</option>
+                <option value="rectangle">rektangel</option>
+                <option value="triangle">trekant</option>
+              </select>
+            </label>
+            <label>Antall deler
+              <input id="parts2" type="number" min="1" value="4" />
+            </label>
+            <label>Delt
+              <select id="division2">
+                <option value="horizontal">horisontalt</option>
+                <option value="vertical">vertikalt</option>
+                <option value="diagonal">diagonalt</option>
+                <option value="grid">horisontalt og vertikalt</option>
+              </select>
+            </label>
+            <label>Fylte deler (kommaseparert, klikk på figuren for å fargelegge)
+              <input id="filled2" type="text" value="0" />
+            </label>
+            <div class="checkbox-row"><input id="allowWrong2" type="checkbox" /><label for="allowWrong2">Tillat gale illustrasjoner</label></div>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="../brøkvisualiseringer.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Duplicate `brøkvisualiseringer.html` as `brøkvisualiseringer/index.html` so GitHub Pages serves the dual-figure version when the extension is omitted

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b9135dfc83249d5c7171d6692bce