### PR TITLE
Add simple think block stepper component

### DIFF
--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="no">
+<head>
+<meta charset="utf-8" />
+<title>Tenkeblokker</title>
+<style>
+  #blocks{display:flex;gap:20px;flex-wrap:wrap}
+  .tb-block-wrapper{display:flex;flex-direction:column;align-items:center}
+  .tb-block{display:flex;border:2px solid #333;height:100px;width:300px}
+  .tb-segment{flex:1;display:flex;align-items:center;justify-content:center;border-right:1px dashed #777;background:#e8eedf;font-size:24px}
+  .tb-segment:last-child{border-right:none}
+  .tb-stepper{display:flex;gap:10px;margin-top:10px}
+  .tb-stepper button{width:40px;height:40px;font-size:24px}
+  #addBlock{margin-top:20px;width:40px;height:40px;font-size:24px}
+</style>
+</head>
+<body>
+<div id="blocks"></div>
+<button id="addBlock" type="button">+</button>
+<script src="tenkeblokker-stepper.js"></script>
+</body>
+</html>

--- a/tenkeblokker-stepper.js
+++ b/tenkeblokker-stepper.js
@@ -1,0 +1,54 @@
+class ThinkBlock {
+  constructor(total = 60) {
+    this.total = total;
+    this.parts = 1;
+    this.root = document.createElement('div');
+    this.root.className = 'tb-block-wrapper';
+
+    this.block = document.createElement('div');
+    this.block.className = 'tb-block';
+    this.root.appendChild(this.block);
+
+    this.stepper = document.createElement('div');
+    this.stepper.className = 'tb-stepper';
+    this.minus = document.createElement('button');
+    this.minus.type = 'button';
+    this.minus.textContent = '-';
+    this.plus = document.createElement('button');
+    this.plus.type = 'button';
+    this.plus.textContent = '+';
+    this.stepper.append(this.minus, this.plus);
+    this.root.appendChild(this.stepper);
+
+    this.minus.addEventListener('click', () => this.setParts(this.parts - 1));
+    this.plus.addEventListener('click', () => this.setParts(this.parts + 1));
+
+    this.render();
+  }
+
+  setParts(p) {
+    this.parts = Math.max(1, p);
+    this.render();
+  }
+
+  render() {
+    this.block.innerHTML = '';
+    const value = this.total / this.parts;
+    for (let i = 0; i < this.parts; i++) {
+      const seg = document.createElement('div');
+      seg.className = 'tb-segment';
+      seg.textContent = value;
+      this.block.appendChild(seg);
+    }
+  }
+}
+
+const container = document.getElementById('blocks');
+
+function addBlock() {
+  const tb = new ThinkBlock();
+  container.appendChild(tb.root);
+}
+
+document.getElementById('addBlock').addEventListener('click', addBlock);
+addBlock();


### PR DESCRIPTION
## Summary
- Create minimal think block component that can be duplicated with a plus button
- Support per-block plus/minus stepper to change how many parts a block is divided into

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7284cd45483248d3bb1ab5403d17b