### PR TITLE
Fjern mellomrom mellom tenkeblokker

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -32,18 +32,15 @@
       flex-wrap:nowrap;
       overflow-x:auto;
       --tb-svg-width:min(420px,88vw);
-      --tb-overlap:calc(var(--tb-svg-width) * 140 / 900);
     }
     .tb-panels.two{
       gap:0;
       justify-content:flex-start;
-      --tb-svg-width:min(420px,44vw);
+      --tb-svg-width:calc(min(420px,44vw) * 830 / 900);
     }
-    .tb-panels.two .tb-panel + .tb-panel{margin-left:calc(-1 * var(--tb-overlap));}
     .tb-panels > *{flex:0 0 auto;}
     .tb-panel{display:flex;flex-direction:column;align-items:center;gap:16px;max-width:420px;}
-    .tb-svg{width:min(420px,88vw);height:auto;background:#fff;}
-    .tb-panels.two .tb-svg{width:min(420px,44vw);}
+    .tb-svg{width:var(--tb-svg-width);height:auto;background:#fff;}
     .tb-header{width:100%;display:flex;flex-direction:column;align-items:center;gap:6px;}
     .tb-whole{font-size:24px;line-height:1;color:#111827;}
     .tb-header:empty{display:none;}


### PR DESCRIPTION
## Summary
- juster CSS for tenkeblokker slik at to paneler bruker riktig SVG-bredde uten negativ overlapping
- beskjær hver blokk sitt viewBox og oppdater koordinatberegninger slik at blokkene vises kant i kant

## Testing
- npm start (manuell visuell sjekk)


------
https://chatgpt.com/codex/tasks/task_e_68c8767318e083249f8ceb1f6332e3cd