### PR TITLE
Add optional play button for Kvikkbilder

### DIFF
--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -50,6 +50,9 @@
           <label>Vis i sekunder
             <input id="cfg-duration" type="number" min="1" value="3">
           </label>
+          <label>Vis play-knapp
+            <input id="cfg-showBtn" type="checkbox">
+          </label>
         </div>
       </div>
     </div>

--- a/kvikkbilder-monster.js
+++ b/kvikkbilder-monster.js
@@ -1,6 +1,7 @@
 (function(){
   const cfgAntall = document.getElementById('cfg-antall');
   const cfgDuration = document.getElementById('cfg-duration');
+  const cfgShowBtn = document.getElementById('cfg-showBtn');
   const patternContainer = document.getElementById('patternContainer');
   const playBtn = document.getElementById('playBtn');
   const expression = document.getElementById('expression');
@@ -72,7 +73,23 @@
     expression.textContent=faktorer.length?`${faktorer.join(' × ')} = ${n}`:`${n}`;
   }
 
+  function updateVisibility(){
+    if(cfgShowBtn.checked){
+      playBtn.style.display='inline-block';
+      patternContainer.style.display='none';
+      expression.style.display='none';
+    }else{
+      playBtn.style.display='none';
+      patternContainer.style.display='block';
+      expression.style.display='block';
+    }
+  }
+
   cfgAntall.addEventListener('input',render);
+  cfgShowBtn.addEventListener('change', () => {
+    updateVisibility();
+    if(!cfgShowBtn.checked) render();
+  });
 
   playBtn.addEventListener('click',()=>{
     const duration=parseInt(cfgDuration.value,10)||0;
@@ -81,13 +98,9 @@
     patternContainer.style.display='block';
     expression.style.display='block';
     setTimeout(()=>{
-      patternContainer.style.display='none';
-      expression.style.display='none';
-      playBtn.style.display='inline-block';
+      updateVisibility();
     }, duration*1000);
   });
-
-  patternContainer.style.display='none';
-  expression.style.display='none';
+  updateVisibility();
   render();
 })();

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -94,7 +94,7 @@
               <input id="cfg-duration-klosser" type="number" min="1" value="3">
             </label>
             <label>Vis play-knapp
-              <input id="cfg-showBtn" type="checkbox" checked>
+              <input id="cfg-showBtn" type="checkbox">
             </label>
           </div>
           <div id="monsterConfig">
@@ -103,6 +103,9 @@
             </label>
             <label>Vis i sekunder
               <input id="cfg-duration-monster" type="number" min="1" value="3">
+            </label>
+            <label>Vis play-knapp
+              <input id="cfg-showBtn-monster" type="checkbox">
             </label>
           </div>
         </div>

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -10,10 +10,10 @@
   const cfgDybde = document.getElementById('cfg-dybde');
   const cfgDurationKlosser = document.getElementById('cfg-duration-klosser');
   const cfgShowBtn = document.getElementById('cfg-showBtn');
-  cfgShowBtn.checked = true;
 
   const cfgAntall = document.getElementById('cfg-antall');
   const cfgDurationMonster = document.getElementById('cfg-duration-monster');
+  const cfgShowBtnMonster = document.getElementById('cfg-showBtn-monster');
 
   const brickContainer = document.getElementById('brickContainer');
   const patternContainer = document.getElementById('patternContainer');
@@ -186,6 +186,19 @@
     patternContainer.style.display='none';
   }
 
+  function updateVisibilityMonster(){
+    brickContainer.style.display='none';
+    if(cfgShowBtnMonster.checked){
+      playBtn.style.display='inline-flex';
+      patternContainer.style.display='none';
+      expression.style.display='none';
+    } else {
+      playBtn.style.display='none';
+      patternContainer.style.display='block';
+      expression.style.display='block';
+    }
+  }
+
   function updateType(){
     if(cfgType.value==='klosser'){
       klosserConfig.style.display='block';
@@ -195,11 +208,8 @@
     }else{
       klosserConfig.style.display='none';
       monsterConfig.style.display='block';
-      brickContainer.style.display='none';
-      playBtn.style.display='inline-flex';
-      expression.style.display='none';
-      patternContainer.style.display='none';
       renderMonster();
+      updateVisibilityMonster();
     }
   }
 
@@ -209,6 +219,10 @@
   cfgShowBtn.addEventListener('change', () => {
     updateVisibilityKlosser();
     renderKlosser();
+  });
+  cfgShowBtnMonster.addEventListener('change', () => {
+    updateVisibilityMonster();
+    renderMonster();
   });
   cfgAntall.addEventListener('input', renderMonster);
   cfgType.addEventListener('change', updateType);
@@ -230,9 +244,7 @@
       patternContainer.style.display='block';
       expression.style.display='block';
       setTimeout(()=>{
-        patternContainer.style.display='none';
-        expression.style.display='none';
-        playBtn.style.display='inline-flex';
+        updateVisibilityMonster();
       }, duration*1000);
     }
   });


### PR DESCRIPTION
## Summary
- Add play button visibility toggles for both klosser and monster Kvikkbilder, defaulting to hidden.
- Implement visibility logic in JavaScript to show or hide play button and figures based on configuration.
- Mirror the configuration on the standalone monster page.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7272473c083248994b7fce73f3d36