### PR TITLE
Improve 3D figure framing and add rotation lock

### DIFF
--- a/trefigurer.html
+++ b/trefigurer.html
@@ -83,6 +83,26 @@
       .grid { grid-template-columns: 1fr; }
       .figure-grid { --figure-columns: 1; }
     }
+    .option-row {
+      margin-top: 10px;
+    }
+    .checkbox {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      color: #4b5563;
+      cursor: pointer;
+      user-select: none;
+    }
+    .checkbox input {
+      width: 16px;
+      height: 16px;
+      accent-color: #3b82f6;
+    }
+    .checkbox span {
+      line-height: 1.3;
+    }
   </style>
   <link rel="stylesheet" href="split.css" />
 </head>
@@ -118,6 +138,12 @@
           </div>
           <div class="small">Bruk ordene <strong>prisme</strong>, <strong>trekantet sylinder</strong>, <strong>firkantet sylinder</strong>, <strong>pyramide</strong> eller <strong>kule</strong>.</div>
           <div class="small">Trykk Ctrl+Enter (eller ⌘+Enter) for å tegne mens du skriver.</div>
+          <div class="option-row">
+            <label class="checkbox">
+              <input id="chkLockRotation" type="checkbox" />
+              <span>Lås rotasjonen</span>
+            </label>
+          </div>
         </div>
       </div>
     </div>

--- a/trefigurer.js
+++ b/trefigurer.js
@@ -56,6 +56,10 @@
       this.shapeGroup = new THREE.Group();
       this.scene.add(this.shapeGroup);
 
+      this.currentFrame = null;
+      this.rotationLocked = false;
+      this.fitMargin = 1.2;
+
       this._animate = this._animate.bind(this);
       this._handleResize = this._handleResize.bind(this);
 
@@ -75,16 +79,105 @@
       const height = this.container.clientHeight || Math.max(320, Math.round(width * 0.75));
       if (!width) return;
       this.renderer.setSize(width, height, false);
-      this.camera.aspect = width / height;
+      this.camera.aspect = width / Math.max(height, 1);
       this.camera.updateProjectionMatrix();
