### PR TITLE
Ensure nKant examples capture unsaved textarea changes

### DIFF
--- a/nkant.js
+++ b/nkant.js
@@ -858,6 +858,11 @@ function bindUI(){
   f2Angles.value = STATE.fig2.angles.default;
   layoutRadios.forEach(r => r.checked = (r.value===STATE.layout));
 
+  // Oppdater lokal STATE mens bruker skriver, slik at lagring av eksempler får med uendrede endringer
+  inpSpecs.addEventListener("input", () => {
+    STATE.specsText = inpSpecs.value;
+  });
+
   // Oppdater når bruker trykker Enter, forlater feltet eller trykker Tegn-knappen
   inpSpecs.addEventListener("blur", () => {
     if (STATE.specsText !== inpSpecs.value) {


### PR DESCRIPTION
## Summary
- keep the specs textarea in sync with STATE as the user types
- ensures saving an example captures the latest text without requiring blur/draw

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c982d44d7c832495199ef1022b3943