### PR TITLE
Move main menu to top bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,65 +8,95 @@
     body {
       margin: 0;
       display: grid;
-      grid-template-columns: 200px 1fr;
+      grid-template-rows: auto 1fr;
       height: 100vh;
       font-family: system-ui, sans-serif;
       background: #f7f8fb;
       color: #111827;
     }
     nav {
-      padding: 20px;
-      border-right: 1px solid #e5e7eb;
+      padding: 16px 20px;
+      border-bottom: 1px solid #e5e7eb;
+      background: #ffffffee;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
     }
-    h1 { font-size: 20px; margin-top: 0; }
-    ul { list-style: none; padding: 0; margin: 0; }
-    li { margin: 8px 0; }
+    h1 {
+      font-size: 20px;
+      margin: 0;
+      white-space: nowrap;
+    }
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      gap: 12px;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+    li {
+      margin: 0;
+      flex: 0 0 auto;
+    }
     nav a {
       color: #147a9c;
       text-decoration: none;
-      display: flex;
+      display: inline-flex;
       gap: 0.5rem;
       align-items: center;
-      padding: 4px 8px;
-      border-radius: 4px;
+      padding: 6px 10px;
+      border-radius: 9999px;
+      transition: background-color 0.15s ease, color 0.15s ease;
     }
-    nav a:hover { text-decoration: underline; }
+    nav a:hover {
+      background: rgba(20, 122, 156, 0.1);
+    }
     nav a.active {
       background: #e5e7eb;
-      font-weight: bold;
+      font-weight: 600;
     }
-    nav a:focus, nav a:focus-visible {
+    nav a:focus,
+    nav a:focus-visible {
       outline: 2px solid #111827;
       outline-offset: 2px;
     }
     nav svg {
       width: 1.25rem;
       height: 1.25rem;
+      flex-shrink: 0;
     }
     iframe {
       border: 0;
       width: 100%;
       height: 100%;
+      background: white;
     }
 
-    @media (max-width: 640px) {
-      body {
-        grid-template-columns: 1fr;
-        grid-template-rows: auto 1fr;
-      }
+    @media (min-width: 768px) {
       nav {
-        border-right: none;
-        border-bottom: 1px solid #e5e7eb;
-        padding: 10px;
-        overflow-x: auto;
+        flex-direction: row;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 16px;
       }
-      nav ul {
-        display: flex;
-        gap: 12px;
+      ul {
+        flex: 1 1 auto;
+        flex-wrap: wrap;
+        overflow-x: visible;
       }
-      nav li {
-        margin: 0;
-        white-space: nowrap;
+    }
+
+    @media (max-width: 480px) {
+      nav {
+        padding: 12px;
+      }
+      h1 {
+        font-size: 18px;
+      }
+      nav a {
+        padding: 6px 8px;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- repositioned the main navigation into a horizontal bar at the top of the page
- refreshed menu styling for better spacing, hover states, and mobile scrolling
- kept the iframe content filling the remaining viewport area under the menu

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c985a46fc88324bfae7090c81197d1