### PR TITLE
Hide start position input when no gliders

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -1304,6 +1304,7 @@ function setupSettingsForm(){
   gliderRow.style.display = 'none';
   const gliderCountInput = gliderRow.querySelector('[data-points]');
   const gliderStartInput = gliderRow.querySelector('input[data-startx]');
+  const gliderStartLabel = gliderStartInput ? gliderStartInput.closest('label') : null;
 
   const isCoords = str => /^\s*(?:\(\s*-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?\s*\)|-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?)(?:\s*;\s*(?:\(\s*-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?\s*\)|-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?))*\s*$/.test(str);
   const isExplicitFun = str => {
@@ -1351,6 +1352,9 @@ function setupSettingsForm(){
     const active = shouldEnableGliders();
     const count = getGliderCount();
     gliderStartInput.disabled = !active || count <= 0;
+    if(gliderStartLabel){
+      gliderStartLabel.style.display = active && count > 0 ? '' : 'none';
+    }
   };
 
   const updateGliderVisibility = () => {


### PR DESCRIPTION
## Summary
- hide the start position input field whenever the glider count is zero to avoid showing unused controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cae282176483249fa0222251fb7e06