### PR TITLE
Add Trefigurer 3D visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,17 @@
         </a>
       </li>
       <li>
+        <a href="trefigurer.html" target="content" title="Trefigurer" aria-label="Trefigurer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 3 4 7v10l8 4 8-4V7Z" fill="currentColor" fill-opacity=".25" />
+            <path d="M12 3v10l8 4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-linecap="round" stroke-width="1.4" />
+            <path d="M12 3 4 7l8 4 8-4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.4" />
+            <path d="M4 7v10l8 4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.4" />
+          </svg>
+          <span class="sr-only">Trefigurer</span>
+        </a>
+      </li>
+      <li>
         <a href="diagram/index.html" target="content" title="Diagram" aria-label="Diagram">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path d="M4.25 3.75v15.5" stroke-linecap="round" stroke-width="1.5" />

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="no">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Trefigurer</title>
+  <style>
+    :root { --gap: 18px; }
+    html, body { height: 100%; }
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
+      color: #111827;
+      background: #f7f8fb;
+      padding: 20px;
+    }
+    .wrap { max-width: 1200px; margin: 0 auto; }
+    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 420px; align-items: start; }
+    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
+    .side { display: flex; flex-direction: column; gap: var(--gap); }
+    .card {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 14px;
+      box-shadow: 0 1px 2px rgba(0,0,0,.04);
+      padding: 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+    .toolbar { display: flex; gap: 10px; justify-content: flex-start; align-items: center; flex-wrap: wrap; }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: 10px;
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow .2s, transform .02s;
+    }
+    .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
+    .btn:active { transform: translateY(1px); }
+    label { font-size: 13px; color: #4b5563; }
+    textarea { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; width: 100%; }
+    .specs-row { display: flex; gap: 10px; align-items: flex-start; }
+    .specs-row textarea { flex: 1; }
+    .small { font-size: 12px; color: #6b7280; }
+    .figure-grid {
+      --figure-columns: 1;
+      display: grid;
+      gap: var(--gap);
+      grid-template-columns: repeat(var(--figure-columns), minmax(0, 1fr));
+      align-items: stretch;
+    }
+    .figure-grid[data-figures="2"] { --figure-columns: 2; }
+    .figure {
+      position: relative;
+      border-radius: 12px;
+      border: 1px solid #eef0f3;
+      background: #fdfdfe;
+      overflow: hidden;
+      min-height: 340px;
+      display: flex;
+      flex-direction: column;
+    }
+    .figure.is-hidden { display: none; }
+    .figureCanvas { flex: 1; }
+    .figureCanvas canvas { width: 100%; height: 100%; display: block; }
+    .figureLabel {
+      position: absolute;
+      inset: auto 12px 12px 12px;
+      padding: 6px 10px;
+      border-radius: 8px;
+      background: rgba(17, 24, 39, .72);
+      color: #f9fafb;
+      font-size: 13px;
+      letter-spacing: .01em;
+      pointer-events: none;
+    }
+    @media (max-width: 720px) {
+      .grid { grid-template-columns: 1fr; }
+      .figure-grid { --figure-columns: 1; }
+    }
+  </style>
+  <link rel="stylesheet" href="split.css" />
+</head>
+<body>
+  <div class="wrap">
+    <div class="grid">
+      <div class="card">
+        <div id="figureGrid" class="figure-grid" data-figures="1">
+          <div class="figure" data-figure-index="0">
+            <div class="figureCanvas" id="figure0"></div>
+            <div class="figureLabel" aria-live="polite"></div>
+          </div>
+          <div class="figure is-hidden" data-figure-index="1">
+            <div class="figureCanvas" id="figure1"></div>
+            <div class="figureLabel" aria-live="polite"></div>
+          </div>
+        </div>
+      </div>
+      <div class="side">
+        <div class="card">
+          <h2>Eksempler</h2>
+          <div class="toolbar">
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Innstillinger</h2>
+          <label for="inpSpecs">Skriv fritekst (én figur per linje)</label>
+          <div class="specs-row">
+            <textarea id="inpSpecs" rows="4" spellcheck="false">kule</textarea>
+            <button id="btnDraw" class="btn" type="button">Tegn</button>
+          </div>
+          <div class="small">Bruk ordene <strong>prisme</strong>, <strong>trekantet sylinder</strong>, <strong>firkantet sylinder</strong>, <strong>pyramide</strong> eller <strong>kule</strong>.</div>
+          <div class="small">Trykk Ctrl+Enter (eller ⌘+Enter) for å tegne mens du skriver.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="https://unpkg.com/three@0.158.0/build/three.min.js"></script>
+  <script src="https://unpkg.com/three@0.158.0/examples/js/controls/OrbitControls.js"></script>
+  <script src="trefigurer.js"></script>
+  <script src="examples.js"></script>
+  <script src="split.js"></script>
+</body>
+</html>

--- a/trefigurer.js
+++ b/trefigurer.js
@@ -1,0 +1,307 @@
+(function(){
+  if (typeof THREE === 'undefined') {
+    console.error('THREE.js er ikke lastet inn.');
+    return;
+  }
+
+  class ShapeRenderer {
+    constructor(container) {
+      this.container = container;
+      this.scene = new THREE.Scene();
+      this.scene.background = new THREE.Color(0xf6f7fb);
+
+      this.camera = new THREE.PerspectiveCamera(35, 1, 0.1, 100);
+      this.camera.position.set(4.2, 3.6, 5.6);
+
+      this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+      this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      this.renderer.shadowMap.enabled = false;
+      this.container.appendChild(this.renderer.domElement);
+
+      this.controls = typeof THREE.OrbitControls === 'function'
+        ? new THREE.OrbitControls(this.camera, this.renderer.domElement)
+        : null;
+      if (this.controls) {
+        this.controls.enableDamping = true;
+        this.controls.enablePan = false;
+        this.controls.minDistance = 2.5;
+        this.controls.maxDistance = 12;
+        this.controls.target.set(0, 1.1, 0);
+        this.controls.addEventListener('start', () => { this.userIsInteracting = true; });
+        this.controls.addEventListener('end', () => { this.userIsInteracting = false; });
+      }
+
+      const ambient = new THREE.AmbientLight(0xffffff, 0.55);
+      this.scene.add(ambient);
+
+      const keyLight = new THREE.DirectionalLight(0xffffff, 0.85);
+      keyLight.position.set(5, 8, 6);
+      this.scene.add(keyLight);
+
+      const fillLight = new THREE.DirectionalLight(0xffffff, 0.35);
+      fillLight.position.set(-4, 4, -2);
+      this.scene.add(fillLight);
+
+      const groundMaterial = new THREE.MeshStandardMaterial({
+        color: 0xe5e7eb,
+        roughness: 1,
+        metalness: 0,
+        side: THREE.DoubleSide
+      });
+      const ground = new THREE.Mesh(new THREE.CircleGeometry(3.6, 64), groundMaterial);
+      ground.rotation.x = -Math.PI / 2;
+      ground.position.y = -0.02;
+      this.scene.add(ground);
+
+      this.shapeGroup = new THREE.Group();
+      this.scene.add(this.shapeGroup);
+
+      this._animate = this._animate.bind(this);
+      this._handleResize = this._handleResize.bind(this);
+
+      if (typeof ResizeObserver === 'function') {
+        this.resizeObserver = new ResizeObserver(() => this._handleResize());
+        this.resizeObserver.observe(this.container);
+      } else {
+        window.addEventListener('resize', this._handleResize);
+      }
+
+      this._handleResize();
+      this.renderer.setAnimationLoop(this._animate);
+    }
+
+    _handleResize() {
+      const width = this.container.clientWidth;
+      const height = this.container.clientHeight || Math.max(320, Math.round(width * 0.75));
+      if (!width) return;
+      this.renderer.setSize(width, height, false);
+      this.camera.aspect = width / height;
+      this.camera.updateProjectionMatrix();
+    }
+
+    _animate() {
+      if (!this.userIsInteracting && this.shapeGroup.children.length) {
+        this.shapeGroup.rotation.y += 0.006;
+      }
+      if (this.controls) this.controls.update();
+      this.renderer.render(this.scene, this.camera);
+    }
+
+    disposeCurrentShape() {
+      if (!this.currentShape) return;
+      this.shapeGroup.remove(this.currentShape);
+      this.currentShape.traverse(obj => {
+        if (obj.geometry) obj.geometry.dispose();
+        if (obj.material) {
+          if (Array.isArray(obj.material)) {
+            obj.material.forEach(mat => mat.dispose());
+          } else if (typeof obj.material.dispose === 'function') {
+            obj.material.dispose();
+          }
+        }
+      });
+      this.currentShape = null;
+      this.shapeGroup.rotation.set(0, 0, 0);
+    }
+
+    createMaterial(color) {
+      return new THREE.MeshStandardMaterial({
+        color,
+        metalness: 0,
+        roughness: 0.36,
+        flatShading: true
+      });
+    }
+
+    createEdges(geometry, color = 0x1f2937) {
+      return new THREE.LineSegments(
+        new THREE.EdgesGeometry(geometry),
+        new THREE.LineBasicMaterial({ color })
+      );
+    }
+
+    createShape(type) {
+      const group = new THREE.Group();
+      let geometry;
+      let rotationY = 0;
+      let materialColor = 0x3b82f6;
+
+      switch (type) {
+        case 'sphere': {
+          const radius = 1.35;
+          geometry = new THREE.SphereGeometry(radius, 40, 32);
+          geometry.translate(0, radius, 0);
+          materialColor = 0x6366f1;
+          break;
+        }
+        case 'pyramid': {
+          const height = 2.8;
+          const radius = 1.7;
+          geometry = new THREE.ConeGeometry(radius, height, 4, 1);
+          geometry.translate(0, height / 2, 0);
+          rotationY = Math.PI / 4;
+          materialColor = 0xf59e0b;
+          break;
+        }
+        case 'triangular-cylinder': {
+          const height = 3;
+          const radius = 1.6;
+          geometry = new THREE.CylinderGeometry(radius, radius, height, 3, 1, false);
+          geometry.translate(0, height / 2, 0);
+          rotationY = Math.PI / 6;
+          materialColor = 0x0ea5e9;
+          break;
+        }
+        case 'square-cylinder': {
+          const height = 3.2;
+          const radius = 1.55;
+          geometry = new THREE.CylinderGeometry(radius, radius, height, 4, 1, false);
+          geometry.translate(0, height / 2, 0);
+          rotationY = Math.PI / 4;
+          materialColor = 0x10b981;
+          break;
+        }
+        case 'cylinder': {
+          const height = 3.2;
+          const radius = 1.6;
+          geometry = new THREE.CylinderGeometry(radius, radius, height, 32, 1, false);
+          geometry.translate(0, height / 2, 0);
+          materialColor = 0x0ea5e9;
+          break;
+        }
+        case 'prism':
+        default: {
+          const width = 2.6;
+          const height = 2.2;
+          const depth = 1.8;
+          geometry = new THREE.BoxGeometry(width, height, depth);
+          geometry.translate(0, height / 2, 0);
+          materialColor = 0x3b82f6;
+          break;
+        }
+      }
+
+      const mesh = new THREE.Mesh(geometry, this.createMaterial(materialColor));
+      group.add(mesh);
+      if (type !== 'sphere') {
+        const edges = this.createEdges(geometry);
+        group.add(edges);
+      }
+      group.rotation.y = rotationY;
+      return group;
+    }
+
+    setShape(type) {
+      this.disposeCurrentShape();
+      if (!type) return;
+      this.currentShape = this.createShape(type);
+      this.shapeGroup.add(this.currentShape);
+    }
+
+    clear() {
+      this.disposeCurrentShape();
+    }
+  }
+
+  const grid = document.getElementById('figureGrid');
+  const figureWrappers = Array.from(document.querySelectorAll('[data-figure-index]'));
+  const renderers = figureWrappers.map(wrapper => {
+    const canvasWrap = wrapper.querySelector('.figureCanvas');
+    return new ShapeRenderer(canvasWrap);
+  });
+
+  const textarea = document.getElementById('inpSpecs');
+  const drawBtn = document.getElementById('btnDraw');
+
+  const defaultInput = textarea ? textarea.value : 'kule';
+  window.STATE = window.STATE || {};
+  if (typeof window.STATE.rawInput !== 'string') {
+    window.STATE.rawInput = defaultInput;
+  }
+  if (!Array.isArray(window.STATE.figures)) {
+    window.STATE.figures = [];
+  }
+
+  function detectType(line) {
+    const normalized = line.toLowerCase();
+    if (normalized.includes('kule')) return 'sphere';
+    if (normalized.includes('pyram')) return 'pyramid';
+    if (normalized.includes('trekant') && normalized.includes('sylinder')) return 'triangular-cylinder';
+    if (normalized.includes('firkant') && normalized.includes('sylinder')) return 'square-cylinder';
+    if (normalized.includes('kvadrat') && normalized.includes('sylinder')) return 'square-cylinder';
+    if (normalized.includes('sylinder')) return 'cylinder';
+    if (normalized.includes('prism')) return 'prism';
+    return 'prism';
+  }
+
+  function parseInput(rawInput) {
+    const lines = rawInput.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+    const figures = [];
+    for (const line of lines) {
+      const type = detectType(line);
+      figures.push({ input: line, type });
+      if (figures.length >= renderers.length) break;
+    }
+    return figures;
+  }
+
+  function updateForm(rawInput) {
+    if (textarea && textarea.value !== rawInput) {
+      textarea.value = rawInput;
+    }
+  }
+
+  function updateFigures(figures) {
+    const count = Math.max(figures.length, 1);
+    if (grid) {
+      grid.dataset.figures = String(count);
+    }
+    figureWrappers.forEach((wrapper, index) => {
+      const renderer = renderers[index];
+      const info = figures[index];
+      const label = wrapper.querySelector('.figureLabel');
+      if (info) {
+        wrapper.classList.remove('is-hidden');
+        renderer.setShape(info.type);
+        if (typeof renderer._handleResize === 'function') {
+          renderer._handleResize();
+        }
+        if (label) label.textContent = info.input;
+      } else {
+        renderer.clear();
+        wrapper.classList.add('is-hidden');
+        if (label) label.textContent = '';
+      }
+    });
+  }
+
+  function draw() {
+    const rawInput = typeof window.STATE.rawInput === 'string' ? window.STATE.rawInput : defaultInput;
+    const figures = parseInput(rawInput);
+    window.STATE.rawInput = rawInput;
+    window.STATE.figures = figures;
+    updateForm(rawInput);
+    updateFigures(figures);
+  }
+
+  if (drawBtn) {
+    drawBtn.addEventListener('click', () => {
+      window.STATE.rawInput = textarea ? textarea.value : '';
+      draw();
+    });
+  }
+
+  if (textarea) {
+    textarea.addEventListener('keydown', evt => {
+      if ((evt.metaKey || evt.ctrlKey) && evt.key === 'Enter') {
+        evt.preventDefault();
+        window.STATE.rawInput = textarea.value;
+        draw();
+      }
+    });
+  }
+
+  window.draw = draw;
+
+  draw();
+})();


### PR DESCRIPTION
## Summary
- add a Trefigurer page with layout and controls for the new 3D visualiser
- implement a Three.js renderer that builds prisms, cylinders, pyramids and spheres from free-text input
- expose the visualiser through the main navigation

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9ab4493648324b5cd16c6fb539b3a