### PR TITLE
Vis brøker i tenkeblokker som \frac og oppdater ikon

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,12 @@
       </li>
       <li>
         <a href="tenkeblokker.html" target="content" title="Tenkeblokker" aria-label="Tenkeblokker">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" d="M4 7h16M4 7v4M20 7v4"/><rect x="5" y="11" width="4" height="4" fill="currentColor" stroke="none"/><rect x="10" y="11" width="4" height="4" fill="currentColor" stroke="none"/><rect x="15" y="11" width="4" height="4" fill="currentColor" stroke="none"/></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <rect x="3" y="7" width="9" height="10" fill="currentColor" opacity=".2" stroke="none" />
+            <rect x="3" y="7" width="4.5" height="10" fill="currentColor" opacity=".35" stroke="none" />
+            <rect x="3" y="7" width="18" height="10" rx="2" ry="2" fill="none" stroke="currentColor" stroke-linejoin="round" />
+            <path stroke-linecap="round" stroke-dasharray="1.6 1.6" d="M7.5 7v10M12 7v10M16.5 7v10" fill="none" />
+          </svg>
           <span class="sr-only">Tenkeblokker</span>
         </a>
       </li>

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -444,7 +444,7 @@ function drawBlock(index) {
 
   const displayMode = sanitizeDisplayMode(cfg.valueDisplay) || 'number';
   const per = cfg.n ? cfg.total / cfg.n : 0;
-  const fracText = cfg.n ? `1/${cfg.n}` : '0';
+  const fracText = cfg.n ? `\frac{1}{${cfg.n}}` : '0';
   const percentValue = cfg.n ? (100 / cfg.n) : 0;
 
   for (let i = 0; i < cfg.n; i++) {


### PR DESCRIPTION
## Summary
- viser brøkverdier i tenkeblokker med LaTeX-strengen `\frac{1}{n}` i stedet for `1/n`
- oppdaterer navigasjonsikonet for tenkeblokker slik at det ligner den faktiske figuren uten håndtak

## Testing
- ikke kjørt (ikke forespurt)


------
https://chatgpt.com/codex/tasks/task_e_68c9ae3dd18c8324a2c5ac2dcb5c624a