### PR TITLE
Preserve 3D view sliders when redrawing or saving

### DIFF
--- a/trefigurer.js
+++ b/trefigurer.js
@@ -1656,11 +1656,16 @@
       const info = figures[index];
       if (info) {
         wrapper.classList.remove('is-hidden');
+        const storedView = getStoredView(index);
         renderer.setShape(info);
         if (typeof renderer._handleResize === 'function') {
           renderer._handleResize();
         }
-        applyStoredView(index);
+        if (storedView) {
+          renderer.applyViewState(storedView);
+        } else {
+          applyStoredView(index);
+        }
       } else {
         renderer.clear();
         wrapper.classList.add('is-hidden');


### PR DESCRIPTION
## Summary
- cache the current camera view before rebuilding a 3D figure
- reapply the cached view after the figure is redrawn so slider values stay intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca72f0308483249b25184091a1b716