### PR TITLE
Align Kuler settings controls side by side

### DIFF
--- a/kuler.html
+++ b/kuler.html
@@ -40,6 +40,8 @@
     .btn:active{transform:translateY(1px);}
     .toolbar select{border:1px solid #d1d5db;border-radius:10px;padding:6px 10px;font-size:14px;background:#fff;}
     .controlsWrap{display:flex;flex-direction:column;gap:var(--gap);}
+    .controlsWrap.controlsWrap--split{flex-direction:row;flex-wrap:wrap;align-items:stretch;}
+    .controlsWrap.controlsWrap--split>.bowlFieldset{flex:1 1 280px;min-width:min(280px,100%);}
     fieldset.bowlFieldset{border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;display:flex;flex-direction:column;gap:8px;}
     fieldset.bowlFieldset legend{font-weight:600;font-size:13px;color:#374151;padding:0 4px;}
   </style>

--- a/kuler.js
+++ b/kuler.js
@@ -414,6 +414,7 @@ function renderFigure(fig){
 function applyFigureVisibility(){
   const secondExists = !!figureViews[1];
   const showSecond = !!STATE.figure2Visible && secondExists;
+  if(controlsWrap) controlsWrap.classList.toggle("controlsWrap--split", showSecond);
   if(addBtn) addBtn.style.display = (showSecond || !secondExists) ? "none" : "";
   if(panelEls[1]) panelEls[1].style.display = showSecond ? "" : "none";
   if(exportToolbar2) exportToolbar2.style.display = showSecond ? "" : "none";


### PR DESCRIPTION
## Summary
- update the Kuler settings panel to support a side-by-side layout when two figures are shown
- toggle a layout class in the visibility handler so the controls mirror the Brøkpizza layout

## Testing
- no automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c910385a4c83249a28223cd8740527