### PR TITLE
Align tenkeblokker settings side by side

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -53,10 +53,14 @@
     .tb-header:empty{display:none;}
     .tb-panel .removeFigureBtn{align-self:center;}
     .tb-settings{
-      display:grid;
+      display:flex;
+      flex-wrap:wrap;
       gap:var(--gap);
-      grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
-      align-items:start;
+      align-items:stretch;
+    }
+    .tb-settings fieldset{
+      flex:1 1 200px;
+      min-width:120px;
     }
     .addFigureBtn{
       width:clamp(30px,7.5vw,60px);


### PR DESCRIPTION
## Summary
- update the tenkeblokker settings layout to use a flexible row-based layout
- allow individual tenkeblokk fieldsets to sit side by side like in brøkpizza

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb1d7eb22c8324b403572d027a16aa