### PR TITLE
Legg til innstillinger for Tenkeblokker

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -1,35 +1,98 @@
+<!doctype html>
+<html lang="no">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Tenkeblokker</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
-
-<div class="tb-wrap">
-  <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker"></svg>
-
-  <div class="tb-stepper" aria-label="Antall blokker">
-    <button id="tbMinus" type="button" aria-label="Færre blokker">−</button>
-    <div class="tb-divider"></div>
-    <button id="tbPlus"  type="button" aria-label="Flere blokker">+</button>
+  <style>
+    :root { --gap:18px; }
+    html,body{height:100%;}
+    body{
+      margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+      color:#111827; background:#f7f8fb; padding:20px;
+    }
+    .wrap{max-width:1200px;margin:0 auto;}
+    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    .side{display:flex;flex-direction:column;gap:var(--gap);}
+    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
+    .card{
+      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
+      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
+      display:flex;flex-direction:column;gap:10px;
+    }
+    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;}
+    .figure svg{width:100%;height:auto;display:block;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
+    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
+    .btn:active{transform:translateY(1px);}
+    label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
+    input[type="number"]{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
+    /* Tenkeblokker spesifikt */
+    .tb-stepper{display:flex;align-items:center;gap:0;border:1px solid #cfcfcf;border-radius:16px;padding:6px;background:#fff;box-shadow:0 6px 24px rgba(0,0,0,.08);align-self:center;}
+    .tb-stepper button{width:64px;height:48px;border:0;background:#fff;font-size:28px;cursor:pointer;}
+    .tb-stepper button:active{transform:translateY(1px);}
+    .tb-divider{width:1px;height:36px;background:#d6d6e3;margin:0 6px;}
+    .tb-rect{fill:#e8eedf}
+    .tb-rect-empty{fill:#ffffff}
+    .tb-frame{fill:none;stroke:#333;stroke-width:6}
+    .tb-sep{stroke:#555;stroke-width:2;stroke-dasharray:8 8;opacity:.6}
+    .tb-brace{fill:none;stroke:#0e6577;stroke-width:6;stroke-linecap:round}
+    .tb-total{font-size:34px;fill:#000;text-anchor:middle}
+    .tb-val{font-size:34px;fill:#111;text-anchor:middle;dominant-baseline:middle}
+    .tb-handle-shadow{fill:#000;opacity:.12}
+    .tb-handle{fill:#f1f1f6;stroke:#555;stroke-width:2;cursor:pointer}
+  </style>
+  <link rel="stylesheet" href="split.css" />
+</head>
+<body>
+  <div class="wrap">
+    <div class="grid">
+      <div class="card">
+        <div class="figure">
+          <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker"></svg>
+        </div>
+        <div class="tb-stepper" aria-label="Antall blokker">
+          <button id="tbMinus" type="button" aria-label="Færre blokker">−</button>
+          <div class="tb-divider"></div>
+          <button id="tbPlus"  type="button" aria-label="Flere blokker">+</button>
+        </div>
+      </div>
+      <div class="side">
+        <div class="card">
+          <h2>Last ned figurer</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Forfatters innstillinger</h2>
+          <label>Totaltall
+            <input id="cfg-total" type="number" min="1" value="50">
+          </label>
+          <label>Min n
+            <input id="cfg-min-n" type="number" min="1" value="2">
+          </label>
+          <label>Maks n
+            <input id="cfg-max-n" type="number" min="1" value="12">
+          </label>
+          <label>Antall blokker (n)
+            <input id="cfg-n" type="number" min="1" value="5">
+          </label>
+          <label>Fylte blokker (k)
+            <input id="cfg-k" type="number" min="0" value="4">
+          </label>
+        </div>
+      </div>
+    </div>
   </div>
-</div>
-
-<style>
-  .tb-wrap{display:grid;place-items:center;gap:16px;padding:20px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
-  /* SVG */
-  #thinkBlocks{width:min(900px,92vw);height:auto;background:#fff}
-  .tb-rect{fill:#e8eedf}
-  .tb-rect-empty{fill:#ffffff}
-  .tb-frame{fill:none;stroke:#333;stroke-width:6}
-  .tb-sep{stroke:#555;stroke-width:2;stroke-dasharray:8 8;opacity:.6}
-  .tb-brace{fill:none;stroke:#0e6577;stroke-width:6;stroke-linecap:round}
-  .tb-total{font-size:34px;fill:#000;text-anchor:middle}
-  .tb-val{font-size:34px;fill:#111;text-anchor:middle;dominant-baseline:middle}
-  .tb-handle-shadow{fill:#000;opacity:.12}
-  .tb-handle{fill:#f1f1f6;stroke:#555;stroke-width:2;cursor:pointer}
-
-  /* Stepper */
-  .tb-stepper{display:flex;align-items:center;gap:0;border:1px solid #cfcfcf;border-radius:16px;
-              padding:6px;background:#fff;box-shadow:0 6px 24px rgba(0,0,0,.08)}
-  .tb-stepper button{width:64px;height:48px;border:0;background:#fff;font-size:28px;cursor:pointer}
-  .tb-stepper button:active{transform:translateY(1px)}
-  .tb-divider{width:1px;height:36px;background:#d6d6e3;margin:0 6px}
-</style>
-
-<script src="tenkeblokker.js"></script>
+  <script src="tenkeblokker.js"></script>
+  <script src="examples.js"></script>
+  <script src="split.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Legg til fullstendig HTML-side for Tenkeblokker med nedlastingsknapper og forfatterinnstillinger
- Gjør Tenkeblokker-konfigurerbar via inputfelter og legg til eksport som SVG/PNG

## Testing
- `npm test` *(forventet feil: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c800dae5308324be9371c7dada8b7d