### PR TITLE
Make saved examples interactive

### DIFF
--- a/examples-viewer.js
+++ b/examples-viewer.js
@@ -22,8 +22,21 @@ function renderExamples(){
       if(ex.svg){
         const divSvg = document.createElement('div');
         divSvg.innerHTML = ex.svg;
-        wrap.appendChild(divSvg.firstChild);
+        const svgEl = divSvg.firstElementChild;
+        if(svgEl) wrap.appendChild(svgEl);
       }
+      const iframe = document.createElement('iframe');
+      iframe.setAttribute('loading', 'lazy');
+      iframe.title = `Eksempel ${idx + 1} – ${path}`;
+      try {
+        const url = new URL(path, window.location.href);
+        url.searchParams.set('example', String(idx + 1));
+        iframe.src = url.href;
+      } catch {
+        const sep = path.includes('?') ? '&' : '?';
+        iframe.src = `${path}${sep}example=${idx + 1}`;
+      }
+      wrap.appendChild(iframe);
       const btns = document.createElement('div');
       btns.className = 'buttons';
       const loadBtn = document.createElement('button');

--- a/examples.html
+++ b/examples.html
@@ -8,8 +8,9 @@
     body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#111827;background:#f7f8fb;padding:20px;}
     h2{font-size:16px;margin:24px 0 8px;}
     .example{background:#fff;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin-bottom:16px;}
-    .example svg{max-width:100%;height:auto;display:block;margin-bottom:8px;}
-    .buttons{display:flex;gap:10px;}
+    .example svg{max-width:100%;height:auto;display:block;margin-bottom:12px;}
+    .example iframe{width:100%;min-height:560px;border:1px solid #e5e7eb;border-radius:10px;background:#fff;margin-bottom:12px;}
+    .buttons{display:flex;gap:10px;flex-wrap:wrap;}
     button{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:6px 10px;font-size:14px;cursor:pointer;}
     button:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}button:active{transform:translateY(1px);}
   </style>


### PR DESCRIPTION
## Summary
- load saved configurations automatically when an example is opened via query or hash parameters
- show each stored example inside a lazy-loaded iframe so it behaves like the original visualization
- tune the examples page styles to accommodate embedded interactive previews

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c85ce571c88324abe020c9b10c702b