### PR TITLE
Fix stacked bar dragging for base series

### DIFF
--- a/diagram.js
+++ b/diagram.js
@@ -476,11 +476,24 @@ function onDragStart(e){
   e.preventDefault();
   const target = e.currentTarget;
   const idx = +target.dataset.index;
-  const series = +target.dataset.series || 0;
+  let series = +target.dataset.series || 0;
   if (locked[idx]) return;
   lastFocusIndex = idx;
 
-  const base = +target.dataset.base || 0;
+  let base = +target.dataset.base || 0;
+
+  if (CFG.type === 'stacked' && values2 && values2.length) {
+    const pointer = clientToSvg(e.clientX, e.clientY);
+    const boundaryY = yPos(values[idx]);
+    const margin = 12;
+    if (series === 1 && pointer.y >= boundaryY - margin) {
+      series = 0;
+      base = 0;
+    } else if (series === 0 && pointer.y < boundaryY - margin) {
+      series = 1;
+      base = values[idx];
+    }
+  }
 
   const move = ev=>{
     ev.preventDefault();


### PR DESCRIPTION
## Summary
- adjust drag start handling so stacked charts reinterpret pointer hits near the series boundary
- allow dragging the lower series even when the upper stack intercepts the initial pointer target

## Testing
- No automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68caddc2fa8c8324a6b9e39e81c2fb5e