### PR TITLE
Improve kvikkbilder settings layout

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -49,6 +49,9 @@
     #expression{text-align:center;font-size:24px;font-weight:600;}
     label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     input[type="number"], select{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
+    .field-row{display:grid;gap:10px;}
+    .field-row.field-row--two{grid-template-columns:repeat(auto-fit,minmax(140px,1fr));}
+    .field-row.field-row--three{grid-template-columns:repeat(auto-fit,minmax(100px,1fr));}
     .checkbox-row{display:flex;align-items:center;gap:6px;}
     #playBtn{
       position:absolute;
@@ -111,21 +114,25 @@
             </select>
           </label>
           <div id="klosserConfig">
-            <label>Antall X
-              <input id="cfg-antallX" type="number" min="1" value="5">
-            </label>
-            <label>Antall Y
-              <input id="cfg-antallY" type="number" min="1" value="2">
-            </label>
-            <label>Bredde
-              <input id="cfg-bredde" type="number" min="1" value="2">
-            </label>
-            <label>Høyde
-              <input id="cfg-hoyde" type="number" min="1" value="3">
-            </label>
-            <label>Dybde
-              <input id="cfg-dybde" type="number" min="1" value="2">
-            </label>
+            <div class="field-row field-row--two">
+              <label>Antall X
+                <input id="cfg-antallX" type="number" min="1" value="5">
+              </label>
+              <label>Antall Y
+                <input id="cfg-antallY" type="number" min="1" value="2">
+              </label>
+            </div>
+            <div class="field-row field-row--three">
+              <label>Bredde
+                <input id="cfg-bredde" type="number" min="1" value="2">
+              </label>
+              <label>Høyde
+                <input id="cfg-hoyde" type="number" min="1" value="3">
+              </label>
+              <label>Dybde
+                <input id="cfg-dybde" type="number" min="1" value="2">
+              </label>
+            </div>
             <label>Vis i sekunder
               <input id="cfg-duration-klosser" type="number" min="1" value="3">
             </label>


### PR DESCRIPTION
## Summary
- group Antall X og Antall Y-innstillinger på samme rad i kortet for Kvikkbilder
- plasser Bredde, Høyde og Dybde i en egen rad ved hjelp av nye grid-hjelpeklasser

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c881e884608324bc387ec23f022bcf