### PR TITLE
Simplify Brøkpizza icon for readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,19 +157,11 @@
       <li>
         <a href="brøkpizza.html" target="content" title="Brøkpizza" aria-label="Brøkpizza">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M12 12 L 21.25 12 A 9.25 9.25 0 0 1 2.75 12 Z" fill="#4b3abf" />
-            <g fill="none" stroke="#2f2f35" stroke-linecap="round">
-              <g stroke-width="1.1" stroke-dasharray="1.6 1.6">
-                <line x1="12" y1="12" x2="21.35" y2="12" />
-                <line x1="12" y1="12" x2="2.65" y2="12" />
-                <line x1="12" y1="12" x2="16.68" y2="20.1" />
-                <line x1="12" y1="12" x2="7.32" y2="20.1" />
-                <line x1="12" y1="12" x2="7.32" y2="3.9" />
-                <line x1="12" y1="12" x2="16.68" y2="3.9" />
-              </g>
-              <circle cx="12" cy="12" r="9.5" stroke-width="1.5" />
-            </g>
-            <circle cx="12" cy="12" r="0.8" fill="#2f2f35" />
+            <circle cx="12" cy="12" r="8.5" fill="#eef2ff" stroke="currentColor" stroke-width="1.6" />
+            <path d="M12 12L12 4.5A7.5 7.5 0 0 1 19.5 12Z" fill="#4b3abf" stroke="currentColor" stroke-width="1.1" stroke-linejoin="round" />
+            <line x1="12" y1="4.5" x2="12" y2="19.5" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" />
+            <line x1="12" y1="12" x2="19.5" y2="12" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" />
+            <circle cx="12" cy="12" r="1.2" fill="#1f2937" />
           </svg>
           <span class="sr-only">Brøkpizza</span>
         </a>


### PR DESCRIPTION
## Summary
- replace the Brøkpizza navigation glyph with a simplified pie-chart style icon
- ensure clearer shapes, contrast, and central focal point for better legibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9acb167748324bcd8b812c93c98d2