### PR TITLE
Ensure Kvikkbilder shows play button by default

### DIFF
--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -10,6 +10,7 @@
   const cfgDybde = document.getElementById('cfg-dybde');
   const cfgDurationKlosser = document.getElementById('cfg-duration-klosser');
   const cfgShowBtn = document.getElementById('cfg-showBtn');
+  cfgShowBtn.checked = true;
 
   const cfgAntall = document.getElementById('cfg-antall');
   const cfgDurationMonster = document.getElementById('cfg-duration-monster');


### PR DESCRIPTION
## Summary
- Default the "Vis play-knapp" option to true so Kvikkbilder initially displays the play button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c722e61934832499cd25461b5e03b1