### PR TITLE
Ensure tenkeblokker blocks align without gaps

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -43,7 +43,7 @@
     .tb-row{display:flex;gap:0;width:100%;}
     .tb-panel{display:flex;flex-direction:column;align-items:stretch;gap:16px;width:100%;min-width:0;}
     .tb-panel .tb-stepper{align-self:center;}
-    .tb-svg{display:block;width:100%;height:auto;background:#fff;}
+    .tb-svg{display:block;width:100%;height:var(--tb-svg-height,260px);background:#fff;}
     .tb-board .addFigureBtn{align-self:center;justify-self:center;}
     .tb-add-right{grid-column:2;grid-row:1;}
     .tb-add-bottom{grid-column:1;grid-row:2;}


### PR DESCRIPTION
## Summary
- set a fixed SVG height so each tenkeblokk keeps the same visual height regardless of total value
- compute drawing metrics from the rendered panel size to stretch rectangles edge-to-edge and keep handles and labels aligned
- update combined braces, dragging logic, and export rendering to use the new metrics so exported figures match the on-screen layout

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cac15333548324873cf53efd5424ee