### PR TITLE
Add inline show whole toggle for stacked second block

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -116,6 +116,8 @@
     .tb-stepper button{width:40px;height:36px;border:1px solid #cfcfcf;border-radius:8px;background:#fff;font-size:20px;cursor:pointer}
     .tb-stepper span{min-width:32px;text-align:center;font-variant-numeric:tabular-nums;font-size:16px;}
     .tb-stepper button:active{transform:translateY(1px)}
+    .tb-inline-row{display:flex;align-items:center;gap:6px;font-size:13px;color:#4b5563;}
+    .tb-inline-row label{font-size:13px;color:inherit;cursor:pointer;}
     label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     input[type="number"],
     select{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -465,6 +465,7 @@ function createBlock(index) {
   svg.innerHTML = '';
 
   const block = { index, svg };
+  block.panel = document.getElementById(`tbPanel${index + 1}`) || null;
   block.gBase   = createSvgElement(svg, 'g');     // bakgrunn
   block.gFill   = createSvgElement(svg, 'g');     // fylte blokker
   block.gSep    = createSvgElement(svg, 'g');     // skillelinjer
@@ -487,6 +488,7 @@ function createBlock(index) {
     header.innerHTML = '';
     header.style.display = 'none';
   }
+  block.header = header || null;
 
   const minus = document.getElementById(`tbMinus${index + 1}`);
   const plus  = document.getElementById(`tbPlus${index + 1}`);
@@ -504,6 +506,32 @@ function createBlock(index) {
   block.plusBtn = plus || null;
   block.nVal = document.getElementById(`tbNVal${index + 1}`) || null;
   block.stepper = block.nVal?.closest('.tb-stepper') || minus?.closest('.tb-stepper') || null;
+
+  if (block.panel && block.stepper && index === 1) {
+    const row = document.createElement('div');
+    row.className = 'tb-inline-row tb-inline-show-whole';
+    const inlineId = `tb-inline-show-whole-${index + 1}`;
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = inlineId;
+    const label = document.createElement('label');
+    label.setAttribute('for', inlineId);
+    label.textContent = 'Vis hele';
+    row.append(checkbox, label);
+    row.style.display = 'none';
+    block.panel.insertBefore(row, block.stepper);
+    checkbox.addEventListener('change', () => {
+      normalizeConfig();
+      const cfg = CONFIG.blocks[index];
+      if (!cfg) return;
+      const nextValue = !!checkbox.checked;
+      if (cfg.showWhole === nextValue) return;
+      cfg.showWhole = nextValue;
+      draw();
+    });
+    block.inlineShowWholeRow = row;
+    block.inlineShowWholeInput = checkbox;
+  }
 
   BLOCKS[index] = block;
   return block;
@@ -876,6 +904,15 @@ function drawBlock(index) {
   if (block.handle) block.handle.style.cursor = cfg.lockNumerator ? 'default' : 'pointer';
 
   const showWhole = !!cfg.showWhole;
+
+  if (block.inlineShowWholeInput) {
+    block.inlineShowWholeInput.checked = showWhole;
+  }
+  if (block.inlineShowWholeRow) {
+    const activeCount = clamp(CONFIG.activeBlocks || 1, 1, 2);
+    const shouldShowInline = index === 1 && isStackedLayout() && index < activeCount;
+    block.inlineShowWholeRow.style.display = shouldShowInline ? '' : 'none';
+  }
 
   if (block.gBrace) block.gBrace.style.display = showWhole ? '' : 'none';
 


### PR DESCRIPTION
## Summary
- add an inline "Vis hele" checkbox under the second block when the panels are stacked
- sync the inline control with the existing settings checkbox and hide it outside of stacked mode
- style the new inline checkbox row to match the existing UI

## Testing
- Manual testing in browser (Playwright) to verify the inline checkbox appears only in stacked mode and stays in sync

------
https://chatgpt.com/codex/tasks/task_e_68ca78f4ddc88324a058c87d0130db2a