### PR TITLE
Ensure kvikkbilder uses brick1.svg for bricks

### DIFF
--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -6,6 +6,7 @@
   const cfgDybde = document.getElementById('cfg-dybde');
   const brickContainer = document.getElementById('brickContainer');
   const expression = document.getElementById('expression');
+  const BRICK_SRC = 'images/brick1.svg';
 
   function iso(x,y,z,tileW,tileH,unitH){
     return {
@@ -55,7 +56,8 @@
 
     bricks.forEach(({pos})=>{
       const img = document.createElementNS(svg.namespaceURI,'image');
-      img.setAttributeNS('http://www.w3.org/1999/xlink','href','images/brick1.svg');
+      img.setAttributeNS('http://www.w3.org/1999/xlink','href', BRICK_SRC);
+      img.setAttribute('href', BRICK_SRC);
       img.setAttribute('width', imgW);
       img.setAttribute('height', imgH);
       img.setAttribute('x', pos.x - offsetX - minX);


### PR DESCRIPTION
## Summary
- Use `brick1.svg` consistently when rendering Kvikkbilder bricks
- Set both `href` and `xlink:href` attributes to reference the brick image

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c5db834ba48324a383431c67438efb