### PR TITLE
Arrange kuler settings side by side

### DIFF
--- a/kuler.html
+++ b/kuler.html
@@ -29,6 +29,10 @@
     .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;width:100%;max-width:460px;margin:0 auto;}
     .figure svg{width:100%;height:auto;display:block;touch-action:none;}
     .ctrlRow{display:flex;align-items:center;gap:6px;font-size:14px;}
+    .controlsWrap.controlsWrap--split .ctrlRow{flex-wrap:wrap;}
+    .controlsWrap.controlsWrap--split .ctrlRow--size .ctrlLabel--size{flex:0 0 100%;}
+    .controlsWrap.controlsWrap--split .ctrlRow--size .count{flex:0 0 100%;text-align:right;}
+    .ctrlRow--size input[type="range"]{flex:1 1 160px;}
     .ctrlRow button{border:1px solid #d1d5db;border-radius:6px;background:#fff;width:24px;height:24px;line-height:1;}
     .ctrlRow .count{width:24px;text-align:center;}
     .bead{cursor:grab;}
@@ -41,7 +45,7 @@
     .toolbar select{border:1px solid #d1d5db;border-radius:10px;padding:6px 10px;font-size:14px;background:#fff;}
     .controlsWrap{display:flex;flex-direction:column;gap:var(--gap);}
     .controlsWrap.controlsWrap--split{flex-direction:row;flex-wrap:wrap;align-items:stretch;}
-    .controlsWrap.controlsWrap--split>.bowlFieldset{flex:1 1 280px;min-width:min(280px,100%);}
+    .controlsWrap.controlsWrap--split>.bowlFieldset{flex:1 1 240px;min-width:min(240px,100%);}
     fieldset.bowlFieldset{border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;display:flex;flex-direction:column;gap:8px;}
     fieldset.bowlFieldset legend{font-weight:600;font-size:13px;color:#374151;padding:0 4px;}
   </style>

--- a/kuler.js
+++ b/kuler.js
@@ -83,6 +83,20 @@ const controlsWrap = document.getElementById("controls");
 const addBtn = document.getElementById("addBowl");
 const panelEls = [document.getElementById("panel1"), document.getElementById("panel2")];
 const exportToolbar2 = document.getElementById("exportToolbar2");
+const gridEl = document.querySelector(".grid");
+
+const initialSideWidth = (() => {
+  if(!gridEl) return 360;
+  const inlineVal = Number.parseFloat(gridEl.style.getPropertyValue("--side-width"));
+  if(Number.isFinite(inlineVal)) return inlineVal;
+  try{
+    const computedVal = Number.parseFloat(getComputedStyle(gridEl).getPropertyValue("--side-width"));
+    if(Number.isFinite(computedVal)) return computedVal;
+  }catch(_){ }
+  return 360;
+})();
+
+let lastShowSecond = null;
 
 if(!Array.isArray(SIMPLE.bowls)) SIMPLE.bowls = [];
 if(typeof STATE.figure2Visible !== "boolean"){
@@ -128,8 +142,9 @@ downloadButtons.forEach(({ svgBtn, pngBtn, idx }) => {
 function createFigure(idx, svg, gBowls){
   const fieldset = document.createElement("fieldset");
   fieldset.className = "bowlFieldset";
+  fieldset.id = `kuler${idx + 1}`;
   const legend = document.createElement("legend");
-  legend.textContent = `Illustrasjon ${idx + 1}`;
+  legend.textContent = `Kuler ${idx + 1}`;
   fieldset.appendChild(legend);
 
   const counts = {};
@@ -158,8 +173,9 @@ function createFigure(idx, svg, gBowls){
   });
 
   const sizeRow = document.createElement("div");
-  sizeRow.className = "ctrlRow";
+  sizeRow.className = "ctrlRow ctrlRow--size";
   const sizeLabel = document.createElement("span");
+  sizeLabel.className = "ctrlLabel ctrlLabel--size";
   sizeLabel.textContent = "Kulestørrelse";
   const sizeMinus = document.createElement("button");
   sizeMinus.type = "button";
@@ -168,7 +184,7 @@ function createFigure(idx, svg, gBowls){
   sizeInput.type = "range";
   sizeInput.min = "5";
   sizeInput.max = "60";
-  sizeInput.style.flex = "1";
+  sizeInput.style.flex = "1 1 160px";
   const sizePlus = document.createElement("button");
   sizePlus.type = "button";
   sizePlus.textContent = "+";
@@ -415,6 +431,17 @@ function applyFigureVisibility(){
   const secondExists = !!figureViews[1];
   const showSecond = !!STATE.figure2Visible && secondExists;
   if(controlsWrap) controlsWrap.classList.toggle("controlsWrap--split", showSecond);
+  if(gridEl && showSecond !== lastShowSecond){
+    if(showSecond){
+      const current = Number.parseFloat(gridEl.style.getPropertyValue("--side-width"));
+      const base = Number.isFinite(current) ? current : initialSideWidth;
+      const desired = Math.max(base, 540);
+      gridEl.style.setProperty("--side-width", `${desired}px`);
+    }else{
+      gridEl.style.setProperty("--side-width", `${initialSideWidth}px`);
+    }
+  }
+  lastShowSecond = showSecond;
   if(addBtn) addBtn.style.display = (showSecond || !secondExists) ? "none" : "";
   if(panelEls[1]) panelEls[1].style.display = showSecond ? "" : "none";
   if(exportToolbar2) exportToolbar2.style.display = showSecond ? "" : "none";


### PR DESCRIPTION
## Summary
- show Kuler 1 and Kuler 2 settings fieldsets side-by-side when two bowls are visible
- expand the side column width and adjust slider layout to stay readable on narrow columns
- add clearer legends and ids for each settings fieldset

## Testing
- Viewed kuler.html locally

------
https://chatgpt.com/codex/tasks/task_e_68c920faca9883248cf2e2a697f561ca