### PR TITLE
Place Tenkeblokker settings panel to the right

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -15,7 +15,6 @@
     .wrap{max-width:1200px;margin:0 auto;}
     .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
-    .card--settings{grid-column:1 / -1;}
     @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;


### PR DESCRIPTION
## Summary
- let the settings card rely on the two-column grid so it stays to the right of the main view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c886e1af308324b5cd2181edd87b08