### PR TITLE
Add example save/delete controls

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -66,6 +66,8 @@
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
             <button id="btnSvgInteractive" class="btn" type="button">Last ned interaktiv SVG</button>
             <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
         <div class="card">
@@ -106,6 +108,7 @@
   </div>
   </div>
   <script src="arealmodell0.js"></script>
+  <script src="examples.js"></script>
   <script src="split.js"></script>
 
 </body>

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -73,6 +73,8 @@
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
             <button id="btnSvg" class="btn" type="button">Last ned interaktiv SVG</button>
             <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
         <div class="card">
@@ -107,6 +109,7 @@
     </div>
   </div>
   <script src="arealmodellen1.js"></script>
+  <script src="examples.js"></script>
   <script src="split.js"></script>
 
 </body>

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -119,6 +119,11 @@
           <div class="toolbar" style="display:none">
             <button id="btnSvg2" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng2" class="btn" type="button">Last ned PNG</button>
+            </div>
+            <div class="toolbar">
+              <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+              <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            </div>
           </div>
         </div>
         <div class="card">
@@ -192,6 +197,7 @@
     </div>
   </div>
   <script src="brøkfigurer.js"></script>
+  <script src="examples.js"></script>
   <script src="split.js"></script>
 
 </body>

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -171,6 +171,8 @@
             <button id="btnStaticAll" class="btn" type="button">Last ned SVG</button>
             <button id="btnInteractiveAll" class="btn" type="button">Last ned interaktiv SVG</button>
             <button id="btnPngAll" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
@@ -264,6 +266,7 @@
     </div>
 
     <script src="brøkpizza.js"></script>
+  <script src="examples.js"></script>
   <script src="split.js"></script>
 
   </body>

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -35,6 +35,8 @@
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
@@ -119,6 +121,7 @@
   </div>
 
   <script src="../diagram.js"></script>
+  <script src="../examples.js"></script>
   <script src="../split.js"></script>
 
 </body>

--- a/examples.js
+++ b/examples.js
@@ -1,0 +1,35 @@
+(function(){
+  const saveBtn = document.getElementById('btnSaveExample');
+  const deleteBtn = document.getElementById('btnDeleteExample');
+  if(!saveBtn && !deleteBtn) return;
+  const key = 'examples_' + location.pathname;
+  function getExamples(){
+    try{ return JSON.parse(localStorage.getItem(key)) || []; }
+    catch{ return []; }
+  }
+  function store(examples){
+    localStorage.setItem(key, JSON.stringify(examples));
+  }
+  function collectConfig(){
+    const cfg = {};
+    if(window.STATE) cfg.STATE = window.STATE;
+    if(window.CFG)   cfg.CFG   = window.CFG;
+    if(window.CONFIG) cfg.CONFIG = window.CONFIG;
+    const svg = document.querySelector('svg');
+    return {config: cfg, svg: svg ? svg.outerHTML : ''};
+  }
+  saveBtn?.addEventListener('click', ()=>{
+    const examples = getExamples();
+    examples.push(collectConfig());
+    store(examples);
+    alert('Eksempel lagret');
+  });
+  deleteBtn?.addEventListener('click', ()=>{
+    const examples = getExamples();
+    if(examples.length>0){
+      examples.pop();
+      store(examples);
+      alert('Siste eksempel slettet');
+    }
+  });
+})();

--- a/figurtall.html
+++ b/figurtall.html
@@ -112,6 +112,8 @@
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
             <button id="resetBtn" class="btn" type="button">Nullstill</button>
           </div>
         </div>
@@ -156,6 +158,7 @@
     </div>
   </div>
   <script src="figurtall.js"></script>
+  <script src="examples.js"></script>
   <script src="split.js"></script>
 
 </body>

--- a/graftegner.html
+++ b/graftegner.html
@@ -64,6 +64,8 @@
           <div class="toolbar">
             <button id="btnSvg" class="btn">Last ned SVG</button>
             <button id="btnPng" class="btn">Last ned PNG</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
@@ -97,6 +99,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
   <script defer src="graftegner.js"></script>
+  <script src="examples.js"></script>
   <script src="split.js"></script>
 
 </body>

--- a/kuler.html
+++ b/kuler.html
@@ -51,6 +51,8 @@
           <div class="toolbar">
             <button id="downloadSVG" class="btn" type="button">Last ned SVG</button>
             <button id="downloadPNG" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
         <div class="card">
@@ -61,6 +63,7 @@
     </div>
   </div>
   <script src="kuler.js"></script>
+  <script src="examples.js"></script>
   <script src="split.js"></script>
 
 </body>

--- a/nkant.html
+++ b/nkant.html
@@ -56,6 +56,8 @@
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
@@ -291,6 +293,7 @@ Rettvinklet trekant</textarea>
   </div>
 
   <script src="nkant.js"></script>
+  <script src="examples.js"></script>
   <script src="split.js"></script>
 
 </body>

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -74,6 +74,8 @@
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
@@ -88,6 +90,7 @@
   </div>
 
   <script src="perlesnor.js"></script>
+  <script src="examples.js"></script>
   <script src="split.js"></script>
 
 </body>

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -109,6 +109,8 @@
           <div class="tb-toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
@@ -140,6 +142,7 @@
   </div>
 
   <script src="tenkeblokker.js"></script>
+  <script src="examples.js"></script>
   <script src="split.js"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- add generic `examples.js` to store visualization state and SVG in localStorage
- extend visualization pages with `Lagre eksempel` and `Slett eksempel` buttons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e43a97bc83249e6ff74d65cfda55