### PR TITLE
Improve diagram settings layout for data series

### DIFF
--- a/diagram.css
+++ b/diagram.css
@@ -33,8 +33,15 @@ body {
 .settings { display: flex; flex-direction: column; gap: 8px; }
 .settings label { display: flex; flex-direction: column; font-size: 13px; color: #4b5563; }
 .settings input, .settings select { padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 10px; font-size: 14px; background: #fff; width: 100%; }
+.settings fieldset { border: 1px solid #e5e7eb; border-radius: 10px; padding: 10px; margin: 0; display: flex; flex-direction: column; gap: 10px; }
+.settings legend { font-weight: 600; font-size: 13px; color: #374151; padding: 0 4px; }
 .settings-row { display: flex; gap: 8px; }
 .settings-row label { flex: 1; }
+.series-settings { display: flex; flex-wrap: wrap; gap: 10px; align-items: stretch; }
+.series-settings fieldset { flex: 1 1 220px; min-width: 200px; }
+.series-settings .addFigureBtn { width: clamp(40px, 8vw, 60px); aspect-ratio: 1; border: 2px dashed #cfcfcf; border-radius: 10px; background: #fff; display: flex; align-items: center; justify-content: center; font-size: 20px; color: #6b7280; cursor: pointer; align-self: center; }
+.series-settings .addFigureBtn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
+.series-settings .addFigureBtn:active { transform: translateY(1px); }
 #chartTitle { text-align: center; font-size: 20px; margin: 0 0 6px; }
 
 /* Akser og rutenett */

--- a/diagram.js
+++ b/diagram.js
@@ -71,6 +71,10 @@ let lastFocusIndex = null;
 initFromCfg();
 
 function initFromCfg(){
+  const hasSeries2Config = (Array.isArray(CFG.start2) && CFG.start2.length > 0)
+    || (Array.isArray(CFG.answer2) && CFG.answer2.length > 0)
+    || (typeof CFG.series2 === 'string' && CFG.series2.trim().length > 0);
+  series2Enabled = hasSeries2Config;
   values = CFG.start.slice();
   values2 = series2Enabled && CFG.start2 ? CFG.start2.slice() : null;
   seriesNames = [CFG.series1 || '', series2Enabled ? CFG.series2 || '' : ''];

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -49,77 +49,74 @@
         <div class="card">
           <h2>Innstillinger</h2>
           <div class="settings">
-          <label>Type
-            <select id="cfgType">
-              <option value="bar" selected>Stolpe</option>
-              <option value="line">Linje</option>
-              <option value="grouped">Grupperte stolper</option>
-              <option value="stacked">Stablede stolper</option>
-            </select>
-          </label>
-          <label>Overskrift
-            <input id="cfgTitle" type="text" value="Favorittidretter i 5B">
-          </label>
-          <div class="settings-row">
-            <label>Etiketter (kommaseparert)
-              <input id="cfgLabels" type="text" value="Klatring,Fotball,Håndball,Basket,Tennis,Bowling">
+          <fieldset>
+            <legend>Diagram</legend>
+            <label>Type
+              <select id="cfgType">
+                <option value="bar" selected>Stolpe</option>
+                <option value="line">Linje</option>
+                <option value="grouped">Grupperte stolper</option>
+                <option value="stacked">Stablede stolper</option>
+              </select>
             </label>
-            <label>Fjern håndtak (0/1, kommaseparert)
-              <input id="cfgLocked" type="text" value="">
+            <label>Overskrift
+              <input id="cfgTitle" type="text" value="Favorittidretter i 5B">
             </label>
-          </div>
-          <div class="settings-row">
-            <label>Serienavn 1
-              <input id="cfgSeries1" type="text" value="">
-            </label>
-          </div>
-          <div class="settings-row">
-            <label>Startverdier 1
-              <input id="cfgStart" type="text" value="6,7,3,5,8,2">
-            </label>
-          </div>
-          <div class="settings-row">
-            <label>Fasitverdier 1
-              <input id="cfgAnswer" type="text" value="6,7,3,5,8,2">
-            </label>
-          </div>
-          <div class="settings-row">
-            <button id="addSeries" class="btn" type="button" aria-label="Legg til dataserie">+</button>
-          </div>
-          <div id="series2Fields" style="display:none">
             <div class="settings-row">
-              <label>Serienavn 2
+              <label>Etiketter (kommaseparert)
+                <input id="cfgLabels" type="text" value="Klatring,Fotball,Håndball,Basket,Tennis,Bowling">
+              </label>
+              <label>Fjern håndtak (0/1, kommaseparert)
+                <input id="cfgLocked" type="text" value="">
+              </label>
+            </div>
+            <div class="settings-row">
+              <label>Maks y (valgfritt)
+                <input id="cfgYMax" type="text" value="8">
+              </label>
+              <label>Navn på x-akse
+                <input id="cfgAxisXLabel" type="text" value="Idrett">
+              </label>
+              <label>Navn på y-akse
+                <input id="cfgAxisYLabel" type="text" value="Antall elever">
+              </label>
+            </div>
+            <div class="settings-row">
+              <label>Steg (snap)
+                <input id="cfgSnap" type="text" value="1">
+              </label>
+              <label>Toleranse
+                <input id="cfgTolerance" type="text" value="0">
+              </label>
+            </div>
+          </fieldset>
+          <div class="series-settings">
+            <fieldset id="series1Fields">
+              <legend>Dataserie 1</legend>
+              <label>Serienavn
+                <input id="cfgSeries1" type="text" value="">
+              </label>
+              <label>Startverdier
+                <input id="cfgStart" type="text" value="6,7,3,5,8,2">
+              </label>
+              <label>Fasitverdier
+                <input id="cfgAnswer" type="text" value="6,7,3,5,8,2">
+              </label>
+            </fieldset>
+            <fieldset id="series2Fields" style="display:none">
+              <legend>Dataserie 2</legend>
+              <label>Serienavn
                 <input id="cfgSeries2" type="text" value="">
               </label>
-            </div>
-            <div class="settings-row">
-              <label>Startverdier 2
+              <label>Startverdier
                 <input id="cfgStart2" type="text" value="">
               </label>
-            </div>
-            <div class="settings-row">
-              <label>Fasitverdier 2
+              <label>Fasitverdier
                 <input id="cfgAnswer2" type="text" value="">
               </label>
-            </div>
+            </fieldset>
+            <button id="addSeries" class="addFigureBtn" type="button" aria-label="Legg til dataserie">+</button>
           </div>
-          <div class="settings-row">
-            <label>Maks y (valgfritt)
-              <input id="cfgYMax" type="text" value="8">
-            </label>
-            <label>Navn på x-akse
-              <input id="cfgAxisXLabel" type="text" value="Idrett">
-            </label>
-            <label>Navn på y-akse
-              <input id="cfgAxisYLabel" type="text" value="Antall elever">
-            </label>
-          </div>
-          <label>Steg (snap)
-            <input id="cfgSnap" type="text" value="1">
-          </label>
-          <label>Toleranse
-            <input id="cfgTolerance" type="text" value="0">
-          </label>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- group the general diagram inputs in a single fieldset and create dedicated blocks for each dataserie
- show dataserie 2 controls only after pressing the reused “legg til figur” style button
- ensure existing configurations with a second dataserie automatically reveal the extra inputs

## Testing
- npm start -- --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68c9014a4b488324bfb65a755336c1a7