### PR TITLE
Move trefigurer link and improve scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,17 +139,6 @@
         </a>
       </li>
       <li>
-        <a href="trefigurer.html" target="content" title="Trefigurer" aria-label="Trefigurer">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M12 3 4 7v10l8 4 8-4V7Z" fill="currentColor" fill-opacity=".25" />
-            <path d="M12 3v10l8 4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-linecap="round" stroke-width="1.4" />
-            <path d="M12 3 4 7l8 4 8-4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.4" />
-            <path d="M4 7v10l8 4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.4" />
-          </svg>
-          <span class="sr-only">Trefigurer</span>
-        </a>
-      </li>
-      <li>
         <a href="diagram/index.html" target="content" title="Diagram" aria-label="Diagram">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path d="M4.25 3.75v15.5" stroke-linecap="round" stroke-width="1.5" />
@@ -223,6 +212,17 @@
         <a href="kvikkbilder.html" target="content" title="Kvikkbilder" aria-label="Kvikkbilder">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><circle cx="6" cy="8" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="8" r="1.5" fill="currentColor" stroke="none"/><circle cx="18" cy="8" r="1.5" fill="currentColor" stroke="none"/><circle cx="6" cy="16" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="16" r="1.5" fill="currentColor" stroke="none"/><circle cx="18" cy="16" r="1.5" fill="currentColor" stroke="none"/></svg>
           <span class="sr-only">Kvikkbilder</span>
+        </a>
+      </li>
+      <li>
+        <a href="trefigurer.html" target="content" title="Trefigurer" aria-label="Trefigurer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 3 4 7v10l8 4 8-4V7Z" fill="currentColor" fill-opacity=".25" />
+            <path d="M12 3v10l8 4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-linecap="round" stroke-width="1.4" />
+            <path d="M12 3 4 7l8 4 8-4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.4" />
+            <path d="M4 7v10l8 4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.4" />
+          </svg>
+          <span class="sr-only">Trefigurer</span>
         </a>
       </li>
       <li>

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -61,12 +61,17 @@
       border: 1px solid #eef0f3;
       background: #fdfdfe;
       overflow: hidden;
-      min-height: 340px;
       display: flex;
       flex-direction: column;
+      min-height: 0;
     }
     .figure.is-hidden { display: none; }
-    .figureCanvas { flex: 1; }
+    .figureCanvas {
+      position: relative;
+      flex: 0 0 auto;
+      min-height: 320px;
+      aspect-ratio: 4 / 3;
+    }
     .figureCanvas canvas { width: 100%; height: 100%; display: block; }
     .figureLabel {
       position: absolute;
@@ -82,6 +87,7 @@
     @media (max-width: 720px) {
       .grid { grid-template-columns: 1fr; }
       .figure-grid { --figure-columns: 1; }
+      .figureCanvas { min-height: 280px; }
     }
   </style>
   <link rel="stylesheet" href="split.css" />

--- a/trefigurer.js
+++ b/trefigurer.js
@@ -72,8 +72,14 @@
 
     _handleResize() {
       const width = this.container.clientWidth;
-      const height = this.container.clientHeight || Math.max(320, Math.round(width * 0.75));
       if (!width) return;
+
+      const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : null;
+      const maxHeight = viewportHeight ? viewportHeight * 0.7 : Infinity;
+      const preferred = width * 0.72;
+      const height = Math.max(280, Math.min(Math.round(preferred), 560, maxHeight));
+
+      this.container.style.height = `${height}px`;
       this.renderer.setSize(width, height, false);
       this.camera.aspect = width / height;
       this.camera.updateProjectionMatrix();


### PR DESCRIPTION
## Summary
- move the Trefigurer navigation item to the end of the visualization list
- tweak the Trefigurer layout styles to allow the canvas to scale with the available space
- adjust the resize logic to clamp the renderer height for a steadier aspect ratio

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c9af95ff9c832488dcb9c11ea39c0c