### PR TITLE
Remove reset button from Arealmodell B

### DIFF
--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -98,7 +98,6 @@
               <label class="chk"><input id="grid" type="checkbox"> Vis rutenett</label>
               <label class="chk"><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
             </div>
-            <button id="btnReset" class="btn" type="button">Reset</button>
           </div>
         </div>
         <div class="card">

--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -549,14 +549,6 @@ function draw(){
     });
   }
 
-  // Reset
-  const btnReset = document.getElementById("btnReset");
-  if(btnReset) btnReset.onclick = () => {
-    sx = clampInt(initLeftCols,   1, COLS-1) * UNIT;
-    sy = clampInt(initBottomRows, 1, ROWS-1) * UNIT;
-    scheduleRedraw();
-  };
-
   function buildExportOptions(){
     const includeHandles = (showLeftHandle || showBottomHandle) || ADV.export?.includeHandlesIfHidden;
     return {


### PR DESCRIPTION
## Summary
- remove the Reset button from the Arealmodell B settings panel
- delete the unused JavaScript handler that referenced the removed button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9b2faeb108324824746c4498fcefb