### PR TITLE
Add combined whole brace option for think blocks

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -24,6 +24,7 @@
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
     /* Figur */
     .tb-panels{
+      position:relative;
       display:flex;
       gap:0;
       justify-content:center;
@@ -86,6 +87,16 @@
     .tb-frac-line{stroke:#111;stroke-width:2;stroke-linecap:square}
     .tb-handle-shadow{fill:#000;opacity:.12}
     .tb-handle{fill:#f1f1f6;stroke:#555;stroke-width:2;cursor:pointer}
+    .tb-combined-whole{
+      position:absolute;
+      pointer-events:none;
+      top:0;
+      left:0;
+      width:0;
+      height:0;
+      z-index:1;
+      overflow:visible;
+    }
     /* Stepper */
     .tb-stepper{display:flex;align-items:center;gap:12px;padding:6px 10px;border:1px solid #cfcfcf;border-radius:12px;
                 box-shadow:0 2px 10px rgba(0,0,0,.06);background:#fff;}
@@ -222,6 +233,10 @@
                 </select>
               </label>
             </fieldset>
+            <div id="cfg-show-combined-row" class="checkbox-row" style="display:none">
+              <input id="cfg-show-combined-whole" type="checkbox" />
+              <label for="cfg-show-combined-whole">Vis helhet over begge</label>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a checkbox to toggle a combined "hele" line when two think blocks are shown
- render an overlay brace across both blocks and include it in exported SVG output
- sum block totals for the combined label and keep configuration/UI in sync

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca59e9ef9c83249f01a228b665aa19