### PR TITLE
Remove navigation heading to save space

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,6 @@
       flex-direction: column;
       gap: 12px;
     }
-    h1 {
-      font-size: 20px;
-      margin: 0;
-      white-space: nowrap;
-    }
     ul {
       list-style: none;
       padding: 0;
@@ -92,9 +87,6 @@
       nav {
         padding: 12px;
       }
-      h1 {
-        font-size: 18px;
-      }
       nav a {
         padding: 6px 8px;
       }
@@ -103,7 +95,6 @@
 </head>
 <body>
   <nav>
-    <h1>Velg visualisering</h1>
     <ul>
         <li><a href="graftegner.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18"/><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4-4 4 6 6-10"/></svg>Graftegner</a></li>
         <li><a href="nkant.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><polygon stroke-linejoin="round" points="12 4 20 20 4 20"/></svg>nKant</a></li>


### PR DESCRIPTION
## Summary
- remove the "Velg visualisering" heading above the navigation menu to reduce vertical space
- clean up the unused heading styles in the landing page stylesheet

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c98afb5330832490c4ace15221e0c4