### PR TITLE
Vis teller og nevner uten forkorting i brøkpizza

### DIFF
--- a/brøkpizza.js
+++ b/brøkpizza.js
@@ -331,9 +331,8 @@ class Pizza{
         (this.textMode==="decimal") ? fmt(this.n?this.k/this.n:0) : "";
     }
     if(this.fracBox && this.textMode==="frac"){
-      const g=gcd(this.k,this.n);
-      if(this.fracNum) this.fracNum.textContent=this.k/g;
-      if(this.fracDen) this.fracDen.textContent=this.n/g;
+      if(this.fracNum) this.fracNum.textContent=this.k;
+      if(this.fracDen) this.fracDen.textContent=this.n;
     }
   }
   _updateAria(){
@@ -490,7 +489,7 @@ const INTERACTIVE_SVG_SCRIPT = `
   function updateTexts(){
     if(textMode==="percent"&&tMeta){ var p=n?(k/n*100):0; tMeta.textContent=fmt(p)+" %"; }
     else if(textMode==="decimal"&&tMeta){ var d=n?(k/n):0; tMeta.textContent=fmt(d); }
-    else if(textMode==="frac"&&tNum&&tDen){ var g=gcd(k,n); tNum.textContent=(k/g).toString(); tDen.textContent=(n/g).toString(); }
+    else if(textMode==="frac"&&tNum&&tDen){ tNum.textContent=String(k); tDen.textContent=String(n); }
   }
 
   /* ---- KNAPPER UNDER ---- */


### PR DESCRIPTION
## Summary
- vis brøkteksten over pizzaene med uendret teller og nevner i stedet for å forkorte brøken
- sørg for at eksportert interaktiv SVG også beholder opprinnelige teller- og nevnerverdier i brøkteksten

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c984d23b8483249fc1ff6836ce58c7