### PR TITLE
Add toggle to show expressions in Kvikkbilder

### DIFF
--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -97,6 +97,9 @@
           <label>Vis play-knapp
             <input id="cfg-showBtn" type="checkbox">
           </label>
+          <label>Vis regnestykke
+            <input id="cfg-show-expression" type="checkbox" checked>
+          </label>
           <label>Antall
             <input id="cfg-antall" type="number" min="1" value="9">
           </label>

--- a/kvikkbilder-monster.js
+++ b/kvikkbilder-monster.js
@@ -2,6 +2,7 @@
   const cfgAntall = document.getElementById('cfg-antall');
   const cfgDuration = document.getElementById('cfg-duration');
   const cfgShowBtn = document.getElementById('cfg-showBtn');
+  const cfgShowExpression = document.getElementById('cfg-show-expression');
   const patternContainer = document.getElementById('patternContainer');
   const playBtn = document.getElementById('playBtn');
   const expression = document.getElementById('expression');
@@ -205,19 +206,25 @@
 
     patternContainer.appendChild(svg);
     const factors=primeFactors(n).filter(x=>x>1);
-    expression.textContent=factors.length?`${factors.join(' × ')} = ${n}`:`${n}`;
+    expression.textContent=factors.length?`${factors.join(' · ')} = ${n}`:`${n}`;
+  }
+
+  function applyExpressionVisibility(){
+    if(!expression) return;
+    const enabled = !cfgShowExpression || cfgShowExpression.checked;
+    const playVisible = playBtn.style.display !== 'none';
+    expression.style.display = (enabled && !playVisible) ? 'block' : 'none';
   }
 
   function updateVisibility(){
     if(cfgShowBtn.checked){
       playBtn.style.display='flex';
       patternContainer.style.display='none';
-      expression.style.display='none';
     }else{
       playBtn.style.display='none';
       patternContainer.style.display='flex';
-      expression.style.display='block';
     }
+    applyExpressionVisibility();
   }
 
   cfgAntall.addEventListener('input',render);
@@ -225,13 +232,14 @@
     updateVisibility();
     if(!cfgShowBtn.checked) render();
   });
+  cfgShowExpression?.addEventListener('change', applyExpressionVisibility);
 
   playBtn.addEventListener('click',()=>{
     const duration=parseInt(cfgDuration.value,10)||0;
     render();
     playBtn.style.display='none';
     patternContainer.style.display='flex';
-    expression.style.display='block';
+    applyExpressionVisibility();
     setTimeout(()=>{
       updateVisibility();
     }, duration*1000);
@@ -246,6 +254,7 @@
   });
   updateVisibility();
   render();
+  applyExpressionVisibility();
 
   function svgToString(svgEl){
     const clone = svgEl.cloneNode(true);

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -110,6 +110,10 @@
               <option value="monster">Mønster</option>
             </select>
           </label>
+          <div class="checkbox-row">
+            <input id="cfg-show-expression" type="checkbox" checked>
+            <label for="cfg-show-expression">Vis regnestykke</label>
+          </div>
           <div id="klosserConfig">
             <label>Antall X
               <input id="cfg-antallX" type="number" min="1" value="5">

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -10,6 +10,7 @@
   const cfgDybde = document.getElementById('cfg-dybde');
   const cfgDurationKlosser = document.getElementById('cfg-duration-klosser');
   const cfgShowBtn = document.getElementById('cfg-showBtn');
+  const cfgShowExpression = document.getElementById('cfg-show-expression');
 
   const cfgAntall = document.getElementById('cfg-antall');
   const cfgDurationMonster = document.getElementById('cfg-duration-monster');
@@ -104,7 +105,8 @@
 
     const perFig = bredde * hoyde * dybde;
     const total = antallX * antallY * perFig;
-    expression.textContent = `${antallX} × ${antallY} × (${bredde} × ${hoyde} × ${dybde}) = ${antallX * antallY} × ${perFig} = ${total}`;
+    const dot = ' · ';
+    expression.textContent = `${antallX}${dot}${antallY}${dot}(${bredde}${dot}${hoyde}${dot}${dybde}) = ${antallX * antallY}${dot}${perFig} = ${total}`;
   }
 
   function primeFactors(n){
@@ -307,20 +309,26 @@
 
     patternContainer.appendChild(svg);
     const factors=primeFactors(n).filter(x=>x>1);
-    expression.textContent=factors.length?`${factors.join(' × ')} = ${n}`:`${n}`;
+    expression.textContent=factors.length?`${factors.join(' · ')} = ${n}`:`${n}`;
+  }
+
+  function applyExpressionVisibility(){
+    if(!expression) return;
+    const enabled = !cfgShowExpression || cfgShowExpression.checked;
+    const playVisible = playBtn.style.display !== 'none';
+    expression.style.display = (enabled && !playVisible) ? 'block' : 'none';
   }
 
   function updateVisibilityKlosser(){
     if(cfgShowBtn.checked){
       playBtn.style.display = 'flex';
       brickContainer.style.display = 'none';
-      expression.style.display = 'none';
     } else {
       playBtn.style.display = 'none';
       brickContainer.style.display = 'grid';
-      expression.style.display = 'block';
     }
     patternContainer.style.display='none';
+    applyExpressionVisibility();
   }
 
   function updateVisibilityMonster(){
@@ -328,12 +336,11 @@
     if(cfgShowBtnMonster.checked){
       playBtn.style.display='flex';
       patternContainer.style.display='none';
-      expression.style.display='none';
     } else {
       playBtn.style.display='none';
       patternContainer.style.display='flex';
-      expression.style.display='block';
     }
+    applyExpressionVisibility();
   }
 
   function updateType(){
@@ -363,6 +370,7 @@
   });
   cfgAntall.addEventListener('input', renderMonster);
   cfgType.addEventListener('change', updateType);
+  cfgShowExpression?.addEventListener('change', applyExpressionVisibility);
 
   playBtn.addEventListener('click', () => {
     if(cfgType.value==='klosser'){
@@ -370,7 +378,7 @@
       renderKlosser();
       playBtn.style.display = 'none';
       brickContainer.style.display = 'grid';
-      expression.style.display = 'block';
+      applyExpressionVisibility();
       setTimeout(() => {
         updateVisibilityKlosser();
       }, duration * 1000);
@@ -379,7 +387,7 @@
       renderMonster();
       playBtn.style.display='none';
       patternContainer.style.display='flex';
-      expression.style.display='block';
+      applyExpressionVisibility();
       setTimeout(()=>{
         updateVisibilityMonster();
       }, duration*1000);
@@ -446,6 +454,7 @@
 
   renderMonster();
   updateType();
+  applyExpressionVisibility();
   fetch('images/brick1.svg')
     .then(r=>r.text())
     .then(txt=>{


### PR DESCRIPTION
## Summary
- add a "Vis regnestykke" checkbox to Kvikkbilder and Kvikkbilder mønster
- update the rendering scripts to respect the toggle when showing expressions and switch to dot notation

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c88057a5b48324826dd08966acb16a