### PR TITLE
Add numerator lock toggle for Tenkeblokker handle

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -171,6 +171,10 @@
                 <label for="cfg-lock-n-1">Lås nevner</label>
               </div>
               <div class="checkbox-row">
+                <input id="cfg-lock-k-1" type="checkbox" />
+                <label for="cfg-lock-k-1">Lås teller</label>
+              </div>
+              <div class="checkbox-row">
                 <input id="cfg-hide-n-1" type="checkbox" />
                 <label for="cfg-hide-n-1">Skjul n-verdi</label>
               </div>
@@ -200,6 +204,10 @@
               <div class="checkbox-row">
                 <input id="cfg-lock-n-2" type="checkbox" />
                 <label for="cfg-lock-n-2">Lås nevner</label>
+              </div>
+              <div class="checkbox-row">
+                <input id="cfg-lock-k-2" type="checkbox" />
+                <label for="cfg-lock-k-2">Lås teller</label>
               </div>
               <div class="checkbox-row">
                 <input id="cfg-hide-n-2" type="checkbox" />


### PR DESCRIPTION
## Summary
- add a "Lås teller" checkbox to each Tenkeblokker settings panel
- store the new lockNumerator flag and hide the handle when it is enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9243171d08324b63c67870d32192b