### PR TITLE
Render fraction labels in tenkeblokker

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -81,6 +81,9 @@
     .tb-brace{fill:none;stroke:#0e6577;stroke-width:6;stroke-linecap:round}
     .tb-total{font-size:34px;fill:#000;text-anchor:middle}
     .tb-val{font-size:34px;fill:#111;text-anchor:middle;dominant-baseline:middle}
+    .tb-frac{text-anchor:middle;}
+    .tb-frac text{font-size:28px;fill:#111;text-anchor:middle;font-variant-numeric:tabular-nums;}
+    .tb-frac-line{stroke:#111;stroke-width:2;stroke-linecap:square}
     .tb-handle-shadow{fill:#000;opacity:.12}
     .tb-handle{fill:#f1f1f6;stroke:#555;stroke-width:2;cursor:pointer}
     /* Stepper */


### PR DESCRIPTION
## Summary
- add an SVG helper that draws stacked numerator/denominator pairs for fraction labels
- render the helper when the display mode is set to fractions so the cells show 1/n instead of the raw LaTeX string
- style the new fraction elements to match the existing typography

## Testing
- Manual: `npm start` and viewed tenkeblokker.html with "Vis som" set to "Brøk"

------
https://chatgpt.com/codex/tasks/task_e_68c9c7e8e4988324bd447baad1016b3c