### PR TITLE
Handle unary signs before exponents

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -175,6 +175,7 @@ function parseFunctionSpec(spec){
   const m = rhs.match(/^([a-zA-Z]\w*)\s*\(\s*x\s*\)\s*=\s*(.+)$/);
   if(m){ rhs=m[2]; }
   rhs = rhs
+    .replace(/(^|[=+\-*/])\s*([+-])\s*([a-zA-Z0-9._()]+)\s*\^/g, (m,p,s,b) => p+'0'+s+'('+b+')^')
     .replace(/\^/g,'**')
     .replace(/(\d)([a-zA-Z(])/g,'$1*$2')
     .replace(/([x\)])\(/g,'$1*(')


### PR DESCRIPTION
## Summary
- fix parsing of unary plus/minus before exponents so `-x^2` becomes `0-(x)**2`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "const fs=require('fs'); const code=fs.readFileSync('graftegner.js','utf8'); const match=code.match(/function parseFunctionSpec[\s\S]*?return fn;\n}/); const vm=require('vm'); const sandbox={}; vm.runInNewContext(match[0], sandbox); const fn=sandbox.parseFunctionSpec; console.log(fn('f(x)=-x^2+4')(2)); console.log(fn('f(x)=4-x^2')(2));"`


------
https://chatgpt.com/codex/tasks/task_e_68c7fe9a9b288324b581eb80cec5b20a