### PR TITLE
Add operators and third pizza

### DIFF
--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -41,14 +41,16 @@
     legend { font-weight:600; font-size:13px; color:#374151; padding:0 4px; }
     .checkbox-row { display:flex; align-items:center; gap:6px; }
 
-    /* To kolonner med pizzaer; JS justerer header-høyder */
+    /* Kontainer for pizzaer og tegn mellom dem */
     .grid2 {
-      display:grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      display:flex;
       gap:24px;
       align-items:start;
+      flex-wrap:wrap;
+      justify-content:center;
     }
     .pizzaPanel { display:grid; place-items:center; gap:10px; }
+    .opDisplay { font-size:60px; align-self:center; }
     .addFigureBtn {
       width:clamp(60px,15vw,120px);
       aspect-ratio:1;
@@ -87,7 +89,7 @@
     .stepper span { min-width:32px; text-align:center; font-variant-numeric:tabular-nums; font-size:16px; }
     .a11y:focus { outline:none; stroke:#1e88e5; stroke-width:3; }
     @media (max-width: 420px) {
-      .grid2 { grid-template-columns: 1fr; gap: 16px; }
+      .grid2 { flex-direction:column; gap: 16px; }
       svg.pizza { width: clamp(240px, 92vw, 420px); }
     }
   </style>
@@ -118,7 +120,7 @@
             </div>
           </div>
 
-          <button id="addPizza" class="addFigureBtn" type="button" aria-label="Legg til pizza">+</button>
+          <div id="opDisplay1" class="opDisplay" style="display:none"></div>
 
           <!-- Pizza 2 -->
           <div id="panel2" class="pizzaPanel" style="display:none">
@@ -137,6 +139,28 @@
               <button id="nPlus2"  type="button" aria-label="Flere sektorer">+</button>
             </div>
           </div>
+
+          <div id="opDisplay2" class="opDisplay" style="display:none"></div>
+
+          <!-- Pizza 3 -->
+          <div id="panel3" class="pizzaPanel" style="display:none">
+            <div id="frac3" class="frac" aria-live="polite">
+              <span class="num">4</span><span class="den">10</span>
+            </div>
+
+            <svg id="pizza3" class="pizza" viewBox="-210 -210 420 420" aria-label="Brøkpizza 3">
+              <title>Brøkpizza 3: 4 /10</title>
+              <desc>Viser 10 sektorer totalt, 4 av dem er fylt</desc>
+            </svg>
+
+            <div class="stepper" aria-label="Antall sektorer pizza 3">
+              <button id="nMinus3" type="button" aria-label="Færre sektorer">−</button>
+              <span id="nVal3">10</span>
+              <button id="nPlus3"  type="button" aria-label="Flere sektorer">+</button>
+            </div>
+          </div>
+
+          <button id="addPizza" class="addFigureBtn" type="button" aria-label="Legg til pizza">+</button>
         </div>
       </div>
 
@@ -173,6 +197,13 @@
             <input id="p1MinN" type="number" value="1" min="1">
             <label for="p1MaxN">Maks n</label>
             <input id="p1MaxN" type="number" value="24" min="1">
+            <label for="op1">Tegn</label>
+            <select id="op1">
+              <option value="">none</option>
+              <option value="+">+</option>
+              <option value="-">-</option>
+              <option value="=">=</option>
+            </select>
           </fieldset>
 
           <fieldset id="fieldset2" style="display:none">
@@ -195,6 +226,35 @@
             <input id="p2MinN" type="number" value="1" min="1">
             <label for="p2MaxN">Maks n</label>
             <input id="p2MaxN" type="number" value="24" min="1">
+            <label for="op2">Tegn</label>
+            <select id="op2">
+              <option value="">none</option>
+              <option value="+">+</option>
+              <option value="-">-</option>
+              <option value="=">=</option>
+            </select>
+          </fieldset>
+
+          <fieldset id="fieldset3" style="display:none">
+            <legend>Pizza 3</legend>
+            <label for="p3T">Teller (t)</label>
+            <input id="p3T" type="number" value="4" min="0">
+            <label for="p3N">Nevner (n)</label>
+            <input id="p3N" type="number" value="10" min="1">
+            <div class="checkbox-row"><input id="p3LockN" type="checkbox"><label for="p3LockN">Lås nevner</label></div>
+            <div class="checkbox-row"><input id="p3HideNVal" type="checkbox"><label for="p3HideNVal">Skjul n-verdi</label></div>
+            <div class="checkbox-row"><input id="p3LockT" type="checkbox"><label for="p3LockT">Lås teller</label></div>
+            <label for="p3Text">Tekst</label>
+            <select id="p3Text">
+              <option value="none">none</option>
+              <option value="frac">frac</option>
+              <option value="percent">percent</option>
+              <option value="decimal">decimal</option>
+            </select>
+            <label for="p3MinN">Min n</label>
+            <input id="p3MinN" type="number" value="1" min="1">
+            <label for="p3MaxN">Maks n</label>
+            <input id="p3MaxN" type="number" value="24" min="1">
           </fieldset>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- allow up to three fraction pizzas and read author configuration for each
- let author choose +, -, or = signs between pizzas and render them
- include chosen signs in exported SVGs

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e10f6a8c8324b6273c24d341f66b