### PR TITLE
Unify function and coordinate input in graph tool

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -71,14 +71,6 @@
           <div class="settings">
           <div id="funcRows"></div>
           <div class="settings-row">
-            <button id="addFunc" type="button" class="btn" aria-label="Legg til funksjon">+</button>
-          </div>
-          <div class="settings-row">
-            <label>Punktkoordinater
-              <input id="cfgCoords" type="text" value="" placeholder="x1,y1; x2,y2">
-            </label>
-          </div>
-          <div class="settings-row">
             <label>Screen (overstyrer autozoom hvis satt)
               <input id="cfgScreen" type="text" value="" placeholder="minX, maxX, minY, maxY">
             </label>


### PR DESCRIPTION
## Summary
- Allow entering either functions or coordinate lists in the first input field and remove the separate coordinate row
- Show definition domain only when a valid function expression is provided
- Move the "+" button inline with the last function row

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d8e1ba2483249bc8d7bfdb6a1baa