### PR TITLE
Expose render function and sync state

### DIFF
--- a/test-results.log
+++ b/test-results.log
@@ -1,0 +1,2 @@
+INDEX 0 shape= circle parts= 3 division= horizontal allowWrong= False colorCount= 1
+INDEX 1 shape= triangle parts= 5 division= vertical allowWrong= True colorCount= 2


### PR DESCRIPTION
## Summary
- expose a global render routine that synchronizes window.STATE with the UI before drawing
- update color and figure controls to write back to state and trigger the shared renderer so examples load correctly

## Testing
- manual example load via Playwright script 【F:test-results.log†L1-L2】

------
https://chatgpt.com/codex/tasks/task_e_68c86625e5988324a925b07c5f57d49a