### PR TITLE
Prevent auto-restoring defaults when custom examples exist

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -667,7 +667,9 @@
             updated = true;
           }
         }
-        if(providedDefaults.length > 0){
+        const hasCustomExamples = examples.some(ex => ex && typeof ex === 'object' && typeof ex.__builtinKey !== 'string');
+
+        if(providedDefaults.length > 0 && !hasCustomExamples){
           const existingKeys = new Set();
           examples.forEach(ex => {
             if(ex && typeof ex.__builtinKey === 'string'){ existingKeys.add(ex.__builtinKey); }


### PR DESCRIPTION
## Summary
- avoid re-adding builtin examples when a saved custom example is present

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cb2270d5208324a94871977ec21866