### PR TITLE
Update brøkpizza navigation icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,11 +168,17 @@
       <li>
         <a href="brøkpizza.html" target="content" title="Brøkpizza" aria-label="Brøkpizza">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r="8.5" fill="#eef2ff" stroke="currentColor" stroke-width="1.6" />
-            <path d="M12 12L12 4.5A7.5 7.5 0 0 1 19.5 12Z" fill="#4b3abf" stroke="currentColor" stroke-width="1.1" stroke-linejoin="round" />
-            <line x1="12" y1="4.5" x2="12" y2="19.5" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" />
-            <line x1="12" y1="12" x2="19.5" y2="12" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" />
-            <circle cx="12" cy="12" r="1.2" fill="#1f2937" />
+            <circle cx="12" cy="12" r="9" fill="currentColor" fill-opacity=".12" />
+            <path d="M12 12L12 3A9 9 0 0 1 21 12Z" fill="currentColor" fill-opacity=".42" />
+            <path d="M12 12L7.5 4.206A9 9 0 0 1 3 12Z" fill="currentColor" fill-opacity=".25" />
+            <g stroke="currentColor" stroke-width="1.15" stroke-linecap="round" stroke-dasharray="1.35 2" fill="none">
+              <line x1="12" y1="3" x2="12" y2="21" />
+              <line x1="3" y1="12" x2="21" y2="12" />
+              <line x1="7.5" y1="4.206" x2="16.5" y2="19.794" />
+              <line x1="16.5" y1="4.206" x2="7.5" y2="19.794" />
+            </g>
+            <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.45" />
+            <circle cx="12" cy="12" r="1.35" fill="currentColor" />
           </svg>
           <span class="sr-only">Brøkpizza</span>
         </a>


### PR DESCRIPTION
## Summary
- redesign the Brøkpizza navigation icon with a two-tone pizza illustration
- highlight sixth and quarter slices and add dotted guides for the sector divisions

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68c9af4a234083249c3b2cc3fba582ca