### PR TITLE
Ensure next saved example becomes default after deletion

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -376,18 +376,48 @@
     defaultEnsureScheduled = true;
     const ensure = ()=>{
       let examples = getExamples();
-      let inserted = false;
-      if(!examples[0] || examples[0].isDefault !== true){
+      let updated = false;
+
+      const firstValidIndex = examples.findIndex(ex => ex && typeof ex === 'object');
+      if(firstValidIndex === -1){
+        if(examples.length){
+          examples = [];
+          updated = true;
+        }
+      }else if(firstValidIndex > 0){
+        examples = examples.slice(firstValidIndex);
+        if(Number.isInteger(currentExampleIndex)){
+          currentExampleIndex = Math.max(0, currentExampleIndex - firstValidIndex);
+        }
+        updated = true;
+      }
+
+      if(examples.length === 0){
         const defaultExample = collectConfig();
         defaultExample.isDefault = true;
-        examples.unshift(defaultExample);
+        examples = [defaultExample];
+        currentExampleIndex = 0;
+        updated = true;
+      }else{
+        const first = examples[0];
+        if(first.isDefault !== true){
+          first.isDefault = true;
+          updated = true;
+        }
+        for(let i = 1; i < examples.length; i++){
+          const ex = examples[i];
+          if(ex && typeof ex === 'object' && Object.prototype.hasOwnProperty.call(ex, 'isDefault')){
+            delete ex.isDefault;
+            updated = true;
+          }
+        }
+      }
+
+      if(updated){
         store(examples);
-        inserted = true;
+        examples = getExamples();
       }
-      examples = getExamples();
-      if(inserted){
-        currentExampleIndex = currentExampleIndex == null ? 0 : currentExampleIndex + 1;
-      }
+
       if(currentExampleIndex == null && examples.length > 0){
         currentExampleIndex = 0;
       }


### PR DESCRIPTION
## Summary
- update example normalization so the first stored example is always the default instead of inserting a new copy
- promote the first valid example to default status after deletions and clean up any leftover invalid entries

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c9861e687c83248db78b55f0e2b2fe