### PR TITLE
Update nKant icon with angle indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,12 @@
       </li>
       <li>
         <a href="nkant.html" target="content" title="nKant" aria-label="nKant">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><polygon stroke-linejoin="round" points="12 4 20 20 4 20"/></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path d="M5 18L12.8 7 23.8 14.8Z" stroke-width="1.5" stroke-linejoin="round" />
+            <path d="M11.64 8.63L13.27 9.79L14.43 8.16" stroke-width="1.35" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M6.15 16.4Q5.45 17.25 6.97 17.68" stroke-width="1.15" stroke-linecap="round" />
+            <path d="M22.18 13.64Q23 14.47 21.84 15.16" stroke-width="1.15" stroke-linecap="round" />
+          </svg>
           <span class="sr-only">nKant</span>
         </a>
       </li>


### PR DESCRIPTION
## Summary
- replace the nKant navigation icon with a right triangle matching the new design
- add right-angle and arc markers while omitting numeric angle labels

## Testing
- not run (static asset change)


------
https://chatgpt.com/codex/tasks/task_e_68c9a981ec108324993928587cb68cd3