### PR TITLE
Add example toolbar to Kvikkbilder

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -80,6 +80,10 @@
         </div>
         <div class="card">
           <h2>Forfatters innstillinger</h2>
+          <div class="toolbar">
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+          </div>
           <label>Type
             <select id="cfg-type">
               <option value="klosser">Klosser</option>
@@ -128,6 +132,7 @@
   </div>
   <script src="kvikkbilder.js"></script>
   <script src="split.js"></script>
+  <script src="examples.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a save/delete example toolbar to the author settings card in Kvikkbilder
- load the shared examples.js script so example persistence hooks run on the page

## Testing
- python - <<'PY' (playwright check verifying that saving an example updates the dropdown and localStorage)


------
https://chatgpt.com/codex/tasks/task_e_68c861f84ae48324b4acf423d1166443