### PR TITLE
Add floating toggle for 3D figures

### DIFF
--- a/trefigurer.html
+++ b/trefigurer.html
@@ -73,17 +73,6 @@
       aspect-ratio: 4 / 3;
     }
     .figureCanvas canvas { width: 100%; height: 100%; display: block; }
-    .figureLabel {
-      position: absolute;
-      inset: auto 12px 12px 12px;
-      padding: 6px 10px;
-      border-radius: 8px;
-      background: rgba(17, 24, 39, .72);
-      color: #f9fafb;
-      font-size: 13px;
-      letter-spacing: .01em;
-      pointer-events: none;
-    }
     @media (max-width: 720px) {
       .grid { grid-template-columns: 1fr; }
       .figure-grid { --figure-columns: 1; }
@@ -119,11 +108,9 @@
         <div id="figureGrid" class="figure-grid" data-figures="1">
           <div class="figure" data-figure-index="0">
             <div class="figureCanvas" id="figure0"></div>
-            <div class="figureLabel" aria-live="polite"></div>
           </div>
           <div class="figure is-hidden" data-figure-index="1">
             <div class="figureCanvas" id="figure1"></div>
-            <div class="figureLabel" aria-live="polite"></div>
           </div>
         </div>
       </div>
@@ -148,6 +135,12 @@
             <label class="checkbox">
               <input id="chkLockRotation" type="checkbox" />
               <span>Lås rotasjonen</span>
+            </label>
+          </div>
+          <div class="option-row">
+            <label class="checkbox">
+              <input id="chkFreeFigure" type="checkbox" />
+              <span>Fri figuren</span>
             </label>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the visible name labels from each 3D figure card
- add a checkbox that lets users free the figures from the base plane
- recenter floating figures and hide the ground so they can be viewed from above or below

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9c3b3dc388324b5d674f3c8566881