### PR TITLE
Fix tenkeblokk labels and prevent handle clipping

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -43,7 +43,7 @@
     .tb-row{display:flex;gap:0;width:100%;}
     .tb-panel{display:flex;flex-direction:column;align-items:stretch;gap:16px;width:100%;min-width:0;}
     .tb-panel .tb-stepper{align-self:center;}
-    .tb-svg{display:block;width:100%;height:var(--tb-svg-height,260px);background:#fff;}
+    .tb-svg{display:block;width:100%;height:var(--tb-svg-height,260px);background:#fff;overflow:visible;}
     .tb-board .addFigureBtn{align-self:center;justify-self:center;}
     .tb-add-right{grid-column:2;grid-row:1;}
     .tb-add-bottom{grid-column:1;grid-row:2;}

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -711,7 +711,7 @@ function drawBlock(block) {
 
   if (block.svg) {
     block.svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
-    block.svg.setAttribute('aria-label', `Tenkeblokker ${block.index + 1}`);
+    block.svg.setAttribute('aria-label', `Tenkeblokk ${block.index + 1}`);
     block.svg.setAttribute('preserveAspectRatio', 'none');
   }
 
@@ -732,11 +732,11 @@ function drawBlock(block) {
     block.totalText.textContent = fmt(cfg.total);
   }
   if (block.legend) {
-    block.legend.textContent = `Tenkeblokker ${block.index + 1}`;
+    block.legend.textContent = `Tenkeblokk ${block.index + 1}`;
   }
 
   if (block.stepper) {
-    block.stepper.setAttribute('aria-label', `Antall blokker i tenkeblokker ${block.index + 1}`);
+    block.stepper.setAttribute('aria-label', `Antall blokker i tenkeblokk ${block.index + 1}`);
     block.stepper.style.display = cfg.lockDenominator ? 'none' : '';
   }
 


### PR DESCRIPTION
## Summary
- keep the legend and aria labels in the singular form "Tenkeblokk"
- allow SVGs to overflow so the draggable handle remains fully visible at the edges

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cae4c284608324944ff85ef2054ac0