### PR TITLE
Flytt eksportseksjon under innstillinger i visualiseringer

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -67,15 +67,6 @@
           </div>
         </div>
         <div class="card">
-          <h2>Eksporter</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSvgInteractive" class="btn" type="button">Last ned interaktiv SVG</button>
-            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
-          </div>
-        </div>
-        <div class="card">
           <h2>Innstillinger</h2>
           <div id="settingsMenu" class="settings">
             <div class="row">
@@ -107,6 +98,15 @@
                 <input id="challengeArea" type="number" value="12" min="1">
               </label>
             </div>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSvgInteractive" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
           </div>
         </div>
       </div>

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -74,15 +74,6 @@
           </div>
         </div>
         <div class="card">
-          <h2>Eksporter</h2>
-          <div class="toolbar">
-            <button id="btnSvgStatic" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSvg" class="btn" type="button">Last ned interaktiv SVG</button>
-            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
-          </div>
-        </div>
-        <div class="card">
           <h2>Innstillinger</h2>
           <div class="settings">
             <div class="row">
@@ -108,6 +99,15 @@
               <label class="chk"><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
             </div>
             <button id="btnReset" class="btn" type="button">Reset</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvgStatic" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSvg" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
           </div>
         </div>
       </div>

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -124,17 +124,6 @@
           </div>
         </div>
         <div class="card">
-          <h2>Eksporter</h2>
-          <div class="toolbar">
-            <button id="btnSvg1" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng1" class="btn" type="button">Last ned PNG</button>
-          </div>
-          <div class="toolbar" style="display:none">
-            <button id="btnSvg2" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng2" class="btn" type="button">Last ned PNG</button>
-          </div>
-        </div>
-        <div class="card">
           <h2>Innstillinger</h2>
           <fieldset>
             <legend>Farger</legend>
@@ -199,6 +188,17 @@
               </label>
               <div class="checkbox-row"><input id="allowWrong2" type="checkbox" /><label for="allowWrong2">Tillat gale illustrasjoner</label></div>
             </fieldset>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg1" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng1" class="btn" type="button">Last ned PNG</button>
+          </div>
+          <div class="toolbar" style="display:none">
+            <button id="btnSvg2" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng2" class="btn" type="button">Last ned PNG</button>
           </div>
         </div>
       </div>

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -193,15 +193,6 @@
         </div>
 
         <div class="card">
-          <h2>Eksporter</h2>
-          <div class="toolbar">
-            <button id="btnStaticAll" class="btn" type="button">Last ned SVG</button>
-            <button id="btnInteractiveAll" class="btn" type="button">Last ned interaktiv SVG</button>
-            <button id="btnPngAll" class="btn" type="button">Last ned PNG</button>
-          </div>
-        </div>
-
-        <div class="card">
           <h2>Innstillinger</h2>
           <div class="settings">
           <fieldset>
@@ -283,6 +274,15 @@
             <label for="p3MaxN">Maks n</label>
             <input id="p3MaxN" type="number" value="24" min="1">
           </fieldset>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnStaticAll" class="btn" type="button">Last ned SVG</button>
+            <button id="btnInteractiveAll" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnPngAll" class="btn" type="button">Last ned PNG</button>
           </div>
         </div>
 

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -39,14 +39,6 @@
         </div>
 
         <div class="card">
-          <h2>Eksporter</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-          </div>
-        </div>
-
-        <div class="card">
           <h2>Innstillinger</h2>
           <div class="settings">
           <fieldset>
@@ -116,6 +108,14 @@
               </label>
             </fieldset>
             <button id="addSeries" class="addFigureBtn" type="button" aria-label="Legg til dataserie">+</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
           </div>
         </div>
       </div>

--- a/figurtall.html
+++ b/figurtall.html
@@ -153,13 +153,6 @@
           </div>
         </div>
         <div class="card">
-          <h2>Eksporter</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-          </div>
-        </div>
-        <div class="card">
           <h2>Innstillinger</h2>
           <fieldset>
             <legend>Ruter</legend>
@@ -197,6 +190,13 @@
           </fieldset>
           <div class="toolbar">
             <button id="resetBtn" class="btn" type="button">Nullstill</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
           </div>
         </div>
       </div>

--- a/graftegner.html
+++ b/graftegner.html
@@ -69,14 +69,6 @@
         </div>
 
         <div class="card">
