### PR TITLE
Ensure 3D example saves capture view state

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -256,6 +256,17 @@
 
   function collectConfig(){
     flushPendingChanges();
+    try{
+      if(typeof window !== 'undefined' && window){
+        const evt = typeof CustomEvent === 'function'
+          ? new CustomEvent('examples:collect')
+          : new Event('examples:collect');
+        window.dispatchEvent(evt);
+      }
+    }catch(_){
+      try{ window.dispatchEvent(new Event('examples:collect')); }
+      catch(_){ }
+    }
     const cfg = {};
     for(const name of BINDING_NAMES){
       const binding = getBinding(name);

--- a/trefigurer.js
+++ b/trefigurer.js
@@ -281,6 +281,14 @@
       this._emitViewChange();
     }
 
+    syncViewState() {
+      if (this.controls && this.currentFrame) {
+        this._syncStateFromControls();
+        return;
+      }
+      this._emitViewChange();
+    }
+
     frameCurrentShape() {
       if (!this.currentShape) return;
       this.currentShape.updateMatrixWorld(true);
@@ -923,6 +931,18 @@
     });
   });
 
+  function syncAllViewStates() {
+    renderers.forEach(renderer => {
+      if (renderer && typeof renderer.syncViewState === 'function') {
+        renderer.syncViewState();
+      }
+    });
+  }
+
+  if (typeof window !== 'undefined' && window && typeof window.addEventListener === 'function') {
+    window.addEventListener('examples:collect', syncAllViewStates);
+  }
+
   function getStoredView(index) {
     ensureViewStateCapacity();
     const stored = window.STATE.views[index];
@@ -1196,6 +1216,10 @@
   }
 
   if (textarea) {
+    textarea.addEventListener('input', () => {
+      if (!window.STATE || typeof window.STATE !== 'object') return;
+      window.STATE.rawInput = textarea.value;
+    });
     textarea.addEventListener('keydown', evt => {
       if ((evt.metaKey || evt.ctrlKey) && evt.key === 'Enter') {
         evt.preventDefault();


### PR DESCRIPTION
## Summary
- dispatch an `examples:collect` event before building example payloads so tools can flush their state
- make the 3D figure renderer expose a `syncViewState` helper and listen for the new event to store camera position and zoom
- keep the current textarea value mirrored into `STATE.rawInput` so saved examples retain the latest text

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca5aff68508324b85a0fb95135eb25