### PR TITLE
Refactor toolbar buttons into reusable component

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -29,15 +29,7 @@
     #box{width:clamp(280px,60vw,460px);aspect-ratio:1;margin:0 auto;position:relative;}
     .pairs-list{position:absolute;top:10px;right:10px;display:flex;gap:1.2em;text-align:right;pointer-events:none;font-size:16px;line-height:1.2;}
     .pairs-list .col{display:flex;flex-direction:column;gap:4px;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
-    .btn{
-      appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;
-      padding:8px 12px;font-size:14px;cursor:pointer;
-      transition:box-shadow .2s,transform .02s;
-    }
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
-    .btn:active{transform:translateY(1px);}
-    .settings{display:flex;flex-direction:column;gap:10px;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}    .settings{display:flex;flex-direction:column;gap:10px;}
     .settings label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     .settings input{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
     .settings .row{display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end;}
@@ -48,27 +40,20 @@
   </style>
   <link rel="stylesheet" href="split.css" />
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
+  <link rel="stylesheet" href="styles/toolbar.css" />
 </head>
 <body>
   <div class="wrap">
     <div class="grid">
       <div class="card">
         <div id="box" class="jxgbox" aria-label="Arealmodell rektangel"></div>
-        <div class="toolbar">
-          <button id="btnReset" class="btn" type="button">Reset</button>
+        <div class="toolbar" id="toolbar"></div>
         </div>
       </div>
       <div class="side">
         <div class="card">
           <h2>Last ned figurer</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSvgInteractive" class="btn" type="button">Last ned interaktiv SVG</button>
-            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
+          <div class="toolbar" id="downloadToolbar"></div>
         </div>
         <div class="card">
           <h2>Forfatters innstillinger</h2>
@@ -107,7 +92,21 @@
     </div>
   </div>
   </div>
-  <script src="arealmodell0.js"></script>
+  <script type="module">
+import { createToolbar } from "./components/toolbar.js";
+createToolbar("toolbar", [
+  { id: "btnReset", text: "Reset" }
+]);
+createToolbar("downloadToolbar", [
+  { id: "btnSvg", text: "Last ned SVG" },
+  { id: "btnPng", text: "Last ned PNG" },
+  { id: "btnSvgInteractive", text: "Last ned interaktiv SVG" },
+  { id: "btnHtml", text: "Last ned interaktiv HTML" },
+  { id: "btnSaveExample", text: "Lagre eksempel" },
+  { id: "btnDeleteExample", text: "Slett eksempel" }
+]);
+</script>
+<script src="arealmodell0.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>
 

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -27,11 +27,7 @@
     .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
     svg { width: 100%; height: auto; background: #fff; display: block; }
     .settings { display: flex; flex-direction: column; gap: 10px; }
-    .toolbar { display:flex; gap:10px; justify-content:flex-end; }
-    .btn { appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px; padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s; }
-    .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform:translateY(1px); }
-    .settings label { font-size: 13px; color: #4b5563; display: flex; flex-direction: column; }
+    .toolbar { display:flex; gap:10px; justify-content:flex-end; }    .settings label { font-size: 13px; color: #4b5563; display: flex; flex-direction: column; }
     .settings input { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; }
 
     .settings .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
@@ -58,6 +54,7 @@
     .labelEdge { fill: #000; font-size: 28px; font-family: "Georgia", "Times New Roman", serif; }
   </style>
   <link rel="stylesheet" href="split.css" />
+  <link rel="stylesheet" href="styles/toolbar.css" />
 </head>
 <body>
   <div class="wrap">
@@ -68,14 +65,7 @@
       <div class="side">
         <div class="card">
           <h2>Last ned figurer</h2>
-          <div class="toolbar">
-            <button id="btnSvgStatic" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSvg" class="btn" type="button">Last ned interaktiv SVG</button>
-            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
+          <div class="toolbar" id="downloadToolbar"></div>
         </div>
         <div class="card">
           <h2>Forfatters innstillinger</h2>
@@ -108,7 +98,18 @@
       </div>
     </div>
   </div>
-  <script src="arealmodellen1.js"></script>
+  <script type="module">
+import { createToolbar } from "./components/toolbar.js";
+createToolbar("downloadToolbar", [
+  { id: "btnSvgStatic", text: "Last ned SVG" },
+  { id: "btnPng", text: "Last ned PNG" },
+  { id: "btnSvg", text: "Last ned interaktiv SVG" },
+  { id: "btnHtml", text: "Last ned interaktiv HTML" },
+  { id: "btnSaveExample", text: "Lagre eksempel" },
+  { id: "btnDeleteExample", text: "Slett eksempel" }
+]);
+</script>
+<script src="arealmodellen1.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>
 

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -68,11 +68,7 @@
       background:#fff;font-size:20px;cursor:pointer;
     }
     .stepper span{min-width:32px;text-align:center;font-variant-numeric:tabular-nums;font-size:16px;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
-    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
-    .btn:active{transform:translateY(1px)}
-    .settings{display:flex;gap:var(--gap);}
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}    .settings{display:flex;gap:var(--gap);}
     .card>fieldset{display:flex;flex-direction:column;gap:8px;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;}
     .settings fieldset{flex:1;display:flex;flex-direction:column;gap:8px;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;}
     legend{font-weight:600;font-size:13px;color:#374151;padding:0 4px;}
@@ -84,6 +80,7 @@
     .box svg *:focus{outline:none;}
   </style>
   <link rel="stylesheet" href="split.css" />
+  <link rel="stylesheet" href="styles/toolbar.css" />
 </head>
 <body>
   <div class="wrap">
@@ -112,18 +109,9 @@
       <div class="side">
         <div class="card">
           <h2>Last ned figurer</h2>
-          <div class="toolbar">
-            <button id="btnSvg1" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng1" class="btn" type="button">Last ned PNG</button>
-          </div>
-          <div class="toolbar" style="display:none">
-            <button id="btnSvg2" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng2" class="btn" type="button">Last ned PNG</button>
-          </div>
-          <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
+          <div class="toolbar" id="downloadToolbar1"></div>
+          <div class="toolbar" id="downloadToolbar2" style="display:none"></div>
+          <div class="toolbar" id="saveToolbar"></div>
         </div>
         <div class="card">
           <h2>Forfatters innstillinger</h2>
@@ -195,7 +183,22 @@
       </div>
     </div>
   </div>
-  <script src="brøkfigurer.js"></script>
+  <script type="module">
+import { createToolbar } from "./components/toolbar.js";
+createToolbar("downloadToolbar1", [
+  { id: "btnSvg1", text: "Last ned SVG" },
+  { id: "btnPng1", text: "Last ned PNG" }
+]);
+createToolbar("downloadToolbar2", [
+  { id: "btnSvg2", text: "Last ned SVG" },
+  { id: "btnPng2", text: "Last ned PNG" }
+]);
+createToolbar("saveToolbar", [
+  { id: "btnSaveExample", text: "Lagre eksempel" },
+  { id: "btnDeleteExample", text: "Slett eksempel" }
+]);
+</script>
+<script src="brøkfigurer.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>
 

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -23,14 +23,7 @@
       display:flex; flex-direction:column; gap:10px;
     }
     .card h2 { margin:0 0 6px 2px; font-size:16px; font-weight:600; color:#374151; }
-    .toolbar { display:flex; gap:10px; justify-content:flex-end; }
-    .btn {
-      appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px;
-      padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s;
-    }
-    .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform:translateY(1px); }
-    label { font-size:13px; color:#4b5563; }
+    .toolbar { display:flex; gap:10px; justify-content:flex-end; }    label { font-size:13px; color:#4b5563; }
     input[type="number"], select {
       border:1px solid #d1d5db; border-radius:10px; padding:8px 10px;
       font-size:14px; background:#fff; width:100%; box-sizing:border-box;
@@ -90,6 +83,7 @@
     .a11y:focus { outline:none; stroke:#1e88e5; stroke-width:3; }
   </style>
   <link rel="stylesheet" href="split.css" />
+  <link rel="stylesheet" href="styles/toolbar.css" />
 </head>
 <body>
   <div class="wrap">
@@ -163,13 +157,7 @@
       <div class="side">
         <div class="card">
           <h2>Last ned figurer</h2>
-          <div class="toolbar">
-            <button id="btnStaticAll" class="btn" type="button">Last ned SVG</button>
-            <button id="btnInteractiveAll" class="btn" type="button">Last ned interaktiv SVG</button>
-            <button id="btnPngAll" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
+          <div class="toolbar" id="downloadToolbar"></div>
         </div>
 
         <div class="card">
@@ -261,7 +249,17 @@
     </div>
     </div>
 
-    <script src="brøkpizza.js"></script>
+    <script type="module">
+import { createToolbar } from "./components/toolbar.js";
+createToolbar("downloadToolbar", [
+  { id: "btnStaticAll", text: "Last ned SVG" },
+  { id: "btnInteractiveAll", text: "Last ned interaktiv SVG" },
+  { id: "btnPngAll", text: "Last ned PNG" },
+  { id: "btnSaveExample", text: "Lagre eksempel" },
+  { id: "btnDeleteExample", text: "Slett eksempel" }
+]);
+</script>
+<script src="brøkpizza.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>
 

--- a/components/toolbar.js
+++ b/components/toolbar.js
@@ -1,0 +1,15 @@
+export function createToolbar(container, buttons) {
+  if (typeof container === 'string') {
+    container = document.getElementById(container);
+  }
+  if (!container) return;
+  buttons.forEach(btn => {
+    const el = document.createElement('button');
+    el.type = 'button';
+    el.id = btn.id;
+    el.textContent = btn.text;
+    el.className = btn.class || 'btn';
+    if (btn.ariaLabel) el.setAttribute('aria-label', btn.ariaLabel);
+    container.appendChild(el);
+  });
+}

--- a/diagram.css
+++ b/diagram.css
@@ -16,15 +16,7 @@ body {
 .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
 .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
 .figure svg { width: 100%; height: auto; display: block; background: #fff; }
-.toolbar { display: flex; gap: 10px; justify-content: flex-end; }
-.btn {
-  appearance: none; border: 1px solid #d1d5db; background: #fff; border-radius: 10px;
-  padding: 8px 12px; font-size: 14px; cursor: pointer;
-  transition: box-shadow .2s, transform .02s;
-}
-.btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
-.btn:active { transform: translateY(1px); }
-.status {
+.toolbar { display: flex; gap: 10px; justify-content: flex-end; }.status {
   position: absolute;
   width: 1px; height: 1px; margin: -1px;
   padding: 0; overflow: hidden; clip: rect(0,0,0,0);

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -6,6 +6,7 @@
   <title>Interaktivt stolpediagram (UU)</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
     <link rel="stylesheet" href="../diagram.css" />
+  <link rel="stylesheet" href="../styles/toolbar.css" />
 
   <style>
     svg { touch-action: none; }
@@ -21,23 +22,14 @@
         <div class="figure">
           <svg id="barsvg" viewBox="0 0 900 560" aria-label="Interaktivt stolpediagram"></svg>
         </div>
-        <div class="toolbar">
-          <button id="btnCheck" class="btn">Sjekk</button>
-          <button id="btnReset" class="btn">Nullstill</button>
-          <button id="btnShow" class="btn">Vis fasit</button>
-        </div>
+        <div class="toolbar" id="actionToolbar"></div>
         <div id="status" class="status" role="status" aria-live="polite"></div>
       </div>
 
       <div class="side">
         <div class="card">
           <h2>Last ned figurer</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
+          <div class="toolbar" id="downloadToolbar"></div>
         </div>
 
         <div class="card">
@@ -120,7 +112,21 @@
   </div>
   </div>
 
-  <script src="../diagram.js"></script>
+  <script type="module">
+import { createToolbar } from "../components/toolbar.js";
+createToolbar("actionToolbar", [
+  { id: "btnCheck", text: "Sjekk" },
+  { id: "btnReset", text: "Nullstill" },
+  { id: "btnShow", text: "Vis fasit" }
+]);
+createToolbar("downloadToolbar", [
+  { id: "btnSvg", text: "Last ned SVG" },
+  { id: "btnPng", text: "Last ned PNG" },
+  { id: "btnSaveExample", text: "Lagre eksempel" },
+  { id: "btnDeleteExample", text: "Slett eksempel" }
+]);
+</script>
+<script src="../diagram.js"></script>
   <script src="../examples.js"></script>
   <script src="../split.js"></script>
 

--- a/figurtall.html
+++ b/figurtall.html
@@ -47,11 +47,7 @@
       flex-direction:column;gap:10px;
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
-    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
-    .btn:active{transform:translateY(1px);}
-    .card>fieldset{display:flex;flex-direction:column;gap:8px;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}    .card>fieldset{display:flex;flex-direction:column;gap:8px;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;}
     legend{font-weight:600;font-size:13px;color:#374151;padding:0 4px;}
     .card input[type="color"]{width:40px;height:40px;padding:0;border:none;}
     .colors{display:flex;flex-wrap:wrap;gap:6px;}
@@ -97,6 +93,7 @@
     .nameInput{width:100%;border:1px solid #d1d5db;border-radius:8px;padding:6px 8px;font-size:14px;box-sizing:border-box;}
   </style>
   <link rel="stylesheet" href="split.css" />
+  <link rel="stylesheet" href="styles/toolbar.css" />
 </head>
 <body>
   <div class="wrap">
@@ -109,13 +106,7 @@
       <div class="side">
         <div class="card">
           <h2>Last ned figurer</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-            <button id="resetBtn" class="btn" type="button">Nullstill</button>
-          </div>
+          <div class="toolbar" id="downloadToolbar"></div>
         </div>
         <div class="card">
           <h2>Forfatters innstillinger</h2>
@@ -157,7 +148,17 @@
       </div>
     </div>
   </div>
-  <script src="figurtall.js"></script>
+  <script type="module">
+import { createToolbar } from "./components/toolbar.js";
+createToolbar("downloadToolbar", [
+  { id: "btnSvg", text: "Last ned SVG" },
+  { id: "btnPng", text: "Last ned PNG" },
+  { id: "btnSaveExample", text: "Lagre eksempel" },
+  { id: "btnDeleteExample", text: "Slett eksempel" },
+  { id: "resetBtn", text: "Nullstill" }
+]);
+</script>
+<script src="figurtall.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>
 

--- a/graftegner.html
+++ b/graftegner.html
@@ -22,9 +22,7 @@
     .card h2{ margin:0 0 6px 2px; font-size:16px; font-weight:600; color:#374151; }
     .figure{ border-radius:10px; background:#fafbfc; overflow:hidden; border:1px solid #eef0f3; }
     #board{ width:100%; height:560px; background:#fff; }
-    .toolbar{ display:flex; gap:12px; flex-wrap:wrap; justify-content:flex-end; }
-    .btn{ appearance:none; cursor:pointer; padding:8px 14px; border-radius:10px; border:1px solid #d1d5db; background:#fff; }
-    .checkbar{ display:flex; gap:10px; align-items:center; }
+    .toolbar{ display:flex; gap:12px; flex-wrap:wrap; justify-content:flex-end; }    .checkbar{ display:flex; gap:10px; align-items:center; }
     .status{ padding:6px 10px; border-radius:10px; font-weight:600; border:1px solid transparent; }
     .status--ok{ color:#065f46; background:#ecfdf5; border-color:#a7f3d0; }
     .status--err{ color:#b91c1c; background:#fef2f2; border-color:#fecaca; }
@@ -44,6 +42,7 @@
     .axis-label input{ width:80px; }
   </style>
   <link rel="stylesheet" href="split.css" />
+  <link rel="stylesheet" href="styles/toolbar.css" />
 </head>
 <body>
   <div class="wrap">
@@ -52,21 +51,14 @@
         <div class="figure">
           <div id="board" aria-label="JSXGraph-tavle"></div>
         </div>
-        <div class="toolbar" id="toolbar">
-          <div id="checkArea" class="checkbar"></div>
-          <button id="btnReset" class="btn">Nullstill zoom/pan</button>
+        <div class="toolbar" id="toolbar"><div id="checkArea" class="checkbar"></div></div>
         </div>
       </div>
 
       <div class="side">
         <div class="card">
           <h2>Last ned figurer</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn">Last ned SVG</button>
-            <button id="btnPng" class="btn">Last ned PNG</button>
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
+          <div class="toolbar" id="downloadToolbar"></div>
         </div>
 
         <div class="card">
@@ -98,6 +90,18 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
+  <script type="module">
+    import { createToolbar } from "./components/toolbar.js";
+    createToolbar("toolbar", [
+      { id: "btnReset", text: "Nullstill zoom/pan" }
+    ]);
+    createToolbar("downloadToolbar", [
+      { id: "btnSvg", text: "Last ned SVG" },
+      { id: "btnPng", text: "Last ned PNG" },
+      { id: "btnSaveExample", text: "Lagre eksempel" },
+      { id: "btnDeleteExample", text: "Slett eksempel" }
+    ]);
+  </script>
   <script defer src="graftegner.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>

--- a/kuler.html
+++ b/kuler.html
@@ -30,12 +30,9 @@
     .bead{cursor:grab;}
     .bead:active{cursor:grabbing;}
     .beadShadow{filter:drop-shadow(0 1px 1px rgba(0,0,0,.25));}
-    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
-    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
-    .btn:active{transform:translateY(1px);}
-  </style>
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}  </style>
   <link rel="stylesheet" href="split.css" />
+  <link rel="stylesheet" href="styles/toolbar.css" />
 </head>
 <body>
   <div class="wrap">
@@ -48,12 +45,7 @@
       <div class="side">
         <div class="card">
           <h2>Last ned figurer</h2>
-          <div class="toolbar">
-            <button id="downloadSVG" class="btn" type="button">Last ned SVG</button>
-            <button id="downloadPNG" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
+          <div class="toolbar" id="downloadToolbar"></div>
         </div>
         <div class="card">
           <h2>Forfatters innstillinger</h2>
@@ -62,7 +54,16 @@
       </div>
     </div>
   </div>
-  <script src="kuler.js"></script>
+  <script type="module">
+import { createToolbar } from "./components/toolbar.js";
+createToolbar("downloadToolbar", [
+  { id: "downloadSVG", text: "Last ned SVG" },
+  { id: "downloadPNG", text: "Last ned PNG" },
+  { id: "btnSaveExample", text: "Lagre eksempel" },
+  { id: "btnDeleteExample", text: "Slett eksempel" }
+]);
+</script>
+<script src="kuler.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>
 

--- a/nkant.html
+++ b/nkant.html
@@ -20,11 +20,7 @@
     .figure svg { width: 100%; height: 360px; display: block; }
     .toolbar { display: flex; gap: 10px; justify-content: flex-end; }
     .specs-row { display:flex; gap:10px; align-items:flex-start; }
-    .specs-row textarea { flex:1; width:auto; }
-    .btn { appearance: none; border: 1px solid #d1d5db; background: #fff; border-radius: 10px; padding: 8px 12px; font-size: 14px;
-           cursor: pointer; transition: box-shadow .2s, transform .02s; }
-    .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); } .btn:active { transform: translateY(1px); }
-    label { font-size: 13px; color: #4b5563; }
+    .specs-row textarea { flex:1; width:auto; }    label { font-size: 13px; color: #4b5563; }
     textarea, select, input[type="text"] { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; width: 100%; }
     .small { font-size: 12px; color: #6b7280; }
     .sep { height: 1px; background: #eef0f3; margin: 8px 0; }
@@ -37,6 +33,7 @@
     input[type="text"]:disabled { background: #f3f4f6; color: #9ca3af; }
   </style>
   <link rel="stylesheet" href="split.css" />
+  <link rel="stylesheet" href="styles/toolbar.css" />
 </head>
 <body>
   <div class="wrap">
@@ -45,20 +42,13 @@
         <div class="figure">
           <svg id="paper" viewBox="0 0 600 420" preserveAspectRatio="xMidYMid meet" aria-label=""></svg>
         </div>
-        <div class="toolbar">
-          <button id="btnReset" class="btn" type="button">Reset</button>
-        </div>
+        <div class="toolbar" id="toolbar"></div>
       </div>
 
       <div class="side">
         <div class="card">
           <h2>Last ned figurer</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
+          <div class="toolbar" id="downloadToolbar"></div>
         </div>
 
         <div class="card">
@@ -294,7 +284,19 @@ Rettvinklet trekant</textarea>
   </div>
   </div>
 
-  <script src="nkant.js"></script>
+  <script type="module">
+import { createToolbar } from "./components/toolbar.js";
+createToolbar("toolbar", [
+  { id: "btnReset", text: "Reset" }
+]);
+createToolbar("downloadToolbar", [
+  { id: "btnSvg", text: "Last ned SVG" },
+  { id: "btnPng", text: "Last ned PNG" },
+  { id: "btnSaveExample", text: "Lagre eksempel" },
+  { id: "btnDeleteExample", text: "Slett eksempel" }
+]);
+</script>
+<script src="nkant.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>
 

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -31,11 +31,7 @@
     .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
     .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
     .figure svg { width: 100%; height: 360px; display: block; touch-action: none; }
-    .toolbar { display:flex; gap:10px; justify-content:flex-end; }
-    .btn { appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px; padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s; }
-    .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform:translateY(1px); }
-    label { font-size: 13px; color: #4b5563; }
+    .toolbar { display:flex; gap:10px; justify-content:flex-end; }    label { font-size: 13px; color: #4b5563; }
     input[type="number"] {
       border: 1px solid #d1d5db;
       border-radius: 10px;
@@ -54,6 +50,7 @@
     .slider:focus{ outline:none; stroke:#1e88e5; stroke-width:3; }
   </style>
   <link rel="stylesheet" href="split.css" />
+  <link rel="stylesheet" href="styles/toolbar.css" />
 </head>
 <body>
   <div class="wrap">
@@ -71,12 +68,7 @@
       <div class="side">
         <div class="card">
           <h2>Last ned figurer</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
+          <div class="toolbar" id="downloadToolbar"></div>
         </div>
 
         <div class="card">
@@ -89,7 +81,16 @@
     </div>
   </div>
 
-  <script src="perlesnor.js"></script>
+  <script type="module">
+import { createToolbar } from "./components/toolbar.js";
+createToolbar("downloadToolbar", [
+  { id: "btnSvg", text: "Last ned SVG" },
+  { id: "btnPng", text: "Last ned PNG" },
+  { id: "btnSaveExample", text: "Lagre eksempel" },
+  { id: "btnDeleteExample", text: "Slett eksempel" }
+]);
+</script>
+<script src="perlesnor.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>
 

--- a/styles/toolbar.css
+++ b/styles/toolbar.css
@@ -1,0 +1,12 @@
+.btn {
+  appearance: none;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: box-shadow .2s, transform .02s;
+}
+.btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
+.btn:active { transform: translateY(1px); }

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -67,12 +67,9 @@
     .tb-right{top:50%;left:100%;transform:translate(10px,-50%);}
     .tb-bottom{top:100%;left:50%;transform:translate(-50%,10px);}
 
-    .tb-toolbar{display:flex;gap:10px;justify-content:flex-end}
-    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
-    .btn:active{transform:translateY(1px)}
-  </style>
+    .tb-toolbar{display:flex;gap:10px;justify-content:flex-end}  </style>
   <link rel="stylesheet" href="split.css" />
+  <link rel="stylesheet" href="styles/toolbar.css" />
 </head>
 <body>
   <div class="wrap">
@@ -91,12 +88,7 @@
       <div class="side">
         <div class="card">
           <h2>Last ned figurer</h2>
-          <div class="tb-toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
+          <div class="tb-toolbar" id="downloadToolbar"></div>
         </div>
 
         <div class="card">
@@ -126,7 +118,16 @@
   </div>
   </div>
 
-  <script src="tenkeblokker.js"></script>
+  <script type="module">
+import { createToolbar } from "./components/toolbar.js";
+createToolbar("downloadToolbar", [
+  { id: "btnSvg", text: "Last ned SVG" },
+  { id: "btnPng", text: "Last ned PNG" },
+  { id: "btnSaveExample", text: "Lagre eksempel" },
+  { id: "btnDeleteExample", text: "Slett eksempel" }
+]);
+</script>
+<script src="tenkeblokker.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>
 


### PR DESCRIPTION
## Summary
- build `createToolbar` component to render button groups from configuration
- centralize `.btn` styling in `styles/toolbar.css` and reference on pages
- replace hard-coded download/reset buttons with dynamic toolbars across examples

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b73fc404832485baf395c4c845b5