### PR TITLE
Add support for side-by-side kuler illustrations

### DIFF
--- a/kuler.html
+++ b/kuler.html
@@ -15,14 +15,18 @@
     .wrap{max-width:1200px;margin:0 auto;}
     .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
+    .figureGrid{display:grid;gap:var(--gap);grid-template-columns:repeat(2,minmax(0,1fr));align-items:start;}
+    .figurePanel{display:flex;flex-direction:column;gap:12px;align-items:center;}
+    .addFigureBtn{width:clamp(60px,15vw,120px);aspect-ratio:1;border:2px dashed #cfcfcf;border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;font-size:40px;color:#6b7280;cursor:pointer;justify-self:center;align-self:center;}
     @media(max-width:980px){.grid{grid-template-columns:1fr;}}
+    @media(max-width:720px){.figureGrid{grid-template-columns:1fr;}.addFigureBtn{width:clamp(60px,30vw,140px);}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
       box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
       display:flex;flex-direction:column;gap:10px;
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;}
+    .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;width:100%;max-width:460px;margin:0 auto;}
     .figure svg{width:100%;height:auto;display:block;touch-action:none;}
     .ctrlRow{display:flex;align-items:center;gap:6px;font-size:14px;}
     .ctrlRow button{border:1px solid #d1d5db;border-radius:6px;background:#fff;width:24px;height:24px;line-height:1;}
@@ -35,6 +39,9 @@
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
     .btn:active{transform:translateY(1px);}
     .toolbar select{border:1px solid #d1d5db;border-radius:10px;padding:6px 10px;font-size:14px;background:#fff;}
+    .controlsWrap{display:flex;flex-direction:column;gap:var(--gap);}
+    fieldset.bowlFieldset{border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;display:flex;flex-direction:column;gap:8px;}
+    fieldset.bowlFieldset legend{font-weight:600;font-size:13px;color:#374151;padding:0 4px;}
   </style>
   <link rel="stylesheet" href="split.css" />
 </head>
@@ -42,8 +49,18 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <div class="figure">
-          <svg id="bowlSVG" viewBox="0 0 500 300" role="img" aria-label="Bolle med kuler"></svg>
+        <div class="figureGrid">
+          <div id="panel1" class="figurePanel">
+            <div class="figure">
+              <svg id="bowlSVG1" viewBox="0 0 500 300" role="img" aria-label="Bolle med kuler"></svg>
+            </div>
+          </div>
+          <button id="addBowl" class="addFigureBtn" type="button" aria-label="Legg til illustrasjon">+</button>
+          <div id="panel2" class="figurePanel" style="display:none">
+            <div class="figure">
+              <svg id="bowlSVG2" viewBox="0 0 500 300" role="img" aria-label="Bolle med kuler"></svg>
+            </div>
+          </div>
         </div>
       </div>
       <div class="side">
@@ -57,13 +74,17 @@
         <div class="card">
           <h2>Eksporter</h2>
           <div class="toolbar">
-            <button id="downloadSVG" class="btn" type="button">Last ned SVG</button>
-            <button id="downloadPNG" class="btn" type="button">Last ned PNG</button>
+            <button id="downloadSVG1" class="btn" type="button">Last ned SVG</button>
+            <button id="downloadPNG1" class="btn" type="button">Last ned PNG</button>
+          </div>
+          <div id="exportToolbar2" class="toolbar" style="display:none">
+            <button id="downloadSVG2" class="btn" type="button">Last ned SVG</button>
+            <button id="downloadPNG2" class="btn" type="button">Last ned PNG</button>
           </div>
         </div>
         <div class="card">
           <h2>Innstillinger</h2>
-          <div id="controls"></div>
+          <div id="controls" class="controlsWrap"></div>
         </div>
       </div>
     </div>

--- a/kuler.js
+++ b/kuler.js
@@ -35,107 +35,391 @@ const ADV = {
 
 /* ============ DERIVERT KONFIG FOR RENDER (IKKE REDIGER) ============ */
 function makeCFG(){
-  const beadRadius = SIMPLE.beadRadius ?? ADV.beadRadius;
+  const globalRadius = SIMPLE.beadRadius ?? ADV.beadRadius;
+  const bowls = Array.isArray(SIMPLE.bowls) ? SIMPLE.bowls : [];
+  const cfgBowls = bowls.map(b => {
+    const colorsArr = [];
+    const counts = Array.isArray(b.colorCounts) ? b.colorCounts : [];
+    counts.forEach(cc => {
+      const col = ADV.assets.beads[cc.color];
+      const raw = cc?.count;
+      const count = Number.isFinite(raw) ? Math.max(0, Math.round(raw)) : 0;
+      if(col) for(let i=0; i<count; i++) colorsArr.push(col);
+    });
+    if(!colorsArr.length) colorsArr.push(...Object.values(ADV.assets.beads));
+    const radiusRaw = Number.isFinite(b?.beadRadius) ? b.beadRadius : globalRadius;
+    const beadRadius = Math.min(60, Math.max(5, radiusRaw ?? ADV.beadRadius));
+    return { colors: colorsArr, beadRadius };
+  });
+  if(!cfgBowls.length){
+    cfgBowls.push({
+      colors: Object.values(ADV.assets.beads),
+      beadRadius: Math.min(60, Math.max(5, globalRadius ?? ADV.beadRadius))
+    });
+  }
   return {
-    bowls: SIMPLE.bowls.map(b => {
-      const colors = [];
-      (b.colorCounts || []).forEach(cc => {
-        const col = ADV.assets.beads[cc.color];
-        if(col) for(let i=0;i<cc.count;i++) colors.push(col);
-      });
-      if(!colors.length) colors.push(...Object.values(ADV.assets.beads));
-      return { colors };
-    }),
-    beadRadius,
+    bowls: cfgBowls,
     beadGap: ADV.beadGap
   };
 }
 let CFG = makeCFG();
 
 /* ============ DOM & VIEWBOX ============ */
-const svg = document.getElementById("bowlSVG");
+const SVG_IDS = ["bowlSVG1", "bowlSVG2"];
 const VB_W = 500, VB_H = 300;
-svg.setAttribute("viewBox", `0 0 ${VB_W} ${VB_H}`);
+const figureViews = [];
 
-/* ============ LAG ============ */
-const gBowls = mk("g",{class:"bowls"});
-svg.appendChild(gBowls);
-
-/* ============ STATE ============ */
+/* ============ STATE & INIT ============ */
 const STATE = (window.STATE && typeof window.STATE === "object") ? window.STATE : {};
 window.STATE = STATE;
 if(!Array.isArray(STATE.bowls)) STATE.bowls = [];
 
-const bowls = [];
-const controls = document.getElementById("controls");
 const colors = Object.keys(ADV.assets.beads);
 const assetToColor = Object.entries(ADV.assets.beads).reduce((acc, [color, src]) => {
   acc[src] = color;
   return acc;
 }, {});
-const counts = {};
-const displays = {};
-let beadRadius = CFG.beadRadius;
-let sizeDisplay, sizeSlider;
-let dragBead = null;
-let dragOffX = 0, dragOffY = 0;
-let dragInfo = null;
-colors.forEach(color => {
-  const existing = (SIMPLE.bowls[0].colorCounts || []).find(cc => cc.color === color);
-  counts[color] = existing ? existing.count : 0;
-  const row = document.createElement("div");
-  row.className = "ctrlRow";
-  const label = document.createElement("span");
-  label.textContent = `${cap(color)} kuler`;
-  const minus = document.createElement("button");
-  minus.type = "button";
-  minus.textContent = "−";
-  const countSpan = document.createElement("span");
-  countSpan.className = "count";
-  countSpan.textContent = counts[color];
-  const plus = document.createElement("button");
-  plus.type = "button";
-  plus.textContent = "+";
-  minus.addEventListener("click", () => change(color, -1));
-  plus.addEventListener("click", () => change(color, 1));
-  row.append(label, minus, countSpan, plus);
-  controls.appendChild(row);
-  displays[color] = countSpan;
-});
+const controlsWrap = document.getElementById("controls");
+const addBtn = document.getElementById("addBowl");
+const panelEls = [document.getElementById("panel1"), document.getElementById("panel2")];
+const exportToolbar2 = document.getElementById("exportToolbar2");
 
-const sizeRow = document.createElement("div");
-sizeRow.className = "ctrlRow";
-const sizeLabel = document.createElement("span");
-sizeLabel.textContent = "Kulestørrelse";
-const sizeMinus = document.createElement("button");
-sizeMinus.type = "button";
-sizeMinus.textContent = "−";
-const sizeInput = document.createElement("input");
-sizeInput.type = "range";
-sizeInput.min = "5";
-sizeInput.max = "60";
-sizeInput.value = beadRadius;
-sizeInput.style.flex = "1";
-const sizeSpan = document.createElement("span");
-sizeSpan.className = "count";
-sizeSpan.textContent = beadRadius;
-const sizePlus = document.createElement("button");
-sizePlus.type = "button";
-sizePlus.textContent = "+";
-sizeMinus.addEventListener("click", () => changeSize(-2));
-sizePlus.addEventListener("click", () => changeSize(2));
-sizeInput.addEventListener("input", () => setSize(parseInt(sizeInput.value)));
-sizeRow.append(sizeLabel, sizeMinus, sizeInput, sizePlus, sizeSpan);
-controls.appendChild(sizeRow);
-sizeDisplay = sizeSpan;
-sizeSlider = sizeInput;
+if(!Array.isArray(SIMPLE.bowls)) SIMPLE.bowls = [];
+if(typeof STATE.figure2Visible !== "boolean"){
+  STATE.figure2Visible = SIMPLE.bowls.length > 1;
+}
+
+SVG_IDS.forEach((id, idx) => {
+  const svg = document.getElementById(id);
+  if(!svg) return;
+  svg.setAttribute("viewBox", `0 0 ${VB_W} ${VB_H}`);
+  svg.innerHTML = "";
+  const gBowls = mk("g", { class: "bowls" });
+  svg.appendChild(gBowls);
+  const fig = createFigure(idx, svg, gBowls);
+  figureViews[idx] = fig;
+});
 
 render();
 
-document.getElementById("downloadSVG").addEventListener("click", downloadSVG);
-document.getElementById("downloadPNG").addEventListener("click", downloadPNG);
+addBtn?.addEventListener("click", () => {
+  const first = ensureSimpleBowl(0);
+  const copyCounts = colors.map(color => {
+    const entry = Array.isArray(first?.colorCounts) ? first.colorCounts.find(cc => cc.color === color) : null;
+    const count = Number.isFinite(entry?.count) ? Math.max(0, Math.round(entry.count)) : 0;
+    return { color, count };
+  });
+  const radiusSource = Number.isFinite(first?.beadRadius) ? first.beadRadius : (SIMPLE.beadRadius ?? ADV.beadRadius);
+  SIMPLE.bowls[1] = { colorCounts: copyCounts, beadRadius: radiusSource };
+  STATE.figure2Visible = true;
+  render();
+});
+
+const downloadButtons = [
+  { svgBtn: document.getElementById("downloadSVG1"), pngBtn: document.getElementById("downloadPNG1"), idx: 0 },
+  { svgBtn: document.getElementById("downloadSVG2"), pngBtn: document.getElementById("downloadPNG2"), idx: 1 }
+];
+downloadButtons.forEach(({ svgBtn, pngBtn, idx }) => {
+  svgBtn?.addEventListener("click", () => downloadSvgFigure(idx));
+  pngBtn?.addEventListener("click", () => downloadPngFigure(idx));
+});
 
 /* ============ FUNKSJONER ============ */
+function createFigure(idx, svg, gBowls){
+  const fieldset = document.createElement("fieldset");
+  fieldset.className = "bowlFieldset";
+  const legend = document.createElement("legend");
+  legend.textContent = `Illustrasjon ${idx + 1}`;
+  fieldset.appendChild(legend);
+
+  const counts = {};
+  const displays = {};
+
+  colors.forEach(color => {
+    const row = document.createElement("div");
+    row.className = "ctrlRow";
+    const label = document.createElement("span");
+    label.textContent = `${cap(color)} kuler`;
+    const minus = document.createElement("button");
+    minus.type = "button";
+    minus.textContent = "−";
+    const countSpan = document.createElement("span");
+    countSpan.className = "count";
+    countSpan.textContent = "0";
+    const plus = document.createElement("button");
+    plus.type = "button";
+    plus.textContent = "+";
+    minus.addEventListener("click", () => changeCount(idx, color, -1));
+    plus.addEventListener("click", () => changeCount(idx, color, 1));
+    row.append(label, minus, countSpan, plus);
+    fieldset.appendChild(row);
+    displays[color] = countSpan;
+    counts[color] = 0;
+  });
+
+  const sizeRow = document.createElement("div");
+  sizeRow.className = "ctrlRow";
+  const sizeLabel = document.createElement("span");
+  sizeLabel.textContent = "Kulestørrelse";
+  const sizeMinus = document.createElement("button");
+  sizeMinus.type = "button";
+  sizeMinus.textContent = "−";
+  const sizeInput = document.createElement("input");
+  sizeInput.type = "range";
+  sizeInput.min = "5";
+  sizeInput.max = "60";
+  sizeInput.style.flex = "1";
+  const sizePlus = document.createElement("button");
+  sizePlus.type = "button";
+  sizePlus.textContent = "+";
+  const sizeSpan = document.createElement("span");
+  sizeSpan.className = "count";
+  sizeSpan.textContent = "0";
+  sizeMinus.addEventListener("click", () => adjustSize(idx, -2));
+  sizePlus.addEventListener("click", () => adjustSize(idx, 2));
+  sizeInput.addEventListener("input", () => setSize(idx, parseInt(sizeInput.value, 10)));
+  sizeRow.append(sizeLabel, sizeMinus, sizeInput, sizePlus, sizeSpan);
+  fieldset.appendChild(sizeRow);
+
+  controlsWrap?.appendChild(fieldset);
+
+  return {
+    idx,
+    svg,
+    gBowls,
+    fieldset,
+    counts,
+    displays,
+    sizeDisplay: sizeSpan,
+    sizeSlider: sizeInput,
+    beadRadius: Math.min(60, Math.max(5, SIMPLE.beadRadius ?? ADV.beadRadius)),
+    renderRadius: Math.min(60, Math.max(5, SIMPLE.beadRadius ?? ADV.beadRadius))
+  };
+}
+
+function ensureSimpleBowl(idx){
+  if(!Array.isArray(SIMPLE.bowls)) SIMPLE.bowls = [];
+  const globalRadius = SIMPLE.beadRadius ?? ADV.beadRadius;
+  let bowl = SIMPLE.bowls[idx];
+  if(!bowl || typeof bowl !== "object"){
+    const template = idx > 0 ? ensureSimpleBowl(0) : null;
+    const counts = new Map();
+    if(template && Array.isArray(template.colorCounts)){
+      template.colorCounts.forEach(cc => {
+        const count = Number.isFinite(cc?.count) ? Math.max(0, Math.round(cc.count)) : 0;
+        counts.set(cc.color, count);
+      });
+    }
+    const colorCounts = colors.map(color => ({ color, count: counts.get(color) ?? 0 }));
+    const radiusSource = Number.isFinite(template?.beadRadius) ? template.beadRadius : globalRadius;
+    bowl = { colorCounts, beadRadius: radiusSource };
+    SIMPLE.bowls[idx] = bowl;
+  }else{
+    const counts = new Map();
+    (bowl.colorCounts || []).forEach(cc => {
+      const count = Number.isFinite(cc?.count) ? Math.max(0, Math.round(cc.count)) : 0;
+      counts.set(cc.color, count);
+    });
+    bowl.colorCounts = colors.map(color => ({ color, count: counts.get(color) ?? 0 }));
+    const radiusSource = Number.isFinite(bowl.beadRadius) ? bowl.beadRadius : globalRadius;
+    bowl.beadRadius = Math.min(60, Math.max(5, radiusSource));
+  }
+  return bowl;
+}
+
+function applySimpleToFigures(){
+  figureViews.forEach(fig => {
+    if(!fig) return;
+    if(fig.idx > 0 && !STATE.figure2Visible && !SIMPLE.bowls[fig.idx]){
+      const first = ensureSimpleBowl(0);
+      const radius = Math.min(60, Math.max(5, Number.isFinite(first?.beadRadius) ? first.beadRadius : (SIMPLE.beadRadius ?? ADV.beadRadius)));
+      fig.beadRadius = radius;
+      fig.renderRadius = radius;
+      if(fig.sizeDisplay) fig.sizeDisplay.textContent = radius;
+      if(fig.sizeSlider) fig.sizeSlider.value = String(radius);
+      colors.forEach(color => {
+        const entry = Array.isArray(first?.colorCounts) ? first.colorCounts.find(cc => cc.color === color) : null;
+        const count = Number.isFinite(entry?.count) ? Math.max(0, Math.round(entry.count)) : 0;
+        fig.counts[color] = count;
+        if(fig.displays[color]) fig.displays[color].textContent = String(count);
+      });
+      return;
+    }
+    const bowl = ensureSimpleBowl(fig.idx);
+    const radius = Math.min(60, Math.max(5, Number.isFinite(bowl?.beadRadius) ? bowl.beadRadius : (SIMPLE.beadRadius ?? ADV.beadRadius)));
+    fig.beadRadius = radius;
+    fig.renderRadius = radius;
+    if(fig.sizeDisplay) fig.sizeDisplay.textContent = radius;
+    if(fig.sizeSlider) fig.sizeSlider.value = String(radius);
+    colors.forEach(color => {
+      const entry = bowl.colorCounts.find(cc => cc.color === color);
+      const count = Number.isFinite(entry?.count) ? Math.max(0, Math.round(entry.count)) : 0;
+      fig.counts[color] = count;
+      if(fig.displays[color]) fig.displays[color].textContent = String(count);
+    });
+  });
+}
+
+function syncSimpleFromFigures(){
+  figureViews.forEach(fig => {
+    if(!fig) return;
+    if(fig.idx > 0 && !STATE.figure2Visible) return;
+    const bowl = ensureSimpleBowl(fig.idx);
+    bowl.colorCounts = colors.map(color => {
+      const value = Number.isFinite(fig.counts[color]) ? Math.max(0, Math.round(fig.counts[color])) : 0;
+      return { color, count: value };
+    });
+    bowl.beadRadius = Math.min(60, Math.max(5, fig.beadRadius ?? bowl.beadRadius ?? SIMPLE.beadRadius ?? ADV.beadRadius));
+  });
+  if(figureViews[0]) SIMPLE.beadRadius = figureViews[0].beadRadius;
+}
+
+function changeCount(idx, color, delta){
+  const fig = figureViews[idx];
+  if(!fig) return;
+  const current = Number.isFinite(fig.counts[color]) ? fig.counts[color] : 0;
+  const next = Math.max(0, current + delta);
+  fig.counts[color] = next;
+  if(fig.displays[color]) fig.displays[color].textContent = String(next);
+  updateConfig();
+}
+
+function adjustSize(idx, delta){
+  const fig = figureViews[idx];
+  if(!fig) return;
+  setSize(idx, fig.beadRadius + delta);
+}
+
+function setSize(idx, value){
+  const fig = figureViews[idx];
+  if(!fig) return;
+  const next = Math.min(60, Math.max(5, Number.isFinite(value) ? value : fig.beadRadius));
+  fig.beadRadius = next;
+  if(fig.sizeDisplay) fig.sizeDisplay.textContent = next;
+  if(fig.sizeSlider && fig.sizeSlider.value !== String(next)) fig.sizeSlider.value = String(next);
+  updateConfig();
+}
+
+function updateConfig(){
+  syncSimpleFromFigures();
+  render();
+}
+
+function render(){
+  if(typeof STATE.figure2Visible !== "boolean"){
+    STATE.figure2Visible = SIMPLE.bowls.length > 1;
+  }
+  CFG = makeCFG();
+  applySimpleToFigures();
+  if(STATE.bowls.length > CFG.bowls.length) STATE.bowls.length = CFG.bowls.length;
+  figureViews.forEach(fig => renderFigure(fig));
+  applyFigureVisibility();
+}
+
+function renderFigure(fig){
+  if(!fig || !fig.svg) return;
+  const idx = fig.idx;
+  const cfg = CFG.bowls[idx];
+  fig.gBowls.innerHTML = "";
+  if(!cfg) return;
+  const beadRadius = cfg.beadRadius ?? (fig.beadRadius ?? SIMPLE.beadRadius ?? ADV.beadRadius);
+  fig.renderRadius = beadRadius;
+  const beadD = beadRadius * 2;
+  const g = mk("g", { class: "bowl" });
+  const midX = VB_W / 2;
+  const bowlSvgW = 273;
+  const bowlSvgH = 251;
+  const rimSvgY = 41;
+  const bowlScale = VB_H / bowlSvgH;
+  const bowlWidth = bowlSvgW * bowlScale;
+  const rimY = rimSvgY * bowlScale;
+  const bowlDepth = VB_H - rimY;
+  const bowlImg = mk("image", {
+    href: "images/bowl.svg",
+    x: 0,
+    y: 0,
+    width: VB_W,
+    height: VB_H,
+    preserveAspectRatio: "xMidYMax meet"
+  });
+
+  const gBeads = mk("g", { class: "beads" });
+  const nBeads = cfg.colors.length;
+  const bowlState = getBowlState(idx);
+  const colorPositions = bowlState.byColor;
+  const colorUsage = {};
+  const placed = [];
+  const cx = midX;
+  const cy = rimY + bowlDepth;
+  const rx = bowlWidth / 2 - beadRadius;
+  const ry = bowlDepth - beadRadius;
+  const minX = VB_W * 0.3;
+  const maxX = VB_W * 0.7;
+  const minY = VB_H * 0.5;
+  const maxY = VB_H * 0.9;
+  function randPos(){
+    let candidate = null;
+    for(let tries=0; tries<1000; tries++){
+      const x = minX + Math.random() * (maxX - minX);
+      const y = minY + Math.random() * (maxY - minY);
+      if(((x - cx) ** 2) / (rx ** 2) + ((y - cy) ** 2) / (ry ** 2) > 1) continue;
+      candidate = { x, y };
+      const collision = placed.some(p => (p.x - candidate.x) ** 2 + (p.y - candidate.y) ** 2 < (beadD + CFG.beadGap) ** 2);
+      if(!collision) return candidate;
+    }
+    return candidate || { x: cx, y: rimY + bowlDepth * 0.6 };
+  }
+  for(let i=0; i<nBeads; i++){
+    const src = cfg.colors[i % cfg.colors.length];
+    const colorKey = assetToColor[src] || src;
+    const useIdx = colorUsage[colorKey] ?? 0;
+    const arr = Array.isArray(colorPositions[colorKey]) ? colorPositions[colorKey] : (colorPositions[colorKey] = []);
+    let pos = arr[useIdx];
+    if(!pos || !Number.isFinite(pos.x) || !Number.isFinite(pos.y)){
+      pos = randPos();
+      arr[useIdx] = pos;
+    }
+    placed.push(pos);
+    colorUsage[colorKey] = useIdx + 1;
+    const bead = mk("image", {
+      href: src,
+      x: pos.x - beadRadius,
+      y: pos.y - beadRadius,
+      width: beadD,
+      height: beadD,
+      class: "bead beadShadow"
+    });
+    bead.dataset.figure = String(idx);
+    bead.dataset.bowl = String(idx);
+    bead.dataset.color = colorKey;
+    bead.dataset.colorIndex = String(useIdx);
+    bead.addEventListener("pointerdown", startDrag);
+    gBeads.appendChild(bead);
+  }
+
+  Object.keys(colorPositions).forEach(key => {
+    const used = colorUsage[key] ?? 0;
+    if(!Array.isArray(colorPositions[key])){
+      colorPositions[key] = [];
+    }else if(colorPositions[key].length > used){
+      colorPositions[key].length = used;
+    }
+  });
+
+  g.appendChild(bowlImg);
+  g.appendChild(gBeads);
+  fig.gBowls.appendChild(g);
+}
+
+function applyFigureVisibility(){
+  const secondExists = !!figureViews[1];
+  const showSecond = !!STATE.figure2Visible && secondExists;
+  if(addBtn) addBtn.style.display = (showSecond || !secondExists) ? "none" : "";
+  if(panelEls[1]) panelEls[1].style.display = showSecond ? "" : "none";
+  if(exportToolbar2) exportToolbar2.style.display = showSecond ? "" : "none";
+  if(figureViews[1]?.fieldset) figureViews[1].fieldset.style.display = showSecond ? "" : "none";
+}
+
 function getBowlState(idx){
   if(!STATE.bowls[idx] || typeof STATE.bowls[idx] !== "object" || Array.isArray(STATE.bowls[idx])){
     STATE.bowls[idx] = {};
@@ -147,220 +431,98 @@ function getBowlState(idx){
   return bowlState;
 }
 
-function render(){
-  gBowls.innerHTML = "";
-  bowls.length = 0;
-  if(STATE.bowls.length > CFG.bowls.length) STATE.bowls.length = CFG.bowls.length;
-  CFG.bowls.forEach((bCfg, idx) => {
-    const g = mk("g", {class:"bowl"});
-    const midX = VB_W / 2;
-    const bowlSvgW = 273;
-    const bowlSvgH = 251;
-    const rimSvgY = 41;
-    const bowlScale = VB_H / bowlSvgH;
-    const bowlWidth = bowlSvgW * bowlScale;
-    const rimY = rimSvgY * bowlScale;
-    const bowlDepth = VB_H - rimY;
-    const bowlImg = mk("image", {
-      href: "images/bowl.svg",
-      x: 0,
-      y: 0,
-      width: VB_W,
-      height: VB_H,
-      preserveAspectRatio: "xMidYMax meet"
-    });
-
-    const gBeads = mk("g", {class:"beads"});
-    const nBeads = bCfg.colors.length;
-    const beadD = CFG.beadRadius * 2;
-    const bowlState = getBowlState(idx);
-    const colorPositions = bowlState.byColor;
-    const colorUsage = {};
-    const placed = [];
-    const cx = midX;
-    const cy = rimY + bowlDepth;
-    const rx = bowlWidth / 2 - CFG.beadRadius;
-    const ry = bowlDepth - CFG.beadRadius;
-    const minX = VB_W * 0.3;
-    const maxX = VB_W * 0.7;
-    const minY = VB_H * 0.5;
-    const maxY = VB_H * 0.9;
-    function randPos(){
-      let candidate = null;
-      for(let tries=0; tries<1000; tries++){
-        const x = minX + Math.random() * (maxX - minX);
-        const y = minY + Math.random() * (maxY - minY);
-        if(((x - cx) ** 2) / (rx ** 2) + ((y - cy) ** 2) / (ry ** 2) > 1) continue;
-        candidate = { x, y };
-        const collision = placed.some(p => (p.x - candidate.x) ** 2 + (p.y - candidate.y) ** 2 < (beadD + CFG.beadGap) ** 2);
-        if(!collision) return candidate;
-      }
-      return candidate || { x: cx, y: rimY + bowlDepth * 0.6 };
-    }
-    for(let i=0;i<nBeads;i++){
-      const src = bCfg.colors[i % bCfg.colors.length];
-      const colorKey = assetToColor[src] || src;
-      const useIdx = colorUsage[colorKey] ?? 0;
-      const arr = Array.isArray(colorPositions[colorKey]) ? colorPositions[colorKey] : (colorPositions[colorKey] = []);
-      let pos = arr[useIdx];
-      if(!pos || !Number.isFinite(pos.x) || !Number.isFinite(pos.y)){
-        pos = randPos();
-        arr[useIdx] = pos;
-      }
-      placed.push(pos);
-      colorUsage[colorKey] = useIdx + 1;
-      const bead = mk("image", {
-        href: src,
-        x: pos.x - CFG.beadRadius,
-        y: pos.y - CFG.beadRadius,
-        width: beadD,
-        height: beadD,
-        class: "bead beadShadow"
-      });
-      bead.dataset.bowl = String(idx);
-      bead.dataset.color = colorKey;
-      bead.dataset.colorIndex = String(useIdx);
-      bead.addEventListener("pointerdown", startDrag);
-      gBeads.appendChild(bead);
-    }
-
-    Object.keys(colorPositions).forEach(key => {
-      const used = colorUsage[key] ?? 0;
-      if(!Array.isArray(colorPositions[key])){
-        colorPositions[key] = [];
-      }else if(colorPositions[key].length > used){
-        colorPositions[key].length = used;
-      }
-    });
-
-    g.appendChild(bowlImg);
-    g.appendChild(gBeads);
-    gBowls.appendChild(g);
-    bowls.push({group:g, beads:gBeads, cfg:bCfg});
-  });
-}
-
-function change(color, delta){
-  counts[color] = Math.max(0, counts[color] + delta);
-  displays[color].textContent = counts[color];
-  updateConfig();
-}
-
-function changeSize(delta){
-    setSize(beadRadius + delta);
-  }
-
-function setSize(value){
-    beadRadius = Math.max(5, value);
-    sizeDisplay.textContent = beadRadius;
-    if(sizeSlider) sizeSlider.value = beadRadius;
-    updateConfig();
-  }
-
-function updateConfig(){
-    SIMPLE.bowls[0].colorCounts = colors.map(c => ({ color: c, count: counts[c] }));
-    SIMPLE.beadRadius = beadRadius;
-    CFG = makeCFG();
-    render();
-  }
+let dragState = null;
 
 function startDrag(e){
-  dragBead = e.target;
-  const bowlIdx = Number.parseInt(dragBead.dataset.bowl, 10);
-  const colorIdx = Number.parseInt(dragBead.dataset.colorIndex, 10);
-  const colorKey = dragBead.dataset.color;
-  dragInfo = {
+  const bead = e.target;
+  if(!bead || typeof bead.getAttribute !== "function") return;
+  const figIdx = Number.parseInt(bead.dataset.figure, 10);
+  const fig = figureViews[figIdx];
+  if(!fig || !fig.svg) return;
+  const bowlIdx = Number.parseInt(bead.dataset.bowl, 10);
+  const colorIdx = Number.parseInt(bead.dataset.colorIndex, 10);
+  const colorKey = bead.dataset.color;
+  const info = {
     bowlIdx: Number.isNaN(bowlIdx) ? null : bowlIdx,
     colorKey: typeof colorKey === "string" && colorKey ? colorKey : null,
     colorIndex: Number.isNaN(colorIdx) ? null : colorIdx
   };
-  const pt = svgPoint(e);
-  const x = parseFloat(dragBead.getAttribute("x"));
-  const y = parseFloat(dragBead.getAttribute("y"));
-  dragOffX = pt.x - x;
-  dragOffY = pt.y - y;
-  svg.addEventListener("pointermove", onDrag);
-  svg.addEventListener("pointerup", endDrag);
-  svg.addEventListener("pointercancel", endDrag);
-  try{svg.setPointerCapture(e.pointerId);}catch(_){}
+  const pt = svgPoint(fig.svg, e);
+  const x = parseFloat(bead.getAttribute("x"));
+  const y = parseFloat(bead.getAttribute("y"));
+  const offsetX = pt.x - x;
+  const offsetY = pt.y - y;
+  dragState = { bead, fig, info, offsetX, offsetY, pointerId: e.pointerId };
+  fig.svg.addEventListener("pointermove", onDrag);
+  fig.svg.addEventListener("pointerup", endDrag);
+  fig.svg.addEventListener("pointercancel", endDrag);
+  try{ fig.svg.setPointerCapture(e.pointerId); }catch(_){ }
 }
 
 function onDrag(e){
-  if(!dragBead) return;
-  const pt = svgPoint(e);
-  dragBead.setAttribute("x", pt.x - dragOffX);
-  dragBead.setAttribute("y", pt.y - dragOffY);
+  if(!dragState) return;
+  const { bead, fig, offsetX, offsetY } = dragState;
+  const pt = svgPoint(fig.svg, e);
+  bead.setAttribute("x", pt.x - offsetX);
+  bead.setAttribute("y", pt.y - offsetY);
   storeDragPosition();
 }
 
 function endDrag(e){
-  svg.removeEventListener("pointermove", onDrag);
-  svg.removeEventListener("pointerup", endDrag);
-  svg.removeEventListener("pointercancel", endDrag);
-  try{svg.releasePointerCapture(e.pointerId);}catch(_){}
+  if(!dragState) return;
+  const { fig, pointerId } = dragState;
+  fig.svg.removeEventListener("pointermove", onDrag);
+  fig.svg.removeEventListener("pointerup", endDrag);
+  fig.svg.removeEventListener("pointercancel", endDrag);
+  try{ fig.svg.releasePointerCapture(pointerId); }catch(_){ }
   storeDragPosition();
-  dragBead = null;
-  dragInfo = null;
+  dragState = null;
 }
 
 function storeDragPosition(){
-  if(!dragBead || !dragInfo) return;
-  const { bowlIdx, colorKey, colorIndex } = dragInfo;
+  if(!dragState) return;
+  const { bead, info, fig } = dragState;
+  const { bowlIdx, colorKey, colorIndex } = info;
   if(bowlIdx == null || colorKey == null || colorIndex == null) return;
-  const x = parseFloat(dragBead.getAttribute("x"));
-  const y = parseFloat(dragBead.getAttribute("y"));
+  const x = parseFloat(bead.getAttribute("x"));
+  const y = parseFloat(bead.getAttribute("y"));
   if(!Number.isFinite(x) || !Number.isFinite(y)) return;
   const bowlState = getBowlState(bowlIdx);
   const colorPositions = bowlState.byColor;
   const arr = Array.isArray(colorPositions[colorKey]) ? colorPositions[colorKey] : (colorPositions[colorKey] = []);
-  arr[colorIndex] = { x: x + CFG.beadRadius, y: y + CFG.beadRadius };
+  const radius = fig.renderRadius ?? fig.beadRadius ?? (SIMPLE.beadRadius ?? ADV.beadRadius);
+  arr[colorIndex] = { x: x + radius, y: y + radius };
 }
 
-function svgPoint(evt){
-  const p = svg.createSVGPoint();
+function svgPoint(svgEl, evt){
+  const p = svgEl.createSVGPoint();
   p.x = evt.clientX;
   p.y = evt.clientY;
-  return p.matrixTransform(svg.getScreenCTM().inverse());
+  return p.matrixTransform(svgEl.getScreenCTM().inverse());
 }
 
-/* ===== helpers ===== */
-function mk(n,attrs={}){ const e=document.createElementNS("http://www.w3.org/2000/svg",n);
-  for(const [k,v] of Object.entries(attrs)) e.setAttribute(k,v); return e; }
-function cap(s){ return s[0].toUpperCase()+s.slice(1); }
-
-async function inlineImages(svgEl){
-  const imgs = svgEl.querySelectorAll("image");
-  await Promise.all(Array.from(imgs).map(async img => {
-    const src = img.getAttribute("href");
-    const res = await fetch(src);
-    const blob = await res.blob();
-    const dataUrl = await new Promise(res => {
-      const reader = new FileReader();
-      reader.onload = () => res(reader.result);
-      reader.readAsDataURL(blob);
-    });
-    img.setAttribute("href", dataUrl);
-  }));
-}
-
-async function downloadSVG(){
-  const clone = svg.cloneNode(true);
+async function downloadSvgFigure(idx){
+  const fig = figureViews[idx];
+  if(!fig || !fig.svg) return;
+  const clone = fig.svg.cloneNode(true);
   await inlineImages(clone);
   const data = new XMLSerializer().serializeToString(clone);
-  const blob = new Blob([data], {type:"image/svg+xml"});
+  const blob = new Blob([data], { type: "image/svg+xml" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = "kuler.svg";
+  a.download = `kuler${idx + 1}.svg`;
   a.click();
   URL.revokeObjectURL(url);
 }
 
-async function downloadPNG(){
-  const clone = svg.cloneNode(true);
+async function downloadPngFigure(idx){
+  const fig = figureViews[idx];
+  if(!fig || !fig.svg) return;
+  const clone = fig.svg.cloneNode(true);
   await inlineImages(clone);
   const data = new XMLSerializer().serializeToString(clone);
-  const svgBlob = new Blob([data], {type:"image/svg+xml"});
+  const svgBlob = new Blob([data], { type: "image/svg+xml" });
   const url = URL.createObjectURL(svgBlob);
   const img = new Image();
   img.onload = () => {
@@ -371,13 +533,40 @@ async function downloadPNG(){
     ctx.drawImage(img, 0, 0);
     URL.revokeObjectURL(url);
     canvas.toBlob(blob => {
+      if(!blob) return;
       const pngUrl = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = pngUrl;
-      a.download = "kuler.png";
+      a.download = `kuler${idx + 1}.png`;
       a.click();
       URL.revokeObjectURL(pngUrl);
     });
   };
   img.src = url;
+}
+
+/* ===== helpers ===== */
+function mk(n, attrs = {}){
+  const e = document.createElementNS("http://www.w3.org/2000/svg", n);
+  for(const [k, v] of Object.entries(attrs)) e.setAttribute(k, v);
+  return e;
+}
+function cap(s){
+  return s[0].toUpperCase() + s.slice(1);
+}
+
+async function inlineImages(svgEl){
+  const imgs = svgEl.querySelectorAll("image");
+  await Promise.all(Array.from(imgs).map(async img => {
+    const src = img.getAttribute("href");
+    if(!src) return;
+    const res = await fetch(src);
+    const blob = await res.blob();
+    const dataUrl = await new Promise(resolve => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.readAsDataURL(blob);
+    });
+    img.setAttribute("href", dataUrl);
+  }));
 }


### PR DESCRIPTION
## Summary
- add a second optional bowl panel with a plus button and matching export controls
- refactor kuler controls and rendering to manage counts and bead size per illustration
- update dragging and download logic to work with multiple figures

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68c88a0b454883248f759c1f768ae7c2