### PR TITLE
Fix graftegner board initialization

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -774,7 +774,6 @@ function rebuildFunctionSegmentsFor(g){
 function rebuildAllFunctionSegments(){ graphs.forEach(rebuildFunctionSegmentsFor); }
 
 /* =================== FUNKSJONER + BRACKETS =================== */
-const graphs=[];
 function makeSmartCurveLabel(g, idx, text){
   if(!ADV.curveName.show) return;
   const label = brd.create('text',[0,0,()=>text],{


### PR DESCRIPTION
## Summary
- remove the duplicate `graphs` constant declaration so the graftegner script parses correctly and the board renders again

## Testing
- no automated tests were run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c93ba1870c8324b3eda5c03b7bd428