### PR TITLE
Restore original navigation icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,9 +69,7 @@
       width: 1.75rem;
       height: 1.75rem;
       flex-shrink: 0;
-      stroke-width: 1.6;
-      stroke-linecap: round;
-      stroke-linejoin: round;
+      stroke-width: 1.75;
     }
     .sr-only {
       position: absolute;
@@ -125,212 +123,126 @@
     <ul>
       <li>
         <a href="graftegner.html" target="content" title="Graftegner" aria-label="Graftegner">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M6 5.4v12.6" fill="none" stroke="currentColor" stroke-width="1.55" />
-            <path d="M5.4 18.5h13.8" fill="none" stroke="currentColor" stroke-width="1.55" />
-            <path d="M9.3 7.2v10.5" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".35" />
-            <path d="M12.6 7.2v10.5" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".25" />
-            <path d="M6 10.3h12.8" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".35" />
-            <path d="M6 13.7h12.8" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".25" />
-            <path d="M6.3 15.8c1.2-4.5 3.3-6.7 5.5-5.9 1.7.6 2.9 2.4 4.1 5.8" fill="none" stroke="currentColor" stroke-width="1.6" />
-            <circle cx="13.1" cy="10.1" r="1" fill="currentColor" />
-            <circle cx="13.1" cy="10.1" r="1.7" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity=".35" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6.5 8.5Q12 21 17.5 8.5" />
           </svg>
           <span class="sr-only">Graftegner</span>
         </a>
       </li>
       <li>
         <a href="nkant.html" target="content" title="nKant" aria-label="nKant">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M12 4.8 5.5 9.4 7.2 18.6 16.8 18.6 19 8.8Z" fill="currentColor" fill-opacity=".08" />
-            <path d="M12 4.8 5.5 9.4 7.2 18.6 16.8 18.6 19 8.8Z" fill="none" stroke="currentColor" stroke-width="1.55" />
-            <path d="M6 12.3 12 4.8 16.1 12.1" fill="none" stroke="currentColor" stroke-width="1.1" stroke-opacity=".55" />
-            <path d="M6.8 11a3 3 0 0 1 2.1-2.5" fill="none" stroke="currentColor" stroke-width="1.2" />
-            <path d="M13.4 6.1l1 1" stroke="currentColor" stroke-width="1.2" />
-            <path d="M14.9 5.3l1 1" stroke="currentColor" stroke-width="1.2" />
-            <circle cx="12" cy="4.8" r=".95" fill="currentColor" />
-            <circle cx="5.5" cy="9.4" r=".9" fill="currentColor" fill-opacity=".45" />
-            <circle cx="16.8" cy="18.6" r=".9" fill="currentColor" fill-opacity=".45" />
-            <circle cx="19" cy="8.8" r=".85" fill="currentColor" fill-opacity=".35" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <polygon stroke-linejoin="round" points="12 4 20 20 4 20" />
           </svg>
           <span class="sr-only">nKant</span>
         </a>
       </li>
       <li>
         <a href="diagram/index.html" target="content" title="Diagram" aria-label="Diagram">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M5.5 5v13.5" fill="none" stroke="currentColor" stroke-width="1.55" />
-            <path d="M5 18.5h14.5" fill="none" stroke="currentColor" stroke-width="1.55" />
-            <path d="M5 9.5h14.5" fill="none" stroke="currentColor" stroke-width="1" stroke-dasharray="2 2" stroke-opacity=".28" />
-            <path d="M5 14h14.5" fill="none" stroke="currentColor" stroke-width="1" stroke-dasharray="2 2" stroke-opacity=".22" />
-            <rect x="6.6" y="12.2" width="2.6" height="6.3" rx=".7" fill="currentColor" fill-opacity=".22" />
-            <rect x="10" y="9.1" width="2.6" height="9.4" rx=".7" fill="currentColor" fill-opacity=".34" />
-            <rect x="13.4" y="14.2" width="2.6" height="4.3" rx=".7" fill="currentColor" fill-opacity=".18" />
-            <rect x="16.8" y="7.1" width="2.6" height="11.4" rx=".7" fill="currentColor" fill-opacity=".42" />
-            <path d="M6.9 13 10.9 9.8 14.7 14 18.2 7.8" fill="none" stroke="currentColor" stroke-width="1.25" />
-            <circle cx="6.9" cy="13" r=".65" fill="currentColor" />
-            <circle cx="10.9" cy="9.8" r=".65" fill="currentColor" />
-            <circle cx="14.7" cy="14" r=".65" fill="currentColor" />
-            <circle cx="18.2" cy="7.8" r=".65" fill="currentColor" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75Z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625Z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
           </svg>
           <span class="sr-only">Diagram</span>
         </a>
       </li>
       <li>
         <a href="brøkpizza.html" target="content" title="Brøkpizza" aria-label="Brøkpizza">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r="8.5" fill="currentColor" fill-opacity=".08" stroke="currentColor" stroke-width="1.55" />
-            <path d="M12 12V3.5a8.5 8.5 0 0 1 7.3 4.2Z" fill="currentColor" fill-opacity=".35" />
-            <path d="M12 12 4.9 8.4A8.5 8.5 0 0 1 12 3.5Z" fill="currentColor" fill-opacity=".2" />
-            <path d="M12 3.5V20.5" fill="none" stroke="currentColor" stroke-width="1.2" stroke-opacity=".45" stroke-dasharray="1.6 2.4" />
-            <path d="M5 12h14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-opacity=".45" stroke-dasharray="1.6 2.4" />
-            <path d="M12 12l7.1-4.3" fill="none" stroke="currentColor" stroke-width="1.25" />
-            <path d="M12 12l-6.9-3.6" fill="none" stroke="currentColor" stroke-width="1.25" />
-            <path d="M12 12l5.6 6.2" fill="none" stroke="currentColor" stroke-width="1.1" stroke-opacity=".6" />
-            <path d="M12 12l-5.2 6.6" fill="none" stroke="currentColor" stroke-width="1.1" stroke-opacity=".6" />
-            <circle cx="12" cy="12" r="1.2" fill="currentColor" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z" />
           </svg>
           <span class="sr-only">Brøkpizza</span>
         </a>
       </li>
       <li>
         <a href="brøkfigurer.html" target="content" title="Brøkfigurer" aria-label="Brøkfigurer">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <rect x="4.6" y="5.2" width="8.6" height="12.6" rx="1.2" fill="currentColor" fill-opacity=".08" stroke="currentColor" stroke-width="1.5" />
-            <path d="M9 5.2v12.6M4.6 11.5h8.6" fill="none" stroke="currentColor" stroke-width="1.1" stroke-opacity=".58" />
-            <rect x="4.6" y="5.2" width="4.4" height="6.3" fill="currentColor" fill-opacity=".28" />
-            <rect x="4.6" y="11.5" width="4.4" height="6.3" fill="currentColor" fill-opacity=".18" />
-            <path d="M15.2 6.2 19.4 18.2H12.6Z" fill="currentColor" fill-opacity=".08" stroke="currentColor" stroke-width="1.45" stroke-linejoin="round" />
-            <path d="M15.2 6.2v12" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".45" />
-            <path d="M14.9 11.1l3.4 7.1" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".55" />
-            <path d="M13.1 14.8h5.9" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".55" />
-            <circle cx="15.2" cy="6.2" r=".85" fill="currentColor" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <polygon points="4 20 12 20 12 4" fill="currentColor" />
+            <polygon points="4 20 20 20 12 4" />
+            <path stroke-linecap="round" d="M12 4v16" />
           </svg>
           <span class="sr-only">Brøkfigurer</span>
         </a>
       </li>
       <li>
         <a href="figurtall.html" target="content" title="Figurtall" aria-label="Figurtall">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M6.4 18.2 12 6.3l5.6 11.9Z" fill="none" stroke="currentColor" stroke-width="1.45" />
-            <circle cx="12" cy="7.6" r="1" fill="currentColor" />
-            <circle cx="9.6" cy="11.2" r="1" fill="currentColor" />
-            <circle cx="14.4" cy="11.2" r="1" fill="currentColor" />
-            <circle cx="8.1" cy="14.8" r="1" fill="currentColor" />
-            <circle cx="12" cy="14.8" r="1" fill="currentColor" />
-            <circle cx="15.9" cy="14.8" r="1" fill="currentColor" />
-            <path d="M8.1 14.8l3.9-6.8 3.9 6.8" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity=".45" />
-            <circle cx="6.2" cy="18.4" r=".85" fill="currentColor" fill-opacity=".32" />
-            <circle cx="9.2" cy="18.4" r=".85" fill="currentColor" fill-opacity=".32" />
-            <circle cx="12.2" cy="18.4" r=".85" fill="currentColor" fill-opacity=".32" />
-            <circle cx="15.2" cy="18.4" r=".85" fill="currentColor" fill-opacity=".32" />
-            <circle cx="18.2" cy="18.4" r=".85" fill="currentColor" fill-opacity=".16" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <rect x="3" y="15" width="6" height="6" fill="currentColor" stroke="none" />
+            <rect x="9" y="9" width="6" height="6" fill="currentColor" stroke="none" />
+            <rect x="9" y="15" width="6" height="6" fill="currentColor" stroke="none" />
+            <rect x="15" y="3" width="6" height="6" fill="currentColor" stroke="none" />
+            <rect x="15" y="9" width="6" height="6" fill="currentColor" stroke="none" />
+            <rect x="15" y="15" width="6" height="6" fill="currentColor" stroke="none" />
           </svg>
           <span class="sr-only">Figurtall</span>
         </a>
       </li>
       <li>
         <a href="tenkeblokker.html" target="content" title="Tenkeblokker" aria-label="Tenkeblokker">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M5.2 5.3h8.8" fill="none" stroke="currentColor" stroke-width="1.15" />
-            <path d="M5.2 5.3v-1M14 5.3v-1" fill="none" stroke="currentColor" stroke-width="1.15" />
-            <rect x="5.2" y="6.2" width="9.2" height="11.8" rx="1.4" fill="currentColor" fill-opacity=".08" stroke="currentColor" stroke-width="1.45" />
-            <path d="M8.5 6.2v11.8M11.8 6.2v11.8M5.2 11.5h9.2" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".58" />
-            <rect x="15.7" y="7.7" width="4" height="4" rx=".9" fill="currentColor" fill-opacity=".32" stroke="currentColor" stroke-width="1.05" />
-            <rect x="15.7" y="13.2" width="4" height="4" rx=".9" fill="currentColor" fill-opacity=".18" stroke="currentColor" stroke-width="1.05" />
-            <path d="M14.4 9.7h1.3M14.4 15.2h1.3" fill="none" stroke="currentColor" stroke-width="1.05" stroke-dasharray="2 1.2" stroke-opacity=".55" />
-            <path d="M20.4 7.2c-.9 0-1.4.5-1.4 1.4v1.3c0 .8-.6 1.4-1.4 1.4h-1" fill="none" stroke="currentColor" stroke-width="1.05" stroke-linecap="round" />
-            <path d="M20.4 16.8c-.9 0-1.4-.5-1.4-1.4v-1.3c0-.8-.6-1.4-1.4-1.4h-1" fill="none" stroke="currentColor" stroke-width="1.05" stroke-linecap="round" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" d="M4 7h16M4 7v4M20 7v4" />
+            <rect x="5" y="11" width="4" height="4" fill="currentColor" stroke="none" />
+            <rect x="10" y="11" width="4" height="4" fill="currentColor" stroke="none" />
+            <rect x="15" y="11" width="4" height="4" fill="currentColor" stroke="none" />
           </svg>
           <span class="sr-only">Tenkeblokker</span>
         </a>
       </li>
       <li>
         <a href="arealmodell0.html" target="content" title="Arealmodell A" aria-label="Arealmodell A">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <rect x="4.4" y="6" width="14.2" height="11.2" rx="1.3" fill="currentColor" fill-opacity=".08" stroke="currentColor" stroke-width="1.45" />
-            <rect x="4.4" y="6" width="5.1" height="5.6" fill="currentColor" fill-opacity=".22" />
-            <path d="M9.5 6v11.2M13.6 6v11.2M4.4 11.6h14.2" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".58" />
-            <path d="M4.4 4.8h14.2" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".5" />
-            <path d="M4.4 4.8v1.2M18.6 4.8v1.2" fill="none" stroke="currentColor" stroke-width="1.05" stroke-linecap="round" />
-            <path d="M3.2 6v11.2" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".5" />
-            <path d="M3.2 6h1.2M3.2 17.2h1.2" fill="none" stroke="currentColor" stroke-width="1.05" stroke-linecap="round" />
-            <circle cx="19.2" cy="5.8" r=".95" fill="currentColor" fill-opacity=".6" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <rect x="3" y="6" width="18" height="12" />
+            <path stroke-linecap="round" d="M9 6v12M15 6v12M3 12h18" />
+            <circle cx="21" cy="5" r="1.5" />
           </svg>
           <span class="sr-only">Arealmodell A</span>
         </a>
       </li>
       <li>
         <a href="arealmodellen1.html" target="content" title="Arealmodell B" aria-label="Arealmodell B">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <rect x="4.2" y="5" width="14.6" height="13" rx="1.4" fill="none" stroke="currentColor" stroke-width="1.45" />
-            <rect x="4.2" y="5" width="6.8" height="6.2" fill="currentColor" fill-opacity=".22" />
-            <rect x="11" y="5" width="3.8" height="6.2" fill="currentColor" fill-opacity=".12" />
-            <rect x="4.2" y="11.2" width="4.4" height="6.8" fill="currentColor" fill-opacity=".18" />
-            <rect x="8.6" y="11.2" width="6.6" height="6.8" fill="currentColor" fill-opacity=".32" />
-            <path d="M11 5v13M8.6 11.2h10.2M4.2 11.2h14.6" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".58" />
-            <path d="M6.5 5v6.2M9 5v6.2M11 13.5h8M11 16h8" fill="none" stroke="currentColor" stroke-width=".9" stroke-opacity=".35" stroke-dasharray="2 1.6" />
-            <path d="M19.6 6v11" fill="none" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-opacity=".6" />
-            <rect x="18.6" y="10.5" width="2" height="3" rx=".8" fill="currentColor" fill-opacity=".4" stroke="currentColor" stroke-width="1" />
-            <circle cx="18.6" cy="6" r=".75" fill="currentColor" fill-opacity=".35" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <rect x="3" y="4" width="18" height="15" />
+            <path d="M4.5 4v15M6 4v15M7.5 4v15M9 4v15M10.5 4v15M12 4v15M13.5 4v15M15 4v15M16.5 4v15M18 4v15M19.5 4v15" />
+            <path d="M3 5h18M3 6h18M3 7h18M3 8h18M3 9h18M3 10h18M3 11h18M3 12h18M3 13h18M3 14h18M3 15h18M3 16h18M3 17h18M3 18h18" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21 11.5l2 1.5-2 1.5" />
           </svg>
           <span class="sr-only">Arealmodell B</span>
         </a>
       </li>
       <li>
         <a href="perlesnor.html" target="content" title="Perlesnor" aria-label="Perlesnor">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M2.8 10.5c.6.6.6 2.4 0 3" fill="none" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" />
-            <path d="M21.2 10.5c-.6.6-.6 2.4 0 3" fill="none" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" />
-            <path d="M3 12c1.5-2.1 3-2.1 4.5 0s3 2.1 4.5 0 3-2.1 4.5 0 3 2.1 4.5 0" fill="none" stroke="currentColor" stroke-width="1.35" />
-            <circle cx="5.6" cy="12" r="1.2" fill="currentColor" />
-            <circle cx="7.8" cy="12" r="1.2" fill="currentColor" />
-            <circle cx="10" cy="12" r="1.2" fill="currentColor" />
-            <circle cx="12.2" cy="12" r="1.2" fill="currentColor" fill-opacity=".35" />
-            <circle cx="14.4" cy="12" r="1.2" fill="currentColor" fill-opacity=".35" />
-            <circle cx="16.6" cy="12" r="1.2" fill="currentColor" />
-            <circle cx="18.8" cy="12" r="1.2" fill="currentColor" />
-            <path d="M9 9.7c.4-.7 1.6-.7 2 0" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity=".45" />
-            <path d="M14.8 14.3c.4.7 1.6.7 2 0" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity=".45" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M2 12h20" />
+            <circle cx="6" cy="12" r="1.5" />
+            <circle cx="12" cy="12" r="1.5" />
+            <circle cx="18" cy="12" r="1.5" />
           </svg>
           <span class="sr-only">Perlesnor</span>
         </a>
       </li>
       <li>
         <a href="kuler.html" target="content" title="Kuler" aria-label="Kuler">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M4.6 10.8c0 4.6 3.7 8.3 7.4 8.3s7.4-3.7 7.4-8.3" fill="none" stroke="currentColor" stroke-width="1.55" />
-            <path d="M4.6 10.8h14.8" fill="none" stroke="currentColor" stroke-width="1.55" />
-            <path d="M6.2 9.2c1.2-1.1 3.1-1.7 5.8-1.7s4.6.6 5.8 1.7" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".4" />
-            <path d="M6.8 13.1c1.1 2 3 3.1 5.2 3.1s4.1-1.1 5.2-3.1" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".45" />
-            <circle cx="8.9" cy="12.3" r="1.2" fill="currentColor" />
-            <circle cx="11.4" cy="13.1" r="1.3" fill="currentColor" />
-            <circle cx="13.9" cy="12.3" r="1.2" fill="currentColor" />
-            <circle cx="12" cy="15.5" r=".7" fill="currentColor" fill-opacity=".2" />
-            <path d="M7.6 18.4c1 .5 2.2.8 3.4.8s2.4-.3 3.4-.8" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity=".4" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 11q9 9 18 0" />
+            <circle cx="9" cy="13" r="1.5" fill="currentColor" stroke="none" />
+            <circle cx="12" cy="13" r="1.5" fill="currentColor" stroke="none" />
+            <circle cx="15" cy="13" r="1.5" fill="currentColor" stroke="none" />
           </svg>
           <span class="sr-only">Kuler</span>
         </a>
       </li>
       <li>
         <a href="kvikkbilder.html" target="content" title="Kvikkbilder" aria-label="Kvikkbilder">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <rect x="4.5" y="6.5" width="15" height="11" rx="1.4" fill="none" stroke="currentColor" stroke-width="1.45" />
-            <path d="M11.2 6.5v11" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".55" />
-            <rect x="5.3" y="7.6" width="2.8" height="2.8" rx=".6" fill="currentColor" fill-opacity=".35" />
-            <rect x="8.3" y="7.6" width="2.8" height="2.8" rx=".6" fill="currentColor" fill-opacity=".2" />
-            <rect x="5.3" y="10.6" width="2.8" height="2.8" rx=".6" fill="currentColor" fill-opacity=".2" />
-            <rect x="8.3" y="10.6" width="2.8" height="2.8" rx=".6" fill="currentColor" fill-opacity=".35" />
-            <rect x="6.8" y="13.6" width="2.8" height="2.8" rx=".6" fill="currentColor" fill-opacity=".25" />
-            <path d="M5.3 10.4h5.8M7 7.6v5.8" fill="none" stroke="currentColor" stroke-width=".9" stroke-opacity=".35" stroke-dasharray="1.8 1.4" />
-            <circle cx="13.8" cy="9" r="1" fill="currentColor" />
-            <circle cx="16.2" cy="9" r="1" fill="currentColor" fill-opacity=".65" />
-            <circle cx="18.6" cy="9" r="1" fill="currentColor" fill-opacity=".35" />
-            <circle cx="15" cy="11.6" r="1" fill="currentColor" />
-            <circle cx="17.4" cy="11.6" r="1" fill="currentColor" fill-opacity=".65" />
-            <circle cx="16.2" cy="14.2" r="1" fill="currentColor" />
-            <path d="M13.6 14.4c1.4 1 3 .9 4.4-.1" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity=".35" stroke-linecap="round" />
-            <path d="M15.8 6.2l.4 1.1 1.1.4-1.1.4-.4 1.1-.4-1.1-1.1-.4 1.1-.4Z" fill="currentColor" fill-opacity=".45" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <circle cx="6" cy="8" r="1.5" fill="currentColor" stroke="none" />
+            <circle cx="12" cy="8" r="1.5" fill="currentColor" stroke="none" />
+            <circle cx="18" cy="8" r="1.5" fill="currentColor" stroke="none" />
+            <circle cx="6" cy="16" r="1.5" fill="currentColor" stroke="none" />
+            <circle cx="12" cy="16" r="1.5" fill="currentColor" stroke="none" />
+            <circle cx="18" cy="16" r="1.5" fill="currentColor" stroke="none" />
           </svg>
           <span class="sr-only">Kvikkbilder</span>
         </a>
@@ -338,29 +250,18 @@
       <li>
         <a href="trefigurer.html" target="content" title="Trefigurer" aria-label="Trefigurer">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M12 3.8 5 7.2l7 3.8 7-3.8Z" fill="currentColor" fill-opacity=".18" />
-            <path d="M12 3.8 5 7.2v9l7 4Z" fill="currentColor" fill-opacity=".22" />
-            <path d="M12 3.8l7 3.4v9l-7 4Z" fill="currentColor" fill-opacity=".1" />
-            <path d="M12 3.8v11.8" fill="none" stroke="currentColor" stroke-width="1.35" />
-            <path d="M5 7.2v9l7 4" fill="none" stroke="currentColor" stroke-width="1.35" />
-            <path d="M19 7.2v9l-7 4" fill="none" stroke="currentColor" stroke-width="1.35" />
-            <path d="M5 7.2l7 3.8 7-3.8" fill="none" stroke="currentColor" stroke-width="1.35" />
-            <path d="M8.6 12.8l3.4 1.8 3.4-1.8" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".55" />
-            <path d="M8.6 12.8v3.8m6.8-3.8v3.8" fill="none" stroke="currentColor" stroke-width="1.05" stroke-opacity=".55" />
+            <path d="M12 3 4 7v10l8 4 8-4V7Z" fill="currentColor" fill-opacity=".25" />
+            <path d="M12 3v10l8 4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-linecap="round" stroke-width="1.4" />
+            <path d="M12 3 4 7l8 4 8-4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.4" />
+            <path d="M4 7v10l8 4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.4" />
           </svg>
           <span class="sr-only">Trefigurer</span>
         </a>
       </li>
       <li>
         <a href="examples.html" target="content" title="Eksempler" aria-label="Eksempler">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <rect x="5" y="6.2" width="2.6" height="2.6" rx=".6" fill="currentColor" fill-opacity=".1" stroke="currentColor" stroke-width="1.2" />
-            <path d="M5.8 7.6l.7.8 1.2-1.4" fill="none" stroke="currentColor" stroke-width="1.05" stroke-linecap="round" stroke-linejoin="round" />
-            <path d="M9.8 7.5h8.6" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" />
-            <rect x="5" y="11" width="2.6" height="2.6" rx=".6" fill="none" stroke="currentColor" stroke-width="1.2" />
-            <path d="M9.8 12.3h8.6" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-dasharray="2.4 1.6" />
-            <circle cx="6.3" cy="17" r="1.3" fill="none" stroke="currentColor" stroke-width="1.2" />
-            <path d="M9.8 17h8.6" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
           <span class="sr-only">Eksempler</span>
         </a>


### PR DESCRIPTION
## Summary
- revert navigation SVGs to the original icon set for each visualization
- adjust navigation SVG styling to match the original icon stroke appearance

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68c9caff20d883249a9bc8c68cd6ad43