### PR TITLE
Add optional second data series via button

### DIFF
--- a/diagram.js
+++ b/diagram.js
@@ -38,6 +38,7 @@ const gLegend = add('g');
 
 let values = [];
 let values2 = null;
+let series2Enabled = false;
 let seriesNames = [];
 let locked = [];
 let N = 0;
@@ -48,6 +49,14 @@ const btnSvg = document.getElementById('btnSvg');
 const btnPng = document.getElementById('btnPng');
 btnSvg?.addEventListener('click', ()=> downloadSVG(svg, 'diagram.svg'));
 btnPng?.addEventListener('click', ()=> downloadPNG(svg, 'diagram.png', 2));
+const addSeriesBtn = document.getElementById('addSeries');
+const series2Fields = document.getElementById('series2Fields');
+addSeriesBtn?.addEventListener('click', () => {
+  series2Enabled = true;
+  addSeriesBtn.style.display = 'none';
+  if(series2Fields) series2Fields.style.display = '';
+  applyCfg();
+});
 const yMin = 0;
 
 // skalaer
@@ -63,8 +72,8 @@ initFromCfg();
 
 function initFromCfg(){
   values = CFG.start.slice();
-  values2 = CFG.start2 ? CFG.start2.slice() : null;
-  seriesNames = [CFG.series1 || '', CFG.series2 || ''];
+  values2 = series2Enabled && CFG.start2 ? CFG.start2.slice() : null;
+  seriesNames = [CFG.series1 || '', series2Enabled ? CFG.series2 || '' : ''];
   N = CFG.labels.length;
   xBand = innerW / N;
   barW  = xBand * 0.6;
@@ -73,6 +82,13 @@ function initFromCfg(){
   locked = alignLength(CFG.locked || [], N, false);
   lastFocusIndex = null;
   document.getElementById('chartTitle').textContent = CFG.title || '';
+
+  if(addSeriesBtn){
+    addSeriesBtn.style.display = series2Enabled ? 'none' : '';
+  }
+  if(series2Fields){
+    series2Fields.style.display = series2Enabled ? '' : 'none';
+  }
 
   // disable stacking/grouping options when only one dataserie
   const typeSel = document.getElementById('cfgType');
@@ -430,19 +446,25 @@ document.querySelector('.settings').addEventListener('input', applyCfg);
 function applyCfg(){
   const lbls = parseList(document.getElementById('cfgLabels').value);
   const starts = parseNumList(document.getElementById('cfgStart').value);
-  const starts2 = parseNumList(document.getElementById('cfgStart2').value);
   const answers = parseNumList(document.getElementById('cfgAnswer').value);
-  const answers2 = parseNumList(document.getElementById('cfgAnswer2').value);
   const yMaxVal = parseFloat(document.getElementById('cfgYMax').value);
   CFG.title = document.getElementById('cfgTitle').value;
   CFG.type = document.getElementById('cfgType').value;
   CFG.series1 = document.getElementById('cfgSeries1').value;
-  CFG.series2 = document.getElementById('cfgSeries2').value;
   CFG.labels = lbls;
   CFG.start  = alignLength(starts, lbls.length, 0);
-  CFG.start2 = alignLength(starts2, lbls.length, 0);
   CFG.answer = alignLength(answers, lbls.length, 0);
-  CFG.answer2= alignLength(answers2, lbls.length, 0);
+  if(series2Enabled){
+    CFG.series2 = document.getElementById('cfgSeries2').value;
+    const starts2 = parseNumList(document.getElementById('cfgStart2').value);
+    const answers2 = parseNumList(document.getElementById('cfgAnswer2').value);
+    CFG.start2 = alignLength(starts2, lbls.length, 0);
+    CFG.answer2 = alignLength(answers2, lbls.length, 0);
+  } else {
+    CFG.series2 = undefined;
+    CFG.start2 = null;
+    CFG.answer2 = null;
+  }
   CFG.yMax   = isNaN(yMaxVal) ? undefined : yMaxVal;
   CFG.axisXLabel = document.getElementById('cfgAxisXLabel').value;
   CFG.axisYLabel = document.getElementById('cfgAxisYLabel').value;

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -64,25 +64,36 @@
             <label>Serienavn 1
               <input id="cfgSeries1" type="text" value="">
             </label>
-            <label>Serienavn 2
-              <input id="cfgSeries2" type="text" value="">
-            </label>
           </div>
           <div class="settings-row">
             <label>Startverdier 1
               <input id="cfgStart" type="text" value="6,7,3,5,8,2">
-            </label>
-            <label>Startverdier 2
-              <input id="cfgStart2" type="text" value="">
             </label>
           </div>
           <div class="settings-row">
             <label>Fasitverdier 1
               <input id="cfgAnswer" type="text" value="6,7,3,5,8,2">
             </label>
-            <label>Fasitverdier 2
-              <input id="cfgAnswer2" type="text" value="">
-            </label>
+          </div>
+          <div class="settings-row">
+            <button id="addSeries" class="btn" type="button">Legg til serie</button>
+          </div>
+          <div id="series2Fields" style="display:none">
+            <div class="settings-row">
+              <label>Serienavn 2
+                <input id="cfgSeries2" type="text" value="">
+              </label>
+            </div>
+            <div class="settings-row">
+              <label>Startverdier 2
+                <input id="cfgStart2" type="text" value="">
+              </label>
+            </div>
+            <div class="settings-row">
+              <label>Fasitverdier 2
+                <input id="cfgAnswer2" type="text" value="">
+              </label>
+            </div>
           </div>
           <div class="settings-row">
             <label>Maks y (valgfritt)


### PR DESCRIPTION
## Summary
- Hide second series inputs behind new "Legg til serie" button
- Track optional second series with `series2Enabled` flag and button handler
- Parse and render second series only when enabled

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6df63426c832495ed7d5e1af33995