### PR TITLE
Improve dynamic scaling of figure panels

### DIFF
--- a/figurtall.html
+++ b/figurtall.html
@@ -17,23 +17,23 @@
     @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
     .grid2{
-      display:flex;
+      --panel-min:clamp(200px,22vw,260px);
+      display:grid;
       gap:clamp(16px,2vw,24px);
-      align-items:stretch;
-      overflow-x:auto;
+      grid-template-columns:repeat(auto-fit,minmax(var(--panel-min),1fr));
+      align-items:start;
+      justify-items:stretch;
       padding-bottom:8px;
-      scroll-snap-type:x proximity;
     }
-    .grid2>*{scroll-snap-align:start;}
     .figurePanel{
       display:flex;
       flex-direction:column;
       gap:12px;
       align-items:stretch;
-      flex:0 0 clamp(200px,24vw,260px);
+      min-width:0;
     }
     .addFigureBtn{
-      width:clamp(60px,15vw,120px);
+      width:min(100%,clamp(72px,calc(var(--panel-min,220px)*0.7),140px));
       aspect-ratio:1;
       border:2px dashed #cfcfcf;
       border-radius:10px;

--- a/figurtall.js
+++ b/figurtall.js
@@ -153,6 +153,26 @@
   const addBtn=document.getElementById('addFigure');
   let figureCount=0;
 
+  const MIN_PANEL_WIDTH=80;
+  const MAX_PANEL_WIDTH=260;
+
+  function updateFigureLayout(){
+    if(!container) return;
+    const panelCount=container.querySelectorAll('.figurePanel').length + (addBtn?1:0);
+    if(panelCount<=0) return;
+    const styles=getComputedStyle(container);
+    const gapStr=styles.columnGap||styles.gap||'0';
+    const gap=parseFloat(gapStr)||0;
+    const available=container.clientWidth;
+    if(available<=0) return;
+    let computed=(available - gap*(panelCount-1))/panelCount;
+    if(!Number.isFinite(computed)) return;
+    if(computed>MAX_PANEL_WIDTH) computed=MAX_PANEL_WIDTH;
+    if(computed<MIN_PANEL_WIDTH) computed=MIN_PANEL_WIDTH;
+    container.style.setProperty('--panel-min',`${computed}px`);
+  }
+  window.addEventListener('resize',updateFigureLayout);
+
   function addFigure(name='',pattern=[]){
     figureCount++;
     const panel=document.createElement('div');
@@ -177,6 +197,7 @@
       });
     }
     updateCellColors();
+    updateFigureLayout();
     return panel;
   }
 
@@ -358,6 +379,7 @@
     addFigure('Figur 3', [[0,1],[1,0],[1,1],[2,0],[2,1],[2,2]]);
 
     updateGridVisibility();
+    updateFigureLayout();
   }
 
   resetBtn?.addEventListener('click',resetAll);
@@ -365,5 +387,6 @@
   updateRows();
   updateCols();
   resetAll();
+  updateFigureLayout();
 })();
 


### PR DESCRIPTION
## Summary
- replace the horizontal scroller in the figure list with a responsive CSS grid
- compute panel width dynamically so figures shrink as more are added and resize with the window

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68c85c300b588324bede6389a14a6c96