### PR TITLE
Remove static fallback from example viewer

### DIFF
--- a/examples-viewer.js
+++ b/examples-viewer.js
@@ -19,12 +19,6 @@ function renderExamples(){
     arr.forEach((ex, idx) => {
       const wrap = document.createElement('div');
       wrap.className = 'example';
-      if(ex.svg){
-        const divSvg = document.createElement('div');
-        divSvg.innerHTML = ex.svg;
-        const svgEl = divSvg.firstElementChild;
-        if(svgEl) wrap.appendChild(svgEl);
-      }
       const iframe = document.createElement('iframe');
       iframe.setAttribute('loading', 'lazy');
       iframe.title = `Eksempel ${idx + 1} – ${path}`;

--- a/examples.html
+++ b/examples.html
@@ -8,7 +8,6 @@
     body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#111827;background:#f7f8fb;padding:20px;}
     h2{font-size:16px;margin:24px 0 8px;}
     .example{background:#fff;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin-bottom:16px;}
-    .example svg{max-width:100%;height:auto;display:block;margin-bottom:12px;}
     .example iframe{width:100%;min-height:560px;border:1px solid #e5e7eb;border-radius:10px;background:#fff;margin-bottom:12px;}
     .buttons{display:flex;gap:10px;flex-wrap:wrap;}
     button{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:6px 10px;font-size:14px;cursor:pointer;}


### PR DESCRIPTION
## Summary
- remove rendering of the stored SVG snapshot in the examples viewer so only the interactive iframe is shown
- clean up the unused CSS rule for static example SVGs

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c87c3784b883248df04413ba04a893