### PR TITLE
fix: preserve transparent colors when exporting diagrams

### DIFF
--- a/diagram.js
+++ b/diagram.js
@@ -534,7 +534,8 @@ async function svgToString(svgEl){
                    'stroke-dasharray'];
     props.forEach(p=>{
       const val = comp.getPropertyValue(p);
-      if(val && val !== 'none' && val !== 'normal' && val !== '0px'){
+      // Include 'none' for fill and stroke to preserve transparency
+      if(val && val !== 'normal' && val !== '0px'){
         dst.setAttribute(p, val);
       }
     });


### PR DESCRIPTION
## Summary
- Keep `fill` and `stroke` attributes with values like `none` when exporting diagrams so colors render correctly

## Testing
- `node - <<'NODE' ... NODE` (svgToString preserves `fill="none"` and stroke color)
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f7e08e04832498f656689481a368