### PR TITLE
Show play button toggle for Kvikkbilder Mønster

### DIFF
--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -44,16 +44,16 @@
       <div class="side">
         <div class="card">
           <h2>Forfatters innstillinger</h2>
-          <label>Antall
-            <input id="cfg-antall" type="number" min="1" value="9">
-          </label>
-          <label>Vis i sekunder
-            <input id="cfg-duration" type="number" min="1" value="3">
-          </label>
-          <label>Vis play-knapp
-            <input id="cfg-showBtn" type="checkbox">
-          </label>
-        </div>
+            <label>Vis play-knapp
+              <input id="cfg-showBtn" type="checkbox">
+            </label>
+            <label>Antall
+              <input id="cfg-antall" type="number" min="1" value="9">
+            </label>
+            <label>Vis i sekunder
+              <input id="cfg-duration" type="number" min="1" value="3">
+            </label>
+          </div>
       </div>
     </div>
   </div>

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -98,14 +98,14 @@
             </label>
           </div>
           <div id="monsterConfig">
+            <label>Vis play-knapp
+              <input id="cfg-showBtn-monster" type="checkbox">
+            </label>
             <label>Antall
               <input id="cfg-antall" type="number" min="1" value="9">
             </label>
             <label>Vis i sekunder
               <input id="cfg-duration-monster" type="number" min="1" value="3">
-            </label>
-            <label>Vis play-knapp
-              <input id="cfg-showBtn-monster" type="checkbox">
             </label>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Move "Vis play-knapp" option to the top of Mønster configuration in Kvikkbilder
- Mirror this setting placement in standalone kvikkbilder-monster page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c728f3eef08324ab4a896ce120a826