### PR TITLE
Update Brøkpizza icon styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,21 @@
       </li>
       <li>
         <a href="brøkpizza.html" target="content" title="Brøkpizza" aria-label="Brøkpizza">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z"/></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 12 L 21.25 12 A 9.25 9.25 0 0 1 2.75 12 Z" fill="#4b3abf" />
+            <g fill="none" stroke="#2f2f35" stroke-linecap="round">
+              <g stroke-width="1.1" stroke-dasharray="1.6 1.6">
+                <line x1="12" y1="12" x2="21.35" y2="12" />
+                <line x1="12" y1="12" x2="2.65" y2="12" />
+                <line x1="12" y1="12" x2="16.68" y2="20.1" />
+                <line x1="12" y1="12" x2="7.32" y2="20.1" />
+                <line x1="12" y1="12" x2="7.32" y2="3.9" />
+                <line x1="12" y1="12" x2="16.68" y2="3.9" />
+              </g>
+              <circle cx="12" cy="12" r="9.5" stroke-width="1.5" />
+            </g>
+            <circle cx="12" cy="12" r="0.8" fill="#2f2f35" />
+          </svg>
           <span class="sr-only">Brøkpizza</span>
         </a>
       </li>


### PR DESCRIPTION
## Summary
- replace the Brøkpizza navigation icon with a multi-slice pizza illustration that matches the provided mock-up

## Testing
- not run (visual change only)


------
https://chatgpt.com/codex/tasks/task_e_68c9a9cdb0088324817941af5514aef9