+      this._ensureFrameFits();
     }
 
     _animate() {
-      if (!this.userIsInteracting && this.shapeGroup.children.length) {
+      if (!this.rotationLocked && !this.userIsInteracting && this.shapeGroup.children.length) {
         this.shapeGroup.rotation.y += 0.006;
       }
       if (this.controls) this.controls.update();
       this.renderer.render(this.scene, this.camera);
+    }
+
+    _computeFitDistance(size) {
+      if (!size) return 0;
+      const halfFov = THREE.MathUtils.degToRad((this.camera.fov || 35) / 2);
+      const safeHalfFov = Math.max(halfFov, 0.001);
+      const aspect = this.camera.aspect || 1;
+      const halfHeight = Math.max(size.y / 2, 0.01);
+      const maxHorizontal = Math.max(size.x, size.z) / 2 || 0.01;
+      const distanceForHeight = halfHeight / Math.tan(safeHalfFov);
+      const halfHorizontalFov = Math.atan(Math.tan(safeHalfFov) * aspect);
+      const safeHalfHorizontal = Math.max(halfHorizontalFov, 0.001);
+      const distanceForWidth = maxHorizontal / Math.tan(safeHalfHorizontal);
+      return Math.max(distanceForHeight, distanceForWidth);
+    }
+
+    _updateControlsDistances(baseDistance, currentDistance = baseDistance) {
+      if (!this.controls) return;
+      const minDistance = Math.max(0.6, baseDistance * 0.45);
+      const maxDistance = Math.max(baseDistance * 3, currentDistance * 1.1, minDistance + 1.5);
+      this.controls.minDistance = minDistance;
+      this.controls.maxDistance = maxDistance;
+    }
+
+    frameCurrentShape() {
+      if (!this.currentShape) return;
+      this.currentShape.updateMatrixWorld(true);
+      this.shapeGroup.updateMatrixWorld(true);
+      const boundingBox = new THREE.Box3().setFromObject(this.currentShape);
+      if (boundingBox.isEmpty()) return;
+      const size = new THREE.Vector3();
+      boundingBox.getSize(size);
+      const center = new THREE.Vector3();
+      boundingBox.getCenter(center);
+      const direction = this.camera.position.clone().sub(this.controls ? this.controls.target : center);
+      if (!direction.lengthSq()) {
+        direction.set(0, 0, 1);
+      }
+      const requiredDistance = Math.max(this._computeFitDistance(size) * this.fitMargin, 0.5);
+      const offset = direction.normalize().multiplyScalar(requiredDistance);
+      const newPosition = center.clone().add(offset);
+      this.camera.position.copy(newPosition);
+      if (this.controls) {
+        this.controls.target.copy(center);
+        this._updateControlsDistances(requiredDistance);
+        this.controls.update();
+      } else {
+        this.camera.lookAt(center);
+      }
+      this.currentFrame = {
+        center: center.clone(),
+        size: size.clone(),
+        distance: requiredDistance
+      };
+      this.camera.updateProjectionMatrix();
+    }
+
+    _ensureFrameFits() {
+      if (!this.currentFrame) return;
+      const center = this.currentFrame.center;
+      const desiredDistance = Math.max(this._computeFitDistance(this.currentFrame.size) * this.fitMargin, 0.5);
+      const toCamera = this.camera.position.clone().sub(center);
+      if (!toCamera.lengthSq()) {
+        toCamera.set(0, 0, 1);
+      }
+      const currentDistance = toCamera.length();
+      if (currentDistance + 1e-4 < desiredDistance) {
+        const adjusted = toCamera.normalize().multiplyScalar(desiredDistance);
+        const newPosition = center.clone().add(adjusted);
+        this.camera.position.copy(newPosition);
+        if (this.controls) {
+          this.controls.update();
+        } else {
+          this.camera.lookAt(center);
+        }
+      }
+      this.currentFrame.distance = this.camera.position.distanceTo(center);
+    }
+
+    setRotationLocked(isLocked) {
+      this.rotationLocked = Boolean(isLocked);
+      if (this.rotationLocked) {
+        this.userIsInteracting = false;
+      }
+      if (this.controls) {
+        this.controls.enableRotate = !this.rotationLocked;
+        this.controls.update();
+      }
     }
 
     disposeCurrentShape() {
@@ -102,6 +195,7 @@
       });
       this.currentShape = null;
       this.shapeGroup.rotation.set(0, 0, 0);
+      this.currentFrame = null;
     }
 
     createMaterial(color) {
@@ -196,6 +290,7 @@
       if (!type) return;
       this.currentShape = this.createShape(type);
       this.shapeGroup.add(this.currentShape);
+      this.frameCurrentShape();
     }
 
     clear() {
@@ -212,6 +307,7 @@
 
   const textarea = document.getElementById('inpSpecs');
   const drawBtn = document.getElementById('btnDraw');
+  const lockRotationCheckbox = document.getElementById('chkLockRotation');
 
   const defaultInput = textarea ? textarea.value : 'kule';
   window.STATE = window.STATE || {};
@@ -221,6 +317,17 @@
   if (!Array.isArray(window.STATE.figures)) {
     window.STATE.figures = [];
   }
+  if (typeof window.STATE.rotationLocked !== 'boolean') {
+    window.STATE.rotationLocked = lockRotationCheckbox ? lockRotationCheckbox.checked : false;
+  }
+  if (lockRotationCheckbox) {
+    lockRotationCheckbox.checked = window.STATE.rotationLocked;
+  }
+
+  const applyRotationLock = locked => {
+    renderers.forEach(renderer => renderer.setRotationLocked(locked));
+  };
+  applyRotationLock(window.STATE.rotationLocked);
 
   function detectType(line) {
     const normalized = line.toLowerCase();
@@ -288,6 +395,14 @@
     drawBtn.addEventListener('click', () => {
       window.STATE.rawInput = textarea ? textarea.value : '';
       draw();
+    });
+  }
+
+  if (lockRotationCheckbox) {
+    lockRotationCheckbox.addEventListener('change', evt => {
+      const locked = Boolean(evt.target.checked);
+      window.STATE.rotationLocked = locked;
+      applyRotationLock(locked);
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure 3D shapes are fully visible by fitting the camera to the rendered geometry and reacting to resize events
- add a rotation lock option with associated styling so automatic and manual rotation can be disabled while still allowing zooming

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9b18f4e748324bdfd8b60bbc1b7ba