### PR TITLE
Fix remove button visibility when only one block

### DIFF
--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -571,10 +571,15 @@ function draw(skipNormalization = false) {
 }
 
 function updateAddButtons() {
-  if (addColumnBtn) addColumnBtn.style.display = CONFIG.cols >= 3 ? 'none' : '';
-  if (addRowBtn) addRowBtn.style.display = CONFIG.rows >= 3 ? 'none' : '';
-  if (removeColumnBtn) removeColumnBtn.style.display = CONFIG.cols <= 1 ? 'none' : '';
-  if (removeRowBtn) removeRowBtn.style.display = CONFIG.rows <= 1 ? 'none' : '';
+  const parsedCols = Number(CONFIG.cols);
+  const parsedRows = Number(CONFIG.rows);
+  const cols = Number.isFinite(parsedCols) ? parsedCols : 1;
+  const rows = Number.isFinite(parsedRows) ? parsedRows : 1;
+
+  if (addColumnBtn) addColumnBtn.style.display = cols >= 3 ? 'none' : '';
+  if (addRowBtn) addRowBtn.style.display = rows >= 3 ? 'none' : '';
+  if (removeColumnBtn) removeColumnBtn.style.display = cols <= 1 ? 'none' : '';
+  if (removeRowBtn) removeRowBtn.style.display = rows <= 1 ? 'none' : '';
 }
 
 function createBlock(row, col, cfg) {


### PR DESCRIPTION
## Summary
- ensure the add/remove controls sanitize row and column counts before toggling visibility so the remove buttons stay hidden when only one figure is shown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cafd306ce483249f416c163b63a220