### PR TITLE
Improve Kuler figure layout responsiveness

### DIFF
--- a/kuler.html
+++ b/kuler.html
@@ -15,18 +15,26 @@
     .wrap{max-width:1200px;margin:0 auto;}
     .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
-    .figureGrid{display:grid;gap:var(--gap);grid-template-columns:repeat(2,minmax(0,1fr));align-items:start;}
-    .figurePanel{display:flex;flex-direction:column;gap:12px;align-items:center;}
-    .addFigureBtn{width:clamp(30px,7.5vw,60px);aspect-ratio:1;border:2px dashed #cfcfcf;border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;font-size:20px;color:#6b7280;cursor:pointer;justify-self:center;align-self:center;}
+    .figureGrid{
+      --figure-columns:1;
+      display:grid;
+      gap:var(--gap);
+      grid-template-columns:repeat(var(--figure-columns),minmax(0,1fr));
+      align-items:start;
+    }
+    .figureGrid[data-figures="2"]{--figure-columns:2;}
+    .figurePanel{display:flex;flex-direction:column;gap:12px;align-items:stretch;}
+    .figurePanel .btn{align-self:center;}
+    .addFigureBtn{width:clamp(30px,7.5vw,60px);aspect-ratio:1;border:2px dashed #cfcfcf;border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;font-size:20px;color:#6b7280;cursor:pointer;justify-self:center;align-self:center;grid-column:1/-1;}
     @media(max-width:980px){.grid{grid-template-columns:1fr;}}
-    @media(max-width:720px){.figureGrid{grid-template-columns:1fr;}.addFigureBtn{width:clamp(30px,15vw,70px);}}
+    @media(max-width:720px){.figureGrid{--figure-columns:1;}.addFigureBtn{width:clamp(30px,15vw,70px);}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
       box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
       display:flex;flex-direction:column;gap:10px;
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;width:100%;max-width:460px;margin:0 auto;}
+    .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;width:100%;}
     .figure svg{width:100%;height:auto;display:block;touch-action:none;}
     .ctrlRow{display:flex;align-items:center;gap:6px;font-size:14px;}
     .controlsWrap.controlsWrap--split .ctrlRow{flex-wrap:wrap;}

--- a/kuler.js
+++ b/kuler.js
@@ -80,6 +80,7 @@ const assetToColor = Object.entries(ADV.assets.beads).reduce((acc, [color, src])
   return acc;
 }, {});
 const controlsWrap = document.getElementById("controls");
+const figureGridEl = document.querySelector(".figureGrid");
 const addBtn = document.getElementById("addBowl");
 const panelEls = [document.getElementById("panel1"), document.getElementById("panel2")];
 const removeBtn2 = document.getElementById("removeBowl2");
@@ -457,6 +458,15 @@ function renderFigure(fig){
 function applyFigureVisibility(){
   const secondExists = !!figureViews[1];
   const showSecond = !!STATE.figure2Visible && secondExists;
+  const firstExists = !!figureViews[0];
+  const figureCount = firstExists ? (showSecond ? 2 : 1) : 0;
+  if(figureGridEl){
+    if(figureCount > 0){
+      figureGridEl.dataset.figures = String(figureCount);
+    }else{
+      delete figureGridEl.dataset.figures;
+    }
+  }
   if(controlsWrap) controlsWrap.classList.toggle("controlsWrap--split", showSecond);
   if(gridEl && showSecond !== lastShowSecond){
     if(showSecond){


### PR DESCRIPTION
## Summary
- make the figure grid responsive so a single bowl illustration can span the full width and the add button moves below it
- stretch figure panels to fill their column, keep the delete button centered, and remove the hard max width on the svg container
- update the runtime to flag how many figures are visible so the layout can react when the second bowl is toggled

## Testing
- not run (static HTML/CSS/JS change)


------
https://chatgpt.com/codex/tasks/task_e_68c9a7020b90832495ba98c75790a814