### PR TITLE
Enlarge dots and spacing for Kvikkbilder mønster

### DIFF
--- a/kvikkbilder-monster.js
+++ b/kvikkbilder-monster.js
@@ -150,20 +150,20 @@
     if(!availableWidth){
       availableWidth=patternContainer.parentElement?.clientWidth||360;
     }
-    const maxPreferred=420;
-    const minPreferred=280;
+    const maxPreferred=560;
+    const minPreferred=320;
     let targetPx=Math.min(availableWidth,maxPreferred);
     if(availableWidth>=minPreferred){
       targetPx=Math.max(targetPx,minPreferred);
     }
     if(!Number.isFinite(targetPx)||targetPx<=0){
-      targetPx=360;
+      targetPx=420;
     }
     const maxDim=Math.max(vbW,vbH);
     const pxPerUnit=targetPx/maxDim;
     const widthPx=vbW*pxPerUnit;
     const heightPx=vbH*pxPerUnit;
-    const dotRadiusPx=4;
+    const dotRadiusPx=6;
     const dotRadius=dotRadiusPx/pxPerUnit;
     const svgNS='http://www.w3.org/2000/svg';
     const svg=document.createElementNS(svgNS,'svg');

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -251,13 +251,13 @@
     const svgNS='http://www.w3.org/2000/svg';
     const svg=document.createElementNS(svgNS,'svg');
     svg.setAttribute('viewBox', `${vbX} ${vbY} ${vbW} ${vbH}`);
-    svg.setAttribute('width', vbW*20);
-    svg.setAttribute('height', vbH*20);
+    svg.setAttribute('width', vbW*28);
+    svg.setAttribute('height', vbH*28);
     points.forEach(({x,y})=>{
       const c=document.createElementNS(svgNS,'circle');
       c.setAttribute('cx', x);
       c.setAttribute('cy', y);
-      c.setAttribute('r', 0.3);
+      c.setAttribute('r', 0.45);
       c.setAttribute('fill', '#534477');
       svg.appendChild(c);
     });


### PR DESCRIPTION
## Summary
- Increase the preferred rendering size and point radius for the standalone Kvikkbilder mønster view so the figures appear larger with more distance between dots.
- Match the embedded Kvikkbilder mønster renderer with larger SVG dimensions and point sizes for consistency.

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68c870afdbb48324ad5cef9d62f4fa5e