### PR TITLE
Legg til fjern figur-knapper for brøkpizza og tenkeblokker

### DIFF
--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -60,6 +60,9 @@
       min-width:var(--panel-min);
       max-width:420px;
     }
+    .pizzaPanel .removeFigureBtn {
+      align-self:center;
+    }
     .opDisplay {
       display:flex;
       align-items:center;
@@ -152,6 +155,7 @@
               <span id="nVal2">10</span>
               <button id="nPlus2"  type="button" aria-label="Flere sektorer">+</button>
             </div>
+            <button id="removePizza2" class="btn removeFigureBtn" type="button" aria-label="Fjern figur">Fjern figur</button>
           </div>
 
           <div id="opDisplay2" class="opDisplay" style="display:none"></div>
@@ -172,6 +176,7 @@
               <span id="nVal3">10</span>
               <button id="nPlus3"  type="button" aria-label="Flere sektorer">+</button>
             </div>
+            <button id="removePizza3" class="btn removeFigureBtn" type="button" aria-label="Fjern figur">Fjern figur</button>
           </div>
 
           <button id="addPizza" class="addFigureBtn" type="button" aria-label="Legg til pizza">+</button>

--- a/brøkpizza.js
+++ b/brøkpizza.js
@@ -123,6 +123,36 @@ function fitPizzasToLine(){
 }
 window.addEventListener("resize", fitPizzasToLine);
 
+function hidePizzaPanel(index){
+  const panel=document.getElementById(`panel${index}`);
+  if(panel) panel.style.display="none";
+  const fieldset=document.getElementById(`fieldset${index}`);
+  if(fieldset) fieldset.style.display="none";
+}
+
+function setupRemovePizzaButtons(){
+  const addBtn=document.getElementById('addPizza');
+  const remove2=document.getElementById('removePizza2');
+  if(remove2 && !remove2.dataset.bound){
+    remove2.dataset.bound='true';
+    remove2.addEventListener('click',()=>{
+      hidePizzaPanel(3);
+      hidePizzaPanel(2);
+      if(addBtn) addBtn.style.display='';
+      initFromHtml();
+    });
+  }
+  const remove3=document.getElementById('removePizza3');
+  if(remove3 && !remove3.dataset.bound){
+    remove3.dataset.bound='true';
+    remove3.addEventListener('click',()=>{
+      hidePizzaPanel(3);
+      if(addBtn) addBtn.style.display='';
+      initFromHtml();
+    });
+  }
+}
+
 /* =======================
    Pizza-klasse
    ======================= */
@@ -819,6 +849,7 @@ function initFromHtml(){
 
   scheduleCenterAlign();
   fitPizzasToLine();
+  setupRemovePizzaButtons();
 }
 
 window.addEventListener("load", () => {

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -43,6 +43,7 @@
     .tb-svg{width:var(--tb-svg-width);height:auto;background:#fff;}
     .tb-header{width:100%;display:flex;flex-direction:column;align-items:center;gap:6px;}
     .tb-header:empty{display:none;}
+    .tb-panel .removeFigureBtn{align-self:center;}
     .tb-settings{
       display:flex;
       flex-direction:column;
@@ -126,6 +127,7 @@
               <span id="tbNVal2">1</span>
               <button id="tbPlus2" type="button" aria-label="Flere blokker">+</button>
             </div>
+            <button id="tbRemove" class="btn removeFigureBtn" type="button" aria-label="Fjern figur">Fjern figur</button>
           </div>
 
           <button id="tbAdd" class="addFigureBtn" type="button" aria-label="Legg til tenkeblokker">+</button>

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -59,7 +59,8 @@ const panels = {
   container: document.getElementById('tbPanels'),
   panel2: document.getElementById('tbPanel2'),
   fieldset2: document.getElementById('cfg-fieldset-2'),
-  addBtn: document.getElementById('tbAdd')
+  addBtn: document.getElementById('tbAdd'),
+  removeBtn: document.getElementById('tbRemove')
 };
 
 const settingsContainer = document.getElementById('tbSettings');
@@ -80,6 +81,12 @@ btnPng?.addEventListener('click', () => {
 
 panels.addBtn?.addEventListener('click', () => {
   CONFIG.activeBlocks = 2;
+  updateVisibility();
+  draw();
+});
+
+panels.removeBtn?.addEventListener('click', () => {
+  CONFIG.activeBlocks = 1;
   updateVisibility();
   draw();
 });
@@ -373,6 +380,7 @@ function updateVisibility() {
   if (panels.panel2) panels.panel2.style.display = showSecond ? '' : 'none';
   if (panels.fieldset2) panels.fieldset2.style.display = showSecond ? '' : 'none';
   if (panels.addBtn) panels.addBtn.style.display = showSecond ? 'none' : '';
+  if (panels.removeBtn) panels.removeBtn.style.display = showSecond ? '' : 'none';
   panels.container?.classList.toggle('two', showSecond);
   settingsContainer?.classList.toggle('two', showSecond);
 }


### PR DESCRIPTION
## Summary
- add remove-figure buttons to additional brøkpizza panels and align their layout
- wire up pizza removal handlers so panels and fieldsets hide and UI re-renders cleanly
- expose a remove button for the second Tenkeblokker panel and toggle visibility through the existing state handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c91ba982988324bfa08272e596e65a