### PR TITLE
Add radius and height annotations to 3D figures

### DIFF
--- a/trefigurer.html
+++ b/trefigurer.html
@@ -124,10 +124,12 @@
         <div class="card card--settings">
           <label for="inpSpecs">Skriv fritekst (én figur per linje)</label>
           <div class="specs-row">
-            <textarea id="inpSpecs" rows="4" spellcheck="false">kule</textarea>
+            <textarea id="inpSpecs" rows="4" spellcheck="false">sylinder radius: r høyde: h</textarea>
             <button id="btnDraw" class="btn" type="button">Tegn</button>
           </div>
           <div class="small">Bruk ordene <strong>prisme</strong>, <strong>trekantet sylinder</strong>, <strong>firkantet sylinder</strong>, <strong>pyramide</strong> eller <strong>kule</strong>.</div>
+          <div class="small">Legg til <strong>radius</strong> og/eller <strong>høyde</strong> i linjen for å vise mål, for eksempel <code>sylinder radius: r høyde: h</code>.</div>
+          <div class="small">Du kan bruke <code>:</code> eller <code>=</code>, og skrive egen tekst (bruk gjerne anførselstegn om teksten har mellomrom). Lar du teksten stå tom, vises bare streken.</div>
           <div class="small">Trykk Ctrl+Enter (eller ⌘+Enter) for å tegne mens du skriver.</div>
           <div class="small">Dra i figuren for å rotere. Bruk høyre museknapp (eller to fingre) for å panorere og rullehjul eller pinch for å zoome.</div>
           <div class="option-row">


### PR DESCRIPTION
## Summary
- add measurement helpers that draw labeled radius and height guides on supported solids
- parse radius/høyde directives from the textarea so each figure controls its annotations
- update the UI copy and default example to highlight the new syntax for measurements

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c9ccb0be88832486127406c2c2b88b