### PR TITLE
Add custom pattern for number four in kvikkbilder

### DIFF
--- a/kvikkbilder-monster.js
+++ b/kvikkbilder-monster.js
@@ -13,8 +13,18 @@
     return {cols, rows};
   }
 
+  const customPatterns={
+    4:[
+      {x:-0.5,y:-0.5},
+      {x:0.5,y:-0.5},
+      {x:-0.5,y:0.5},
+      {x:0.5,y:0.5}
+    ]
+  };
+
   function byggMonster(n){
     if(n<=0) return [];
+    if(customPatterns[n]) return customPatterns[n];
     const {cols, rows}=finnFaktorer(n);
     const points=[];
     const xOff=-(cols-1)/2;

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -110,8 +110,18 @@
     return {cols, rows};
   }
 
+  const customPatterns={
+    4:[
+      {x:-0.5,y:-0.5},
+      {x:0.5,y:-0.5},
+      {x:-0.5,y:0.5},
+      {x:0.5,y:0.5}
+    ]
+  };
+
   function byggMonster(n){
     if(n<=0) return [];
+    if(customPatterns[n]) return customPatterns[n];
     const {cols, rows}=finnFaktorer(n);
     const points=[];
     const xOff=-(cols-1)/2;


### PR DESCRIPTION
## Summary
- ensure kvikkbilder pattern type renders the number four as a 2x2 square
- support custom patterns before fallback grid-based layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c72bde74448324830bce01ec252c61