### PR TITLE
Add controls to remove Tenkeblokker rows and columns

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -45,8 +45,10 @@
     .tb-panel .tb-stepper{align-self:center;}
     .tb-svg{display:block;width:100%;height:var(--tb-svg-height,260px);background:#fff;overflow:visible;}
     .tb-board .addFigureBtn{align-self:center;justify-self:center;}
-    .tb-add-right{grid-column:2;grid-row:1;}
-    .tb-add-bottom{grid-column:1;grid-row:2;}
+    .tb-controls{display:flex;gap:var(--gap);align-items:center;}
+    .tb-controls--cols{grid-column:2;grid-row:1;flex-direction:column;align-self:center;justify-self:center;}
+    .tb-controls--rows{grid-column:1;grid-row:2;align-self:center;justify-self:center;}
+    .tb-controls .addFigureBtn{margin:0;}
     .tb-header{width:100%;display:flex;flex-direction:column;align-items:center;gap:6px;}
     .tb-header:empty{display:none;}
     .tb-panel .removeFigureBtn{align-self:center;}
@@ -123,8 +125,14 @@
       <div class="card">
         <div id="tbBoard" class="tb-board">
           <div id="tbGrid" class="tb-grid" data-cols="1"></div>
-          <button id="tbAddColumn" class="addFigureBtn tb-add-right" type="button" aria-label="Legg til kolonne">+</button>
-          <button id="tbAddRow" class="addFigureBtn tb-add-bottom" type="button" aria-label="Legg til rad">+</button>
+          <div class="tb-controls tb-controls--cols">
+            <button id="tbAddColumn" class="addFigureBtn" type="button" aria-label="Legg til kolonne">+</button>
+            <button id="tbRemoveColumn" class="addFigureBtn" type="button" aria-label="Fjern kolonne">−</button>
+          </div>
+          <div class="tb-controls tb-controls--rows">
+            <button id="tbAddRow" class="addFigureBtn" type="button" aria-label="Legg til rad">+</button>
+            <button id="tbRemoveRow" class="addFigureBtn" type="button" aria-label="Fjern rad">−</button>
+          </div>
         </div>
       </div>
       <div class="side">

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -128,6 +128,8 @@ const board = document.getElementById('tbBoard');
 const grid = document.getElementById('tbGrid');
 const addColumnBtn = document.getElementById('tbAddColumn');
 const addRowBtn = document.getElementById('tbAddRow');
+const removeColumnBtn = document.getElementById('tbRemoveColumn');
+const removeRowBtn = document.getElementById('tbRemoveRow');
 const settingsContainer = document.getElementById('tbSettings');
 
 const combinedWholeControls = {
@@ -156,6 +158,34 @@ addRowBtn?.addEventListener('click', () => {
   const current = Number.isFinite(CONFIG.rows) ? CONFIG.rows : 1;
   setHiddenFlag(CONFIG, '__rowsDirty', true);
   CONFIG.rows = Math.min(3, current + 1);
+  draw();
+});
+
+removeColumnBtn?.addEventListener('click', () => {
+  const current = Number.isFinite(CONFIG.cols) ? Math.round(CONFIG.cols) : 1;
+  if (current <= 1) return;
+  const next = Math.max(1, current - 1);
+  setHiddenFlag(CONFIG, '__colsDirty', true);
+  CONFIG.cols = next;
+  if (Array.isArray(CONFIG.blocks)) {
+    for (const row of CONFIG.blocks) {
+      if (Array.isArray(row) && row.length > next) {
+        row.length = next;
+      }
+    }
+  }
+  draw();
+});
+
+removeRowBtn?.addEventListener('click', () => {
+  const current = Number.isFinite(CONFIG.rows) ? Math.round(CONFIG.rows) : 1;
+  if (current <= 1) return;
+  const next = Math.max(1, current - 1);
+  setHiddenFlag(CONFIG, '__rowsDirty', true);
+  CONFIG.rows = next;
+  if (Array.isArray(CONFIG.blocks) && CONFIG.blocks.length > next) {
+    CONFIG.blocks.length = next;
+  }
   draw();
 });
 
@@ -518,6 +548,8 @@ function draw(skipNormalization = false) {
 function updateAddButtons() {
   if (addColumnBtn) addColumnBtn.style.display = CONFIG.cols >= 3 ? 'none' : '';
   if (addRowBtn) addRowBtn.style.display = CONFIG.rows >= 3 ? 'none' : '';
+  if (removeColumnBtn) removeColumnBtn.style.display = CONFIG.cols <= 1 ? 'none' : '';
+  if (removeRowBtn) removeRowBtn.style.display = CONFIG.rows <= 1 ? 'none' : '';
 }
 
 function createBlock(row, col, cfg) {


### PR DESCRIPTION
## Summary
- add paired add/remove controls for rows and columns in the Tenkeblokker board
- trim configuration data and toggle button visibility when blocks are removed

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68caf612b2408324af9caef6511a0112