### PR TITLE
Add play button for timed quick images

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -29,6 +29,7 @@
     #expression{text-align:center;font-size:24px;font-weight:600;}
     label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     input[type="number"]{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
+    #playBtn{align-self:center;padding:20px 30px;font-size:20px;cursor:pointer;}
   </style>
   <link rel="stylesheet" href="split.css" />
 </head>
@@ -36,6 +37,7 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
+        <button id="playBtn" aria-label="Vis kvikkbilde">▶</button>
         <div id="brickContainer" class="figure" aria-label="Kvikkbilder"></div>
         <div id="expression"></div>
       </div>
@@ -56,6 +58,9 @@
           </label>
           <label>Dybde
             <input id="cfg-dybde" type="number" min="1" value="2">
+          </label>
+          <label>Vis i sekunder
+            <input id="cfg-duration" type="number" min="1" value="3">
           </label>
         </div>
       </div>

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -4,7 +4,9 @@
   const cfgBredde = document.getElementById('cfg-bredde');
   const cfgHoyde = document.getElementById('cfg-hoyde');
   const cfgDybde = document.getElementById('cfg-dybde');
+  const cfgDuration = document.getElementById('cfg-duration');
   const brickContainer = document.getElementById('brickContainer');
+  const playBtn = document.getElementById('playBtn');
   const expression = document.getElementById('expression');
   const BRICK_SRC = 'images/brick1.svg';
 
@@ -92,5 +94,20 @@
     el.addEventListener('input', render);
   });
 
+  playBtn.addEventListener('click', () => {
+    const duration = parseInt(cfgDuration.value, 10) || 0;
+    render();
+    playBtn.style.display = 'none';
+    brickContainer.style.display = 'grid';
+    expression.style.display = 'block';
+    setTimeout(() => {
+      brickContainer.style.display = 'none';
+      expression.style.display = 'none';
+      playBtn.style.display = 'inline-block';
+    }, duration * 1000);
+  });
+
+  brickContainer.style.display = 'none';
+  expression.style.display = 'none';
   render();
 })();


### PR DESCRIPTION
## Summary
- Add configurable play button that reveals quick images for a set number of seconds
- Hide quick image and expression until the button is pressed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6db0e4ee08324b4d298af0ab4f988