### PR TITLE
Fix trefigurer renderer lookup

### DIFF
--- a/trefigurer.js
+++ b/trefigurer.js
@@ -914,7 +914,9 @@
   }
 
   const grid = document.getElementById('figureGrid');
-  const figureWrappers = Array.from(document.querySelectorAll('[data-figure-index]'));
+  const figureWrappers = Array.from(
+    document.querySelectorAll('#figureGrid > .figure[data-figure-index]')
+  );
   const rendererCount = figureWrappers.length;
 
   function ensureViewStateCapacity() {


### PR DESCRIPTION
## Summary
- limit the 3D renderer lookup to actual figure containers so the canvas is always present
- prevent the initialization crash that caused saved examples to show an empty scene

## Testing
- Manual: loaded `trefigurer.html` and verified that the default cylinder renders again

------
https://chatgpt.com/codex/tasks/task_e_68ca5ec67d8c8324a20181e3d8c1baf1