### PR TITLE
feat: add draggable splitter for side panels

### DIFF
--- a/split.css
+++ b/split.css
@@ -1,15 +1,15 @@
-.grid {
+.grid.split-enabled {
   gap: 0 !important;
   grid-template-columns: 1fr var(--gap) var(--side-width, 420px) !important;
 }
-.grid > .splitter {
+.grid.split-enabled > .splitter {
   width: var(--gap);
   cursor: col-resize;
   position: relative;
   user-select: none;
   touch-action: none;
 }
-.grid > .splitter::before {
+.grid.split-enabled > .splitter::before {
   content: "";
   position: absolute;
   top: 0;
@@ -20,11 +20,11 @@
   border-radius: 3px;
 }
 @media (max-width:980px){
-  .grid {
+  .grid.split-enabled {
     grid-template-columns: 1fr !important;
     gap: var(--gap) !important;
   }
-  .grid > .splitter {
+  .grid.split-enabled > .splitter {
     display: none;
   }
 }

--- a/split.js
+++ b/split.js
@@ -2,13 +2,17 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.grid').forEach(grid => {
     const side = grid.querySelector('.side');
     if (!side) return;
+
+    // mål startbredden før splitteren legges til slik at vi bevarer
+    // sidens opprinnelige bredde på ulike sider
+    const initialWidth = side.getBoundingClientRect().width;
+
     const splitter = document.createElement('div');
     splitter.className = 'splitter';
     grid.insertBefore(splitter, side);
+    grid.classList.add('split-enabled');
 
-    // sett startbredden som CSS-variabel slik at ulike sider beholder
-    // sin opprinnelige bredde
-    grid.style.setProperty('--side-width', `${side.getBoundingClientRect().width}px`);
+    grid.style.setProperty('--side-width', `${initialWidth}px`);
 
     let startX = 0;
     let startWidth = 0;


### PR DESCRIPTION
## Summary
- enable optional draggable splitter by gating styles with `.split-enabled`
- preserve each page's initial sidebar width before activating splitter

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e7d678a88324acd886bbed51619a