### PR TITLE
Adjust Kuler layout to enlarge bowl and shrink add button

### DIFF
--- a/kuler.html
+++ b/kuler.html
@@ -21,22 +21,25 @@
       gap:var(--gap);
       grid-template-columns:repeat(var(--figure-columns),minmax(0,1fr));
       align-items:start;
+      justify-items:center;
     }
-    .figureGrid[data-figures="2"],
-    .figureGrid[data-add-visible="true"]{--figure-columns:2;}
-    .figurePanel{display:flex;flex-direction:column;gap:12px;align-items:stretch;}
+    .figureGrid[data-figures="2"]{
+      --figure-columns:2;
+      justify-items:stretch;
+    }
+    .figurePanel{display:flex;flex-direction:column;gap:12px;align-items:stretch;width:100%;max-width:720px;margin:0 auto;}
     .figurePanel .btn{align-self:center;}
     .removeFigureBtn[disabled]{opacity:0.5;cursor:not-allowed;}
-    .addFigureBtn{width:clamp(30px,7.5vw,60px);aspect-ratio:1;border:2px dashed #cfcfcf;border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;font-size:20px;color:#6b7280;cursor:pointer;justify-self:center;align-self:flex-start;}
+    .addFigureBtn{width:clamp(36px,8vw,56px);aspect-ratio:1;border:2px dashed #cfcfcf;border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;font-size:18px;color:#6b7280;cursor:pointer;justify-self:center;align-self:center;}
     @media(max-width:980px){.grid{grid-template-columns:1fr;}}
-    @media(max-width:720px){.figureGrid{--figure-columns:1;}.addFigureBtn{width:clamp(30px,15vw,70px);}}
+    @media(max-width:720px){.figureGrid{--figure-columns:1;justify-items:center;}.figurePanel{max-width:100%;}.figure{max-width:100%;}.addFigureBtn{width:clamp(36px,14vw,60px);}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
       box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
       display:flex;flex-direction:column;gap:10px;
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;width:100%;}
+    .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;width:100%;max-width:680px;margin:0 auto;}
     .figure svg{width:100%;height:auto;display:block;touch-action:none;}
     .ctrlRow{display:flex;align-items:center;gap:6px;font-size:14px;}
     .controlsWrap.controlsWrap--split .ctrlRow{flex-wrap:wrap;}


### PR DESCRIPTION
## Summary
- enlarge the Kuler figure container and center it so the bowl appears larger on screen
- keep two-figure layouts responsive while centering single panels similar to the brøkpizza page
- shrink and center the add-figure button for a less dominant appearance

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c44fdb48832498363e37d91421fa