-          <h2>Eksporter</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn">Last ned SVG</button>
-            <button id="btnPng" class="btn">Last ned PNG</button>
-          </div>
-        </div>
-
-        <div class="card">
           <h2>Innstillinger</h2>
           <div class="settings">
             <div id="funcRows"></div>
@@ -98,6 +90,14 @@
                 </label>
               </div>
             </fieldset>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn">Last ned SVG</button>
+            <button id="btnPng" class="btn">Last ned PNG</button>
           </div>
         </div>
       </div>

--- a/kuler.html
+++ b/kuler.html
@@ -78,6 +78,10 @@
           </div>
         </div>
         <div class="card">
+          <h2>Innstillinger</h2>
+          <div id="controls" class="controlsWrap"></div>
+        </div>
+        <div class="card">
           <h2>Eksporter</h2>
           <div class="toolbar">
             <button id="downloadSVG1" class="btn" type="button">Last ned SVG</button>
@@ -87,10 +91,6 @@
             <button id="downloadSVG2" class="btn" type="button">Last ned SVG</button>
             <button id="downloadPNG2" class="btn" type="button">Last ned PNG</button>
           </div>
-        </div>
-        <div class="card">
-          <h2>Innstillinger</h2>
-          <div id="controls" class="controlsWrap"></div>
         </div>
       </div>
     </div>

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -103,13 +103,6 @@
           </div>
         </div>
         <div class="card">
-          <h2>Eksporter</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-          </div>
-        </div>
-        <div class="card">
           <h2>Innstillinger</h2>
           <label>Vis play-knapp
             <input id="cfg-showBtn" type="checkbox">
@@ -131,6 +124,13 @@
           <label>Vis i sekunder
             <input id="cfg-duration" type="number" min="1" value="3">
           </label>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
         </div>
       </div>
     </div>

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -105,13 +105,6 @@
           </div>
         </div>
         <div class="card">
-          <h2>Eksporter</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-          </div>
-        </div>
-        <div class="card">
           <h2>Innstillinger</h2>
           <label>Type
             <select id="cfg-type">
@@ -170,6 +163,13 @@
               <input id="cfg-showBtn-monster" type="checkbox">
               <label for="cfg-showBtn-monster">Vis play-knapp</label>
             </div>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
           </div>
         </div>
       </div>

--- a/nkant.html
+++ b/nkant.html
@@ -57,14 +57,6 @@
         </div>
 
         <div class="card">
-          <h2>Eksporter</h2>
-          <div class="toolbar">
-            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-          </div>
-        </div>
-
-        <div class="card">
           <h2>Innstillinger</h2>
 
         <label for="inpSpecs">Skriv spesifikasjoner eller fritekst (1–2 linjer per figur)</label>
@@ -293,6 +285,13 @@ Rettvinklet trekant</textarea>
           <label><input type="radio" name="layout" value="col"> Under hverandre</label>
         </div>
       </div>
+        <div class="card">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
     </div>
   </div>
 

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -78,18 +78,18 @@
         </div>
 
         <div class="card">
+          <h2>Innstillinger</h2>
+          <label>Antall perler<input id="cfg-nBeads" type="number" min="1"></label>
+          <label>Startposisjon<input id="cfg-startIndex" type="number" min="0"></label>
+          <label>Fasit venstre<input id="cfg-correct" type="number" min="0"></label>
+        </div>
+
+        <div class="card">
           <h2>Eksporter</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
           </div>
-        </div>
-
-        <div class="card">
-          <h2>Innstillinger</h2>
-          <label>Antall perler<input id="cfg-nBeads" type="number" min="1"></label>
-          <label>Startposisjon<input id="cfg-startIndex" type="number" min="0"></label>
-          <label>Fasit venstre<input id="cfg-correct" type="number" min="0"></label>
         </div>
       </div>
     </div>

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -60,12 +60,12 @@
           </div>
         </div>
         <div class="card">
-          <h2>Eksporter</h2>
-          <p class="muted">Ingen eksport tilgjengelig.</p>
-        </div>
-        <div class="card">
           <h2>Innstillinger</h2>
           <p class="muted">Ingen ekstra innstillinger for denne visningen.</p>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
+          <p class="muted">Ingen eksport tilgjengelig.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- flyttet eksportkortet til under innstillingsseksjonen i alle visualiseringssidene slik at eksportverktøyet vises nederst

## Testing
- ikke kjørt (ikke relevant for rene HTML-endringer)


------
https://chatgpt.com/codex/tasks/task_e_68c93b3349e883249bb440eeb6e55e56