### PR TITLE
Allow removing the first fraction figure

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -101,6 +101,7 @@
               <span id="partsVal1">4</span>
               <button id="partsPlus1" type="button" aria-label="Flere deler">+</button>
             </div>
+            <button id="removeFigure1" class="btn removeFigureBtn" type="button" aria-label="Fjern figur 1" style="display:none">Fjern figur</button>
           </div>
           <button id="addFigure" class="addFigureBtn" type="button" aria-label="Legg til figur">+</button>
           <div id="panel2" class="figurePanel" style="display:none">
@@ -110,7 +111,7 @@
               <span id="partsVal2">4</span>
               <button id="partsPlus2" type="button" aria-label="Flere deler">+</button>
             </div>
-            <button id="removeFigure" class="btn removeFigureBtn" type="button" aria-label="Fjern figur">Fjern figur</button>
+            <button id="removeFigure2" class="btn removeFigureBtn" type="button" aria-label="Fjern figur 2">Fjern figur</button>
           </div>
         </div>
       </div>

--- a/brøkfigurer.js
+++ b/brøkfigurer.js
@@ -59,7 +59,8 @@
     colorInputs.push(inp);
   }
   const addBtn = document.getElementById('addFigure');
-  const removeBtn = document.getElementById('removeFigure');
+  const removeBtn1 = document.getElementById('removeFigure1');
+  const removeBtn2 = document.getElementById('removeFigure2');
   const fieldset2 = document.getElementById('fieldset2');
   const INITIAL_COLORS = colorInputs.map(inp => inp.value);
   const clampInt = (value, min, max) => {
@@ -197,6 +198,8 @@
     const showSecond = !!STATE.figure2Visible;
     if(addBtn) addBtn.style.display = showSecond ? 'none' : '';
     if(fieldset2) fieldset2.style.display = showSecond ? '' : 'none';
+    if(removeBtn2) removeBtn2.style.display = showSecond ? '' : 'none';
+    if(removeBtn1) removeBtn1.style.display = showSecond ? '' : 'none';
     const second = figures[2];
     if(second){
       if(second.panel) second.panel.style.display = showSecond ? '' : 'none';
@@ -703,7 +706,23 @@
       const svg = board?.renderer?.svgRoot;
       if(svg) downloadPNG(svg, `brok${id}.png`, 2);
     });
-    return {draw, panel, toolbar};
+    function getFilled(){
+      return new Map(filled);
+    }
+
+    function setFilled(next){
+      if(next instanceof Map){
+        filled = new Map(next);
+      }else if(Array.isArray(next)){
+        filled = new Map(next);
+      }else if(next && typeof next[Symbol.iterator] === 'function'){
+        filled = new Map(next);
+      }else{
+        filled = new Map();
+      }
+    }
+
+    return {draw, panel, toolbar, getFilled, setFilled};
   }
 
   figures[1] = setupFigure(1);
@@ -712,7 +731,20 @@
     STATE.figure2Visible = true;
     window.render();
   });
-  removeBtn?.addEventListener('click', ()=>{
+  removeBtn1?.addEventListener('click', ()=>{
+    if(!STATE.figure2Visible) return;
+    const fig1State = {...ensureFigureState(1)};
+    const fig2State = {...ensureFigureState(2)};
+    STATE.figures[1] = fig2State;
+    STATE.figures[2] = fig1State;
+    const fig1Filled = figures[1]?.getFilled?.() ?? new Map();
+    const fig2Filled = figures[2]?.getFilled?.() ?? new Map();
+    figures[1]?.setFilled?.(fig2Filled);
+    figures[2]?.setFilled?.(fig1Filled);
+    STATE.figure2Visible = false;
+    window.render();
+  });
+  removeBtn2?.addEventListener('click', ()=>{
     STATE.figure2Visible = false;
     window.render();
   });


### PR DESCRIPTION
## Summary
- add a remove button for the first fraction figure when two figures are visible
- update the logic to hide or show the new button alongside the second figure controls
- promote the second figure to the first slot (including shaded parts) when removing the first figure

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68c92f038cd483248694baa910dc5895