### PR TITLE
Align visualization sidebars

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -29,7 +29,7 @@
     #box{width:clamp(280px,60vw,460px);aspect-ratio:1;margin:0 auto;position:relative;}
     .pairs-list{position:absolute;top:10px;right:10px;display:flex;gap:1.2em;text-align:right;pointer-events:none;font-size:16px;line-height:1.2;}
     .pairs-list .col{display:flex;flex-direction:column;gap:4px;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
     .btn{
       appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;
       padding:8px 12px;font-size:14px;cursor:pointer;
@@ -60,52 +60,57 @@
       </div>
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
           <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSvgInteractive" class="btn" type="button">Last ned interaktiv SVG</button>
-            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSvgInteractive" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Innstillinger</h2>
           <div id="settingsMenu" class="settings">
-          <div class="row">
-            <label>Lengde (celler)
-              <input id="lenCells" type="number" value="1" min="1">
+            <div class="row">
+              <label>Lengde (celler)
+                <input id="lenCells" type="number" value="1" min="1">
+              </label>
+              <label>Maks lengde
+                <input id="lenMax" type="number" value="12" min="1">
+              </label>
+            </div>
+            <div class="row">
+              <label>Høyde (celler)
+                <input id="heiCells" type="number" value="1" min="1">
+              </label>
+              <label>Maks høyde
+                <input id="heiMax" type="number" value="12" min="1">
+              </label>
+            </div>
+            <label>Snap
+              <input id="snap" type="number" value="1" min="1">
             </label>
-            <label>Maks lengde
-              <input id="lenMax" type="number" value="12" min="1">
+            <label>Areal-tekst
+              <input id="areaLabel" type="text" value="areal">
             </label>
-          </div>
-          <div class="row">
-            <label>Høyde (celler)
-              <input id="heiCells" type="number" value="1" min="1">
-            </label>
-            <label>Maks høyde
-              <input id="heiMax" type="number" value="12" min="1">
-            </label>
-          </div>
-          <label>Snap
-            <input id="snap" type="number" value="1" min="1">
-          </label>
-          <label>Areal-tekst
-            <input id="areaLabel" type="text" value="areal">
-          </label>
-          <label class="chk"><input type="checkbox" id="chkGrid" checked> Vis rutenett</label>
-          <div class="row">
-            <label class="chk"><input type="checkbox" id="chkChallenge"> Oppgave-modus</label>
-            <label>Oppgave-areal
-              <input id="challengeArea" type="number" value="12" min="1">
-            </label>
+            <label class="chk"><input type="checkbox" id="chkGrid" checked> Vis rutenett</label>
+            <div class="row">
+              <label class="chk"><input type="checkbox" id="chkChallenge"> Oppgave-modus</label>
+              <label>Oppgave-areal
+                <input id="challengeArea" type="number" value="12" min="1">
+              </label>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
   </div>
   <script src="arealmodell0.js"></script>
   <script src="examples.js"></script>

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -27,7 +27,7 @@
     .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
     svg { width: 100%; height: auto; background: #fff; display: block; }
     .settings { display: flex; flex-direction: column; gap: 10px; }
-    .toolbar { display:flex; gap:10px; justify-content:flex-end; }
+    .toolbar { display:flex; gap:10px; justify-content:flex-start; align-items:center; flex-wrap:wrap; }
     .btn { appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px; padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s; }
     .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
     .btn:active { transform:translateY(1px); }
@@ -67,18 +67,23 @@
       </div>
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
           <div class="toolbar">
-            <button id="btnSvgStatic" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSvg" class="btn" type="button">Last ned interaktiv SVG</button>
-            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvgStatic" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSvg" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Innstillinger</h2>
           <div class="settings">
             <div class="row">
               <label>Lengde

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -68,7 +68,7 @@
       background:#fff;font-size:20px;cursor:pointer;
     }
     .stepper span{min-width:32px;text-align:center;font-variant-numeric:tabular-nums;font-size:16px;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
     .btn:active{transform:translateY(1px)}
@@ -111,7 +111,14 @@
       </div>
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
+          <div class="toolbar">
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
           <div class="toolbar">
             <button id="btnSvg1" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng1" class="btn" type="button">Last ned PNG</button>
@@ -120,13 +127,9 @@
             <button id="btnSvg2" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng2" class="btn" type="button">Last ned PNG</button>
           </div>
-          <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
         </div>
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
+          <h2>Innstillinger</h2>
           <fieldset>
             <legend>Farger</legend>
             <label>Antall farger

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -23,7 +23,7 @@
       display:flex; flex-direction:column; gap:10px;
     }
     .card h2 { margin:0 0 6px 2px; font-size:16px; font-weight:600; color:#374151; }
-    .toolbar { display:flex; gap:10px; justify-content:flex-end; }
+    .toolbar { display:flex; gap:10px; justify-content:flex-start; align-items:center; flex-wrap:wrap; }
     .btn {
       appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px;
       padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s;
@@ -162,18 +162,24 @@
 
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
           <div class="toolbar">
-            <button id="btnStaticAll" class="btn" type="button">Last ned SVG</button>
-            <button id="btnInteractiveAll" class="btn" type="button">Last ned interaktiv SVG</button>
-            <button id="btnPngAll" class="btn" type="button">Last ned PNG</button>
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnStaticAll" class="btn" type="button">Last ned SVG</button>
+            <button id="btnInteractiveAll" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnPngAll" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Innstillinger</h2>
           <div class="settings">
           <fieldset>
             <legend>Pizza 1</legend>

--- a/diagram.css
+++ b/diagram.css
@@ -16,7 +16,7 @@ body {
 .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
 .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
 .figure svg { width: 100%; height: auto; display: block; background: #fff; }
-.toolbar { display: flex; gap: 10px; justify-content: flex-end; }
+.toolbar { display: flex; gap: 10px; justify-content: flex-start; align-items: center; flex-wrap: wrap; }
 .btn {
   appearance: none; border: 1px solid #d1d5db; background: #fff; border-radius: 10px;
   padding: 8px 12px; font-size: 14px; cursor: pointer;

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -31,17 +31,23 @@
 
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
           <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Innstillinger</h2>
           <div class="settings">
           <label>Type
             <select id="cfgType">
@@ -117,7 +123,6 @@
         </div>
       </div>
     </div>
-  </div>
   </div>
 
   <script src="../diagram.js"></script>

--- a/figurtall.html
+++ b/figurtall.html
@@ -56,7 +56,7 @@
       flex-direction:column;gap:10px;
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
     .btn:active{transform:translateY(1px);}
@@ -127,17 +127,21 @@
       </div>
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
           <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-            <button id="resetBtn" class="btn" type="button">Nullstill</button>
           </div>
         </div>
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Innstillinger</h2>
           <fieldset>
             <legend>Ruter</legend>
             <label>Rader
@@ -172,6 +176,9 @@
               <input id="color_6" type="color" value="#E31C3D" />
             </div>
           </fieldset>
+          <div class="toolbar">
+            <button id="resetBtn" class="btn" type="button">Nullstill</button>
+          </div>
         </div>
       </div>
     </div>

--- a/graftegner.html
+++ b/graftegner.html
@@ -22,7 +22,8 @@
     .card h2{ margin:0 0 6px 2px; font-size:16px; font-weight:600; color:#374151; }
     .figure{ border-radius:10px; background:#fafbfc; overflow:hidden; border:1px solid #eef0f3; }
     #board{ width:100%; height:560px; background:#fff; }
-    .toolbar{ display:flex; gap:12px; flex-wrap:wrap; justify-content:flex-end; }
+    .toolbar{ display:flex; gap:12px; flex-wrap:wrap; justify-content:flex-start; align-items:center; }
+    #toolbar{ justify-content:space-between; }
     .btn{ appearance:none; cursor:pointer; padding:8px 14px; border-radius:10px; border:1px solid #d1d5db; background:#fff; }
     .checkbar{ display:flex; gap:10px; align-items:center; }
     .status{ padding:6px 10px; border-radius:10px; font-weight:600; border:1px solid transparent; }
@@ -60,41 +61,47 @@
 
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
           <div class="toolbar">
-            <button id="btnSvg" class="btn">Last ned SVG</button>
-            <button id="btnPng" class="btn">Last ned PNG</button>
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn">Last ned SVG</button>
+            <button id="btnPng" class="btn">Last ned PNG</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Innstillinger</h2>
           <div class="settings">
-          <div id="funcRows"></div>
-          <fieldset>
-            <legend>Koordinatsystem</legend>
-            <label>Screen (overstyrer autozoom hvis satt)
-              <input id="cfgScreen" type="text" value="" placeholder="minX, maxX, minY, maxY">
-            </label>
-            <div class="checkbox-row"><input id="cfgLock" type="checkbox" checked><label for="cfgLock">Lås forhold 1:1 (krever screen)</label></div>
-            <div class="checkbox-row"><input id="cfgPan" type="checkbox"><label for="cfgPan">Tillat pan</label></div>
-            <div class="checkbox-row"><input id="cfgQ1" type="checkbox"><label for="cfgQ1">Bare 1. kvadrant</label></div>
-            <div class="settings-row axis-names">
-              <label>Navn på akser</label>
-              <label class="axis-label">x:
-                <input id="cfgAxisX" type="text" value="x">
+            <div id="funcRows"></div>
+            <fieldset>
+              <legend>Koordinatsystem</legend>
+              <label>Screen (overstyrer autozoom hvis satt)
+                <input id="cfgScreen" type="text" value="" placeholder="minX, maxX, minY, maxY">
               </label>
-              <label class="axis-label">y:
-                <input id="cfgAxisY" type="text" value="y">
-              </label>
-            </div>
-          </fieldset>
+              <div class="checkbox-row"><input id="cfgLock" type="checkbox" checked><label for="cfgLock">Lås forhold 1:1 (krever screen)</label></div>
+              <div class="checkbox-row"><input id="cfgPan" type="checkbox"><label for="cfgPan">Tillat pan</label></div>
+              <div class="checkbox-row"><input id="cfgQ1" type="checkbox"><label for="cfgQ1">Bare 1. kvadrant</label></div>
+              <div class="settings-row axis-names">
+                <label>Navn på akser</label>
+                <label class="axis-label">x:
+                  <input id="cfgAxisX" type="text" value="x">
+                </label>
+                <label class="axis-label">y:
+                  <input id="cfgAxisY" type="text" value="y">
+                </label>
+              </div>
+            </fieldset>
+          </div>
         </div>
       </div>
     </div>
-  </div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>

--- a/kuler.html
+++ b/kuler.html
@@ -62,7 +62,7 @@
           </div>
         </div>
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
+          <h2>Innstillinger</h2>
           <div id="controls"></div>
         </div>
       </div>

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -30,7 +30,7 @@
     label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     input[type="number"]{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
     #playBtn{align-self:center;padding:20px 30px;font-size:20px;cursor:pointer;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
     .btn:active{transform:translateY(1px);}
@@ -47,28 +47,36 @@
       </div>
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
+          <div class="toolbar">
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
           </div>
         </div>
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
-            <label>Vis play-knapp
-              <input id="cfg-showBtn" type="checkbox">
-            </label>
-            <label>Antall
-              <input id="cfg-antall" type="number" min="1" value="9">
-            </label>
-            <label>Vis i sekunder
-              <input id="cfg-duration" type="number" min="1" value="3">
-            </label>
-          </div>
+          <h2>Innstillinger</h2>
+          <label>Vis play-knapp
+            <input id="cfg-showBtn" type="checkbox">
+          </label>
+          <label>Antall
+            <input id="cfg-antall" type="number" min="1" value="9">
+          </label>
+          <label>Vis i sekunder
+            <input id="cfg-duration" type="number" min="1" value="3">
+          </label>
+        </div>
       </div>
     </div>
   </div>
   <script src="kvikkbilder-monster.js"></script>
   <script src="split.js"></script>
+  <script src="examples.js"></script>
 </body>
 </html>

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -54,7 +54,7 @@
       justify-content:center;
       box-shadow:0 2px 8px rgba(0,0,0,.15);
     }
-    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
     .btn:active{transform:translateY(1px);}
@@ -72,18 +72,21 @@
       </div>
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
+          <div class="toolbar">
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
           </div>
         </div>
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
-          <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
-          </div>
+          <h2>Innstillinger</h2>
           <label>Type
             <select id="cfg-type">
               <option value="klosser">Klosser</option>

--- a/nkant.html
+++ b/nkant.html
@@ -18,7 +18,7 @@
     .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
     .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
     .figure svg { width: 100%; height: 360px; display: block; }
-    .toolbar { display: flex; gap: 10px; justify-content: flex-end; }
+    .toolbar { display: flex; gap: 10px; justify-content: flex-start; align-items: center; flex-wrap: wrap; }
     .specs-row { display:flex; gap:10px; align-items:flex-start; }
     .specs-row textarea { flex:1; width:auto; }
     .btn { appearance: none; border: 1px solid #d1d5db; background: #fff; border-radius: 10px; padding: 8px 12px; font-size: 14px;
@@ -52,17 +52,23 @@
 
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
           <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Innstillinger</h2>
 
         <label for="inpSpecs">Skriv spesifikasjoner eller fritekst (1–2 linjer per figur)</label>
         <div class="specs-row">
@@ -291,7 +297,6 @@ Rettvinklet trekant</textarea>
         </div>
       </div>
     </div>
-  </div>
   </div>
 
   <script src="nkant.js"></script>

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -31,7 +31,7 @@
     .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
     .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
     .figure svg { width: 100%; height: 360px; display: block; touch-action: none; }
-    .toolbar { display:flex; gap:10px; justify-content:flex-end; }
+    .toolbar { display:flex; gap:10px; justify-content:flex-start; align-items:center; flex-wrap:wrap; }
     .btn { appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px; padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s; }
     .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
     .btn:active { transform:translateY(1px); }
@@ -70,17 +70,23 @@
 
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
           <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Innstillinger</h2>
           <label>Antall perler<input id="cfg-nBeads" type="number" min="1"></label>
           <label>Startposisjon<input id="cfg-startIndex" type="number" min="0"></label>
           <label>Fasit venstre<input id="cfg-correct" type="number" min="0"></label>

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -1,22 +1,77 @@
 <!doctype html>
 <html lang="no">
 <head>
-<meta charset="utf-8" />
-<title>Tenkeblokker</title>
-<style>
-  #blocks{display:flex;gap:20px;flex-wrap:wrap}
-  .tb-block-wrapper{display:flex;flex-direction:column;align-items:center}
-  .tb-block{display:flex;border:2px solid #333;height:100px;width:300px}
-  .tb-segment{flex:1;display:flex;align-items:center;justify-content:center;border-right:1px dashed #777;background:#e8eedf;font-size:24px}
-  .tb-segment:last-child{border-right:none}
-  .tb-stepper{display:flex;gap:10px;margin-top:10px}
-  .tb-stepper button{width:40px;height:40px;font-size:24px}
-  #addBlock{margin-top:20px;width:40px;height:40px;font-size:24px}
-</style>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Tenkeblokker</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <style>
+    :root { --gap:18px; }
+    html,body{height:100%;}
+    body{
+      margin:0;
+      font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+      color:#111827;
+      background:#f7f8fb;
+      padding:20px;
+    }
+    .wrap{max-width:1200px;margin:0 auto;}
+    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    .side{display:flex;flex-direction:column;gap:var(--gap);}
+    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
+    .card{
+      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
+      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
+      display:flex;flex-direction:column;gap:12px;
+    }
+    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
+    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
+    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
+    .btn:active{transform:translateY(1px);}
+    .muted{font-size:13px;color:#6b7280;margin:0;}
+
+    #blocks{display:flex;gap:20px;flex-wrap:wrap;justify-content:center;}
+    .tb-block-wrapper{display:flex;flex-direction:column;align-items:center;gap:12px;}
+    .tb-block{display:flex;border:2px solid #333;height:120px;width:360px;border-radius:12px;overflow:hidden;background:#fff;}
+    .tb-segment{flex:1;display:flex;align-items:center;justify-content:center;border-right:1px dashed #777;background:#e8eedf;font-size:24px;font-variant-numeric:tabular-nums;}
+    .tb-segment:last-child{border-right:none;}
+    .tb-stepper{display:flex;gap:10px;margin-top:4px;}
+    .tb-stepper button{width:40px;height:36px;font-size:24px;border:1px solid #cfcfcf;border-radius:8px;background:#fff;cursor:pointer;}
+    .tb-stepper button:active{transform:translateY(1px);}
+  </style>
+  <link rel="stylesheet" href="split.css" />
 </head>
 <body>
-<div id="blocks"></div>
-<button id="addBlock" type="button">+</button>
-<script src="tenkeblokker-stepper.js"></script>
+  <div class="wrap">
+    <div class="grid">
+      <div class="card">
+        <div id="blocks" aria-label="Tenkeblokker"></div>
+        <div class="toolbar">
+          <button id="addBlock" class="btn" type="button">Legg til blokk</button>
+        </div>
+      </div>
+      <div class="side">
+        <div class="card">
+          <h2>Eksempler</h2>
+          <div class="toolbar">
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
+          <p class="muted">Ingen eksport tilgjengelig.</p>
+        </div>
+        <div class="card">
+          <h2>Innstillinger</h2>
+          <p class="muted">Ingen ekstra innstillinger for denne visningen.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="tenkeblokker-stepper.js"></script>
+  <script src="examples.js"></script>
+  <script src="split.js"></script>
 </body>
 </html>

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -85,7 +85,7 @@
     .checkbox-row{display:flex;align-items:center;gap:6px;font-size:13px;color:#4b5563;}
     .checkbox-row input{margin:0;}
     .checkbox-row label{display:inline;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
     .btn:active{transform:translateY(1px);}
@@ -124,16 +124,21 @@
       </div>
       <div class="side">
         <div class="card">
-          <h2>Last ned figurer</h2>
+          <h2>Eksempler</h2>
           <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
         <div class="card">
-          <h2>Forfatters innstillinger</h2>
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Innstillinger</h2>
           <div class="tb-settings">
             <fieldset id="cfg-fieldset-1">
               <legend>Tenkeblokker 1</legend>


### PR DESCRIPTION
## Summary
- standardize the right-hand sidebar across visualization pages with Eksempler, Eksporter and Innstillinger cards
- update shared toolbar styling and ensure scripts such as examples.js are loaded where the new layout is used
- refresh the tenkeblokker stepper page to use the shared layout and messaging

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68c8715e551c83249d77d1d812e6d78e