### PR TITLE
Add plus buttons for think block expansion and cap grid size

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -49,31 +49,22 @@
     .tb-handle-shadow{fill:#000;opacity:.12}
     .tb-handle{fill:#f1f1f6;stroke:#555;stroke-width:2;cursor:pointer}
 
-    /* Stepper */
-    .tb-stepper{
-      display:flex;
-      align-items:center;
+      /* Add buttons */
+      .tb-wrap{position:relative;display:inline-block;}
+    .tb-add-btn{
+      position:absolute;
+      width:40px;height:40px;
       border:1px solid #cfcfcf;
       border-radius:16px;
       background:#fff;
-      box-shadow:0 6px 24px rgba(0,0,0,.08);
-      overflow:hidden;
-      margin:0 auto;
-    }
-    .tb-stepper button{
-      width:40px;
-      height:40px;
-      border:0;
-      background:#fff;
       font-size:24px;
       cursor:pointer;
+      box-shadow:0 6px 24px rgba(0,0,0,.08);
+      display:flex;align-items:center;justify-content:center;
     }
-    .tb-stepper button:active{transform:translateY(1px)}
-    .tb-divider{
-      width:1px;
-      background:#d6d6e3;
-      align-self:stretch;
-    }
+    .tb-add-btn:active{transform:translateY(1px)}
+    .tb-right{top:50%;left:100%;transform:translate(10px,-50%);}
+    .tb-bottom{top:100%;left:50%;transform:translate(-50%,10px);}
 
     .tb-toolbar{display:flex;gap:10px;justify-content:flex-end}
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
@@ -86,21 +77,14 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker">
-          <rect id="tbOverlay" tabindex="0" role="slider" aria-label="Fylte blokker" aria-valuemin="0" fill="transparent" style="pointer-events:none"></rect>
-        </svg>
-
-        <div id="tbStepN" class="tb-stepper" aria-label="Blokker">
-          <button id="tbMinus" type="button" aria-label="Færre blokker">−</button>
-          <div class="tb-divider"></div>
-          <button id="tbPlus"  type="button" aria-label="Flere blokker">+</button>
+        <div class="tb-wrap">
+          <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker">
+            <rect id="tbOverlay" tabindex="0" role="slider" aria-label="Fylte blokker" aria-valuemin="0" fill="transparent" style="pointer-events:none"></rect>
+          </svg>
+          <button id="tbAddCol" class="tb-add-btn tb-right" type="button" aria-label="Legg til kolonne">+</button>
+          <button id="tbAddRow" class="tb-add-btn tb-bottom" type="button" aria-label="Legg til rad">+</button>
+          <div id="tbLive" aria-live="polite" style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;"></div>
         </div>
-        <div id="tbStepM" class="tb-stepper" aria-label="Rader">
-          <button id="tbRowMinus" type="button" aria-label="Færre rader">−</button>
-          <div class="tb-divider"></div>
-          <button id="tbRowPlus"  type="button" aria-label="Flere rader">+</button>
-        </div>
-        <div id="tbLive" aria-live="polite" style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;"></div>
       </div>
 
       <div class="side">

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -3,15 +3,15 @@
 /* ============ ENKEL KONFIG (FORFATTER) ============ */
 const SIMPLE = {
   total: 50,       // tallet i parentesen
-  startN: 5,       // antall blokker (nevner)
-  startK: 4,       // antall fylte blokker (teller)
+  startN: 1,       // antall kolonner
+  startK: 0,       // antall fylte blokker
   startM: 1,       // antall rader
-  minN: 2,
-  maxN: 12,
+  minN: 1,
+  maxN: 3,
   minM: 1,
-  maxM: 12,
+  maxM: 2,
   showWhole: true,    // vis parentes + total
-  showStepper: true,  // vis pluss/minus-knapper
+  showStepper: true,  // vis pluss-knapper
   showHandle: true,   // vis håndtak
   valMode: 'rounded'  // 'rounded' | 'exact' | 'fraction' | 'percent'
 };
@@ -76,16 +76,14 @@ addTo(gFrame,'rect',{x:L,y:TOP,width:R-L,height:BOT-TOP,class:'tb-frame'});
 // Håndtak
 const handleShadow = addTo(gHandle,'circle',{cx:R, cy:(TOP+BOT)/2+2, r:20, class:'tb-handle-shadow'});
 const handle       = addTo(gHandle,'circle',{cx:R, cy:(TOP+BOT)/2,   r:18, class:'tb-handle'});
-const stepperN     = document.getElementById('tbStepN');
-const stepperM     = document.getElementById('tbStepM');
+const addColBtn    = document.getElementById('tbAddCol');
+const addRowBtn    = document.getElementById('tbAddRow');
 const btnSvg       = document.getElementById('btnSvg');
 const btnPng       = document.getElementById('btnPng');
 
 // ---------- Interaksjon ----------
-document.getElementById('tbMinus').addEventListener('click', ()=> setN(n-1));
-document.getElementById('tbPlus') .addEventListener('click', ()=> setN(n+1));
-document.getElementById('tbRowMinus').addEventListener('click', ()=> setM(m-1));
-document.getElementById('tbRowPlus') .addEventListener('click', ()=> setM(m+1));
+addColBtn?.addEventListener('click', ()=> setN(n+1));
+addRowBtn?.addEventListener('click', ()=> setM(m+1));
 btnSvg?.addEventListener('click', ()=> downloadSVG(svg, 'tenkeblokker.svg'));
 btnPng?.addEventListener('click', ()=> downloadPNG(svg, 'tenkeblokker.png', 2));
 
@@ -282,8 +280,8 @@ function applyConfig(){
   } else {
     gBrace.style.display = 'none';
   }
-  stepperN.style.display = CFG.showStepper ? '' : 'none';
-  stepperM.style.display = CFG.showStepper ? '' : 'none';
+  if(addColBtn) addColBtn.style.display = CFG.showStepper ? '' : 'none';
+  if(addRowBtn) addRowBtn.style.display = CFG.showStepper ? '' : 'none';
   gHandle.style.display  = CFG.showHandle ? '' : 'none';
   redraw();
 }
@@ -349,6 +347,7 @@ function redraw(){
   handleShadow.setAttribute('cx', hx);
   handleShadow.setAttribute('cy', hy+2);
   updateAria();
+  updateAddButtons();
 }
 
 function updateAria(){
@@ -358,6 +357,15 @@ function updateAria(){
   const text = `${k} av ${n*m} blokker fylt`;
   overlay.setAttribute('aria-valuetext', text);
   if(live) live.textContent = text;
+}
+
+function updateAddButtons(){
+  if(addColBtn){
+    addColBtn.style.visibility = n < CFG.maxN ? 'visible' : 'hidden';
+  }
+  if(addRowBtn){
+    addRowBtn.style.visibility = m < CFG.maxM ? 'visible' : 'hidden';
+  }
 }
 
 // ---------- State ----------


### PR DESCRIPTION
## Summary
- Replace steppers with positioned + buttons for adding columns and rows
- Limit think block grid to max 3 columns by 2 rows
- Hide add buttons when reaching maximum

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e8bd801c8324be6bc25cc6959736