### PR TITLE
Fix zoom reset when saving 3D figure examples

### DIFF
--- a/trefigurer.js
+++ b/trefigurer.js
@@ -394,9 +394,14 @@
     }
 
     setFloating(isFloating) {
-      this.isFloating = Boolean(isFloating);
+      const shouldFloat = Boolean(isFloating);
+      const changed = this.isFloating !== shouldFloat;
+      this.isFloating = shouldFloat;
       if (this.ground) {
         this.ground.visible = !this.isFloating;
+      }
+      if (!changed) {
+        return;
       }
       this._applyFloatingOffset();
       this.frameCurrentShape();


### PR DESCRIPTION
## Summary
- prevent ShapeRenderer.setFloating from reframing figures when the floating state value does not change
- this keeps the current camera distance, so the zoom slider and saved examples preserve their zoom settings after clicking “Lagre eksempel”

## Testing
- Manual verification in the browser: adjusted the zoom slider, saved an example, and confirmed the zoom label and stored state stay unchanged

------
https://chatgpt.com/codex/tasks/task_e_68ca764285c48324aefc98af80967b98