### PR TITLE
Implement GeoGebra-style monster patterns

### DIFF
--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -107,35 +107,125 @@
     expression.textContent = `${antallX} × ${antallY} × (${bredde} × ${hoyde} × ${dybde}) = ${antallX * antallY} × ${perFig} = ${total}`;
   }
 
-  function finnFaktorer(n){
-    let cols=Math.floor(Math.sqrt(n));
-    while(cols>1 && n%cols!==0) cols--;
-    const rows=cols? n/cols : 0;
-    return {cols, rows};
+  function primeFactors(n){
+    const factors=[];
+    let num=n;
+    let p=2;
+    while(num>1 && factors.length<6){
+      while(num%p===0 && factors.length<6){
+        factors.push(p);
+        num/=p;
+      }
+      p++;
+    }
+    while(factors.length<6) factors.push(1);
+    return factors;
   }
 
-  const customPatterns={
-    4:[
-      {x:-0.5,y:-0.5},
-      {x:0.5,y:-0.5},
-      {x:-0.5,y:0.5},
-      {x:0.5,y:0.5}
-    ]
-  };
+  function computeKs(n,f){
+    const [f1,f2,f3,f4,f5,f6]=f;
+
+    let k1=(n<=9?0.5:1)/(f2*f3*f4*f5);
+    if(f3===2 && f4===2) k1*=(f5<3?0.25:0.5);
+    if(f4===2 && f5===2) k1*=0.5;
+    if(f1===2 && f2===2 && f3===2 && f4<3) k1*=2;
+    if(f1===2 && f2===2 && f3===2 && f4===2) k1*=2;
+    if(f3===3) k1*=f2/f1;
+    if(f1===f2 && f2===f3 && f3===f4 && f4===f5) k1*=2;
+    if(n===1) k1=0;
+
+    let k2;
+    if(f2===1) k2=1;
+    else if(f1===2 && f2===2) k2=k1;
+    else if(f3===1) k2=1-1/f2;
+    else if(f2===f1) k2=k1*f2;
+    else if(f3===f2 && f2===3) k2=k1*f1;
+    else if(f3===f2) k2=k1*f2;
+    else if(f1*f2===6 && f3<3) k2=k1*f3/f1;
+    else k2=1/(f3*f4*f5*f6);
+
+    let k3;
+    if(f3===1) k3=1;
+    else{
+      if(f4===1) k3=1-k1;
+      else{
+        k3=1;
+        if(f2*f3===4 && f5===1) k3*=Math.max(...f)/f1;
+        if(f1*f2*f3===8 && f6===1) k3*=1/f2;
+        if(f1===2 && f2===2 && f3===2 && f4===2) k3*=2;
+        k3*=1/(f4*f5);
+      }
+      k3*=1/f6;
+    }
+    if(f1*f2*f3*f4===16 && f5>2) k3*=2;
+
+    let k4;
+    if(f4===1) k4=1;
+    else if(f5===1 && f1*f2===4) k4=1-k3;
+    else if(f5===1) k4=1-k1;
+    else k4=1/(f5*f6);
+
+    let k5;
+    if(f5===1) k5=1;
+    else if(f6===1){
+      const mul=(f1===2 && f2===2 && f3===2 && f4===2)?0.5:1;
+      k5=1-mul*k3;
+    }else{
+      k5=1/f6;
+    }
+
+    const k6=f6===1?1:1-k3;
+
+    return [k1,k2,k3,k4,k5,k6];
+  }
+
+  function rotate(points,angle){
+    const cos=Math.cos(angle);
+    const sin=Math.sin(angle);
+    return points.map(p=>({x:p.x*cos - p.y*sin, y:p.x*sin + p.y*cos}));
+  }
+
+  function translate(points,tx,ty){
+    return points.map(p=>({x:p.x+tx, y:p.y+ty}));
+  }
+
+  function buildLevel(points,factor,r){
+    if(factor===1) return points;
+    const res=[];
+    for(let i=0;i<factor;i++){
+      const rotAngle=-2*Math.PI*i/factor;
+      const rotated=rotate(points,rotAngle);
+      const baseAngle=2*Math.PI*i/factor;
+      let tx,ty;
+      if(factor===2){
+        tx=r*Math.cos(baseAngle);
+        ty=r*Math.sin(baseAngle);
+      }else{
+        tx=r*Math.sin(baseAngle);
+        ty=r*Math.cos(baseAngle);
+      }
+      res.push(...translate(rotated,tx,ty));
+    }
+    return res;
+  }
 
   function byggMonster(n){
     if(n<=0) return [];
-    if(customPatterns[n]) return customPatterns[n];
-    const {cols, rows}=finnFaktorer(n);
-    const points=[];
-    const xOff=-(cols-1)/2;
-    const yOff=-(rows-1)/2;
-    for(let r=0;r<rows;r++){
-      for(let c=0;c<cols;c++){
-        points.push({x:xOff+c, y:yOff+r});
-      }
+    const factors=primeFactors(n);
+    const ks=computeKs(n,factors);
+    let pts=[];
+    const f1=factors[0];
+    for(let i=0;i<f1;i++){
+      const angle=2*Math.PI*i/f1;
+      pts.push({x:ks[0]*Math.sin(angle), y:ks[0]*Math.cos(angle)});
     }
-    return points;
+    pts=buildLevel(pts,factors[1],ks[1]);
+    pts=buildLevel(pts,factors[2],ks[2]);
+    pts=buildLevel(pts,factors[3],ks[3]);
+    pts=buildLevel(pts,factors[4],ks[4]);
+    pts=buildLevel(pts,factors[5],ks[5]);
+    const scale=0.3;
+    return pts.map(p=>({x:p.x*scale, y:p.y*scale}));
   }
 
   function renderMonster(){
@@ -172,8 +262,8 @@
       svg.appendChild(c);
     });
     patternContainer.appendChild(svg);
-    const {cols, rows}=finnFaktorer(n);
-    expression.textContent=(cols>1 && rows>1)?`${cols} × ${rows} = ${n}`:`${n}`;
+    const factors=primeFactors(n).filter(x=>x>1);
+    expression.textContent=factors.length?`${factors.join(' × ')} = ${n}`:`${n}`;
   }
 
   function updateVisibilityKlosser(){


### PR DESCRIPTION
## Summary
- replace the rectangular monster builder with a recursive, factor-based pattern generator
- place points through rotations and translations to mirror the GeoGebra construction
- display the prime factor multiplication that matches the rendered pattern

## Testing
- `node -e "new Function(require('fs').readFileSync('math_visuals/kvikkbilder.js','utf8'))"`


------
https://chatgpt.com/codex/tasks/task_e_68c85b2523cc8324be9b3a9026800127