### PR TITLE
Improve curve label legibility

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -79,7 +79,7 @@ const ADV = {
     fontSize: 16,
     layer: 30,
     fractions: [0.2, 0.8, 0.6, 0.4],
-    gapPx: 20,
+    gapPx: 30,
     plate: { paddingPx: 4, fill: '#fff', opacity: 0.6, radiusPx: 4 },
     marginFracX: 0.04,
     marginFracY: 0.04
@@ -620,6 +620,10 @@ function ensurePlateFor(label){
   });
   label._plate={p1,p2,p3,p4};
 }
+function ensureLabelFront(label){
+  const node = label && label.rendNode;
+  if(node && node.parentNode){ node.parentNode.appendChild(node); }
+}
 function updatePlate(label){
   if(!label._plate) return;
   const [xmin,ymax,xmax,ymin]=brd.getBoundingBox();
@@ -725,6 +729,7 @@ function makeSmartCurveLabel(g, idx, text){
     label.moveTo(best.pos);
     label.setAttribute({anchorX: best.slope>=0?'left':'right'});
     updatePlate(label);
+    ensureLabelFront(label);
   }
   position();
   brd.on('boundingbox', position);


### PR DESCRIPTION
## Summary
- increase the offset used when positioning curve labels so that text stays clear of the graph
- ensure curve-label text nodes are moved to the top of the SVG stack so the text renders above the translucent plate

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8f9bbcf44832496566e20955e3e56