### PR TITLE
Adjust tenkeblokker vertical spacing

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -36,12 +36,15 @@
       grid-row:1;
       display:flex;
       flex-direction:column;
-      gap:var(--gap);
+      gap:0;
+      row-gap:0;
+      column-gap:0;
       padding:12px 4px 4px;
       width:100%;
     }
     .tb-row{display:flex;gap:0;width:100%;}
     .tb-panel{display:flex;flex-direction:column;align-items:stretch;gap:16px;width:100%;min-width:0;}
+    .tb-panel--with-stepper{margin-bottom:var(--gap);}
     .tb-panel .tb-stepper{align-self:center;}
     .tb-svg{display:block;width:100%;height:var(--tb-svg-height,260px);background:#fff;overflow:visible;}
     .tb-board .addFigureBtn{align-self:center;justify-self:center;}

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -965,9 +965,14 @@ function drawBlock(block) {
     block.legend.textContent = `Tenkeblokk ${block.index + 1}`;
   }
 
+  const stepperVisible = !cfg.lockDenominator;
   if (block.stepper) {
     block.stepper.setAttribute('aria-label', `Antall blokker i tenkeblokk ${block.index + 1}`);
-    block.stepper.style.display = cfg.lockDenominator ? 'none' : '';
+    block.stepper.style.display = stepperVisible ? '' : 'none';
+  }
+
+  if (block.panel) {
+    block.panel.classList.toggle('tb-panel--with-stepper', stepperVisible);
   }
 
   if (block.nVal) {


### PR DESCRIPTION
## Summary
- remove the default gap between stacked tenkeblokker panels so adjacent blocks touch when no controls are shown
- toggle a `tb-panel--with-stepper` class from `drawBlock` so vertical space is only reserved when the "endre nevner" stepper is visible

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68cb25854d348324958e7fa8ade3616a