### PR TITLE
Reduce add-figure button footprint

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -27,7 +27,7 @@
     }
     .figurePanel{display:grid;place-items:center;gap:10px;}
     .addFigureBtn{
-      width:clamp(60px,15vw,120px);
+      width:clamp(30px,7.5vw,60px);
       aspect-ratio:1;
       border:2px dashed #cfcfcf;
       border-radius:10px;
@@ -35,7 +35,7 @@
       display:flex;
       align-items:center;
       justify-content:center;
-      font-size:40px;
+      font-size:20px;
       color:#6b7280;
       cursor:pointer;
       justify-self:center;

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -69,8 +69,8 @@
       min-height:48px;
     }
     .addFigureBtn {
-      flex:0 0 clamp(72px,calc(var(--panel-min,220px)*0.7),140px);
-      width:min(100%,clamp(72px,calc(var(--panel-min,220px)*0.7),140px));
+      flex:0 0 clamp(36px,calc(var(--panel-min,220px)*0.35),70px);
+      width:min(100%,clamp(36px,calc(var(--panel-min,220px)*0.35),70px));
       aspect-ratio:1;
       border:2px dashed #cfcfcf;
       border-radius:10px;
@@ -78,7 +78,7 @@
       display:flex;
       align-items:center;
       justify-content:center;
-      font-size:40px;
+      font-size:20px;
       color:#6b7280;
       cursor:pointer;
       justify-self:center;

--- a/figurtall.html
+++ b/figurtall.html
@@ -33,7 +33,7 @@
       min-width:0;
     }
     .addFigureBtn{
-      width:min(100%,clamp(72px,calc(var(--panel-min,220px)*0.7),140px));
+      width:min(100%,clamp(36px,calc(var(--panel-min,220px)*0.35),70px));
       aspect-ratio:1;
       border:2px dashed #cfcfcf;
       border-radius:10px;
@@ -41,7 +41,7 @@
       display:flex;
       align-items:center;
       justify-content:center;
-      font-size:40px;
+      font-size:20px;
       color:#6b7280;
       cursor:pointer;
       justify-self:center;

--- a/kuler.html
+++ b/kuler.html
@@ -17,9 +17,9 @@
     .side{display:flex;flex-direction:column;gap:var(--gap);}
     .figureGrid{display:grid;gap:var(--gap);grid-template-columns:repeat(2,minmax(0,1fr));align-items:start;}
     .figurePanel{display:flex;flex-direction:column;gap:12px;align-items:center;}
-    .addFigureBtn{width:clamp(60px,15vw,120px);aspect-ratio:1;border:2px dashed #cfcfcf;border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;font-size:40px;color:#6b7280;cursor:pointer;justify-self:center;align-self:center;}
+    .addFigureBtn{width:clamp(30px,7.5vw,60px);aspect-ratio:1;border:2px dashed #cfcfcf;border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;font-size:20px;color:#6b7280;cursor:pointer;justify-self:center;align-self:center;}
     @media(max-width:980px){.grid{grid-template-columns:1fr;}}
-    @media(max-width:720px){.figureGrid{grid-template-columns:1fr;}.addFigureBtn{width:clamp(60px,30vw,140px);}}
+    @media(max-width:720px){.figureGrid{grid-template-columns:1fr;}.addFigureBtn{width:clamp(30px,15vw,70px);}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
       box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -50,7 +50,7 @@
       align-items:start;
     }
     .addFigureBtn{
-      width:clamp(60px,15vw,120px);
+      width:clamp(30px,7.5vw,60px);
       aspect-ratio:1;
       border:2px dashed #cfcfcf;
       border-radius:10px;
@@ -58,7 +58,7 @@
       display:flex;
       align-items:center;
       justify-content:center;
-      font-size:40px;
+      font-size:20px;
       color:#6b7280;
       cursor:pointer;
       justify-self:center;


### PR DESCRIPTION
## Summary
- reduce the "legg til figur" button dimensions across the visualizations so a single figure has more space
- keep responsive clamp values so the controls continue to scale on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8fa4d17008324a2bfe72e081fe153