### PR TITLE
Legg til brøkvegg-visualisering

### DIFF
--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="no">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Brøkvegg</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <style>
+    :root { --gap: 18px; --purple:#5B2AA5; }
+    html, body { height: 100%; }
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
+      color: #111827;
+      background: #f7f8fb;
+      padding: 20px;
+    }
+    .wrap { max-width: 1200px; margin: 0 auto; }
+    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 360px; align-items: start; }
+    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
+    .side { display: flex; flex-direction: column; gap: var(--gap); }
+    .card {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 14px;
+      box-shadow: 0 1px 2px rgba(0,0,0,.04);
+      padding: 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+    .card p { margin: 0; font-size: 13px; color: #4b5563; line-height: 1.5; }
+    .toolbar { display: flex; gap: 10px; justify-content: flex-start; align-items: center; flex-wrap: wrap; }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: 10px;
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow .2s, transform .02s;
+    }
+    .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
+    .btn:active { transform: translateY(1px); }
+    .btn:disabled { opacity: .6; cursor: not-allowed; }
+    .btn.is-active {
+      background: #0f6d8f;
+      color: #fff;
+      border-color: #0f6d8f;
+      box-shadow: 0 2px 8px rgba(15, 109, 143, 0.2);
+    }
+    label { font-size: 13px; color: #4b5563; display: flex; flex-direction: column; gap: 6px; }
+    input[type="text"], input[type="number"] {
+      border: 1px solid #d1d5db;
+      border-radius: 10px;
+      padding: 8px 10px;
+      font-size: 14px;
+      background: #fff;
+      width: 100%;
+      box-sizing: border-box;
+    }
+    input[type="range"] {
+      width: 100%;
+      accent-color: #3b82f6;
+    }
+    fieldset {
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      padding: 10px;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    legend { font-weight: 600; font-size: 13px; color: #374151; padding: 0 4px; }
+    .checkbox {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      color: #4b5563;
+      cursor: pointer;
+      user-select: none;
+    }
+    .checkbox input {
+      width: 16px;
+      height: 16px;
+      accent-color: #3b82f6;
+    }
+    .presetButtons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .presetButtons .btn { font-size: 13px; padding: 6px 10px; }
+    .rangeRow {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 10px;
+      align-items: center;
+    }
+    .rangeValue { font-size: 13px; color: #374151; min-width: 42px; text-align: right; font-variant-numeric: tabular-nums; }
+    .settingsGrid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 10px;
+    }
+    .hint {
+      font-size: 12px;
+      color: #6b7280;
+      line-height: 1.4;
+    }
+    .wallCard { gap: 16px; }
+    .wallToolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+    }
+    .wallToolbar__group {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .wallToolbar__label {
+      font-size: 13px;
+      color: #4b5563;
+      margin-right: 4px;
+    }
+    .fractionWallSvg {
+      width: 100%;
+      max-width: 900px;
+      height: auto;
+      align-self: center;
+      background: #fff;
+      border-radius: 12px;
+      border: 1px solid #e5e7eb;
+      box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.04);
+      overflow: visible;
+    }
+    .tile { cursor: pointer; outline: none; }
+    .tile rect {
+      stroke: rgba(255,255,255,0.9);
+      stroke-width: 4;
+      transition: fill .2s ease, stroke .2s ease;
+    }
+    .tile:hover rect { filter: brightness(1.05); }
+    .tile:focus rect,
+    .tile:focus-visible rect {
+      stroke: #0f6d8f;
+      stroke-width: 6;
+    }
+    .tile text {
+      font-size: 20px;
+      font-weight: 600;
+      fill: #111827;
+      pointer-events: none;
+      dominant-baseline: middle;
+      text-anchor: middle;
+    }
+    .rowLabelRect {
+      transition: fill .2s ease;
+    }
+    .rowLabelText {
+      font-size: 22px;
+      font-weight: 600;
+      fill: #334155;
+      dominant-baseline: middle;
+      text-anchor: middle;
+    }
+    .rowLabelSub {
+      font-size: 12px;
+      fill: #64748b;
+      letter-spacing: .02em;
+      text-transform: uppercase;
+      dominant-baseline: hanging;
+      text-anchor: middle;
+    }
+    .card--examples .toolbar { justify-content: flex-start; }
+    @media (max-width: 600px) {
+      body { padding: 16px; }
+      .presetButtons { gap: 6px; }
+      .presetButtons .btn { flex: 1 1 calc(50% - 6px); justify-content: center; }
+      .wallToolbar { flex-direction: column; align-items: flex-start; }
+      .wallToolbar__group { width: 100%; }
+      .wallToolbar__group .btn { flex: 1 1 auto; justify-content: center; }
+    }
+  </style>
+  <link rel="stylesheet" href="split.css" />
+</head>
+<body>
+  <div class="wrap">
+    <div class="grid">
+      <div class="card wallCard">
+        <div class="wallToolbar" aria-label="Bytt visning for alle biter">
+          <span class="wallToolbar__label">Standardvisning:</span>
+          <div class="wallToolbar__group">
+            <button type="button" class="btn" data-set-mode="fraction">Brøk</button>
+            <button type="button" class="btn" data-set-mode="percent">Prosent</button>
+            <button type="button" class="btn" data-set-mode="decimal">Desimaltall</button>
+          </div>
+          <button type="button" class="btn" id="resetModes">Tilbakestill visninger</button>
+        </div>
+        <svg id="fractionWallSvg" class="fractionWallSvg" viewBox="0 0 100 100" role="img" aria-labelledby="fractionWallTitle fractionWallDesc"></svg>
+        <p class="hint">Trykk på en brøkbit for å bytte mellom brøk, prosent og desimaltall.</p>
+      </div>
+
+      <div class="side">
+        <div class="card card--examples">
+          <div class="toolbar">
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+          </div>
+        </div>
+
+        <div class="card card--settings">
+          <fieldset>
+            <legend>Rader</legend>
+            <label for="denominatorInput">Nevnere</label>
+            <input id="denominatorInput" type="text" inputmode="numeric" autocomplete="off" spellcheck="false" placeholder="1,2,3,4,5,6,8,9,10,12" />
+            <p class="hint">Skriv tall adskilt med komma eller mellomrom. Rekkefølgen sorteres automatisk.</p>
+            <div class="presetButtons">
+              <button type="button" class="btn" data-denom-preset="1,2,3,4,5,6,8,9,10,12">Standard</button>
+              <button type="button" class="btn" data-denom-preset="1,3,6,9,12">Tredeler</button>
+              <button type="button" class="btn" data-denom-preset="1,2,4,8,16">Toere</button>
+            </div>
+          </fieldset>
+          <fieldset>
+            <legend>Tekst</legend>
+            <label class="checkbox"><input type="checkbox" id="showRowLabels" checked /> <span>Vis radetiketter</span></label>
+            <label>Tekststørrelse
+              <div class="rangeRow">
+                <input id="textScale" type="range" min="0.35" max="1.05" step="0.05" value="0.7" />
+                <span id="textScaleValue" class="rangeValue">70%</span>
+              </div>
+            </label>
+            <div class="settingsGrid">
+              <label for="decimalDigits">Desimaler (desimaltall)
+                <input id="decimalDigits" type="number" min="0" max="4" value="3" />
+              </label>
+              <label for="percentDigits">Desimaler (prosent)
+                <input id="percentDigits" type="number" min="0" max="3" value="1" />
+              </label>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class="card card--export">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnDownloadSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnDownloadPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="brøkvegg.js"></script>
+  <script src="examples.js"></script>
+  <script src="split.js"></script>
+</body>
+</html>

--- a/brøkvegg.js
+++ b/brøkvegg.js
@@ -1,0 +1,487 @@
+(function(){
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+  const TEXT_MODES = ['fraction','percent','decimal'];
+  const MODE_LABELS = {
+    fraction: 'brøk',
+    percent: 'prosent',
+    decimal: 'desimaltall'
+  };
+  const DEFAULT_DENOMS = [1, 2, 3, 4, 5, 6, 8, 9, 10, 12];
+  const COLOR_PALETTE = ['#B25FE3', '#6C1BA2', '#534477', '#873E79', '#BF4474', '#E31C3D'];
+  const TILE_AREA_WIDTH = 800;
+  const LABEL_WIDTH = 140;
+  const ROW_HEIGHT = 72;
+  const ROW_GAP = 16;
+  const MARGIN_X = 32;
+  const MARGIN_Y = 32;
+  const TILE_RADIUS = 14;
+  const MIN_SCALE = 0.35;
+  const MAX_SCALE = 1.05;
+  const DEFAULT_DECIMAL_DIGITS = 3;
+  const DEFAULT_PERCENT_DIGITS = 1;
+  const MAX_DECIMAL_DIGITS = 4;
+  const MAX_PERCENT_DIGITS = 3;
+  const FRACTION_SLASH = '\u2044';
+
+  const svg = document.getElementById('fractionWallSvg');
+  if(!svg) return;
+
+  const denomInput = document.getElementById('denominatorInput');
+  const showLabelsCheckbox = document.getElementById('showRowLabels');
+  const textScaleRange = document.getElementById('textScale');
+  const textScaleValue = document.getElementById('textScaleValue');
+  const decimalDigitsInput = document.getElementById('decimalDigits');
+  const percentDigitsInput = document.getElementById('percentDigits');
+  const presetButtons = document.querySelectorAll('[data-denom-preset]');
+  const setModeButtons = document.querySelectorAll('[data-set-mode]');
+  const resetModesButton = document.getElementById('resetModes');
+  const downloadSvgButton = document.getElementById('btnDownloadSvg');
+  const downloadPngButton = document.getElementById('btnDownloadPng');
+
+  const STATE = (window.STATE && typeof window.STATE === 'object') ? window.STATE : {};
+  window.STATE = STATE;
+
+  function clamp(value, min, max){
+    if(!Number.isFinite(value)) return min;
+    if(value < min) return min;
+    if(value > max) return max;
+    return value;
+  }
+
+  function clampInt(value, min, max, fallback){
+    const num = Number.parseInt(value, 10);
+    if(!Number.isFinite(num)) return clamp(fallback, min, max);
+    return clamp(num, min, max);
+  }
+
+  function sanitizeDenominators(value){
+    if(Array.isArray(value)){
+      return value
+        .map(v => Number.parseInt(v, 10))
+        .filter(v => Number.isFinite(v) && v > 0 && v <= 48)
+        .filter((v, idx, arr) => arr.indexOf(v) === idx)
+        .sort((a, b) => a - b);
+    }
+    if(typeof value === 'string'){
+      const parts = value.split(/[^0-9]+/);
+      const numbers = [];
+      for(const part of parts){
+        if(!part) continue;
+        const num = Number.parseInt(part, 10);
+        if(Number.isFinite(num) && num > 0 && num <= 48) numbers.push(num);
+      }
+      return sanitizeDenominators(numbers);
+    }
+    return [];
+  }
+
+  function ensureStateDefaults(){
+    const denoms = sanitizeDenominators(STATE.denominators);
+    STATE.denominators = denoms.length ? denoms : DEFAULT_DENOMS.slice();
+    if(!STATE.tileModes || typeof STATE.tileModes !== 'object') STATE.tileModes = {};
+    if(!TEXT_MODES.includes(STATE.defaultMode)) STATE.defaultMode = 'fraction';
+    STATE.showLabels = typeof STATE.showLabels === 'boolean' ? STATE.showLabels : true;
+    const scale = Number(STATE.textScale);
+    STATE.textScale = clamp(Number.isFinite(scale) ? scale : 0.7, MIN_SCALE, MAX_SCALE);
+    STATE.decimalDigits = clampInt(STATE.decimalDigits, 0, MAX_DECIMAL_DIGITS, DEFAULT_DECIMAL_DIGITS);
+    STATE.percentDigits = clampInt(STATE.percentDigits, 0, MAX_PERCENT_DIGITS, DEFAULT_PERCENT_DIGITS);
+  }
+
+  ensureStateDefaults();
+
+  function cleanTileModes(){
+    const validKeys = new Set();
+    for(const den of STATE.denominators){
+      for(let i=0;i<den;i++){
+        validKeys.add(`${den}:${i}`);
+      }
+    }
+    Object.keys(STATE.tileModes).forEach(key => {
+      const mode = STATE.tileModes[key];
+      if(!validKeys.has(key) || !TEXT_MODES.includes(mode)){
+        delete STATE.tileModes[key];
+      }
+    });
+  }
+
+  cleanTileModes();
+
+  function updateModeButtons(){
+    setModeButtons.forEach(btn => {
+      if(!btn || !btn.dataset.setMode) return;
+      btn.classList.toggle('is-active', btn.dataset.setMode === STATE.defaultMode);
+    });
+  }
+
+  function updateTextScaleDisplay(){
+    if(textScaleValue){
+      const percentage = Math.round(STATE.textScale * 100);
+      textScaleValue.textContent = `${percentage}%`;
+    }
+  }
+
+  function updateControlsFromState(){
+    if(denomInput){
+      const joined = STATE.denominators.join(', ');
+      denomInput.value = joined;
+    }
+    if(showLabelsCheckbox) showLabelsCheckbox.checked = !!STATE.showLabels;
+    if(textScaleRange) textScaleRange.value = String(STATE.textScale);
+    if(decimalDigitsInput) decimalDigitsInput.value = String(STATE.decimalDigits);
+    if(percentDigitsInput) percentDigitsInput.value = String(STATE.percentDigits);
+    updateTextScaleDisplay();
+    updateModeButtons();
+  }
+
+  updateControlsFromState();
+
+  function createSvgElement(name, attrs){
+    const el = document.createElementNS(SVG_NS, name);
+    if(attrs){
+      for(const [key, value] of Object.entries(attrs)){
+        if(value == null) continue;
+        if(key === 'textContent') el.textContent = value;
+        else el.setAttribute(key, value);
+      }
+    }
+    return el;
+  }
+
+  function lightenColor(hex, amount){
+    if(typeof hex !== 'string') return hex;
+    const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+    if(!match) return hex;
+    const base = match[1];
+    const r = parseInt(base.slice(0,2), 16);
+    const g = parseInt(base.slice(2,4), 16);
+    const b = parseInt(base.slice(4,6), 16);
+    const ratio = clamp(Number(amount) || 0, 0, 1);
+    const mix = (channel) => Math.round(channel + (255 - channel) * ratio);
+    const nr = mix(r);
+    const ng = mix(g);
+    const nb = mix(b);
+    return `#${nr.toString(16).padStart(2,'0')}${ng.toString(16).padStart(2,'0')}${nb.toString(16).padStart(2,'0')}`;
+  }
+
+  function getTileMode(den, index){
+    const key = `${den}:${index}`;
+    const stored = STATE.tileModes[key];
+    if(TEXT_MODES.includes(stored)) return stored;
+    return STATE.defaultMode;
+  }
+
+  function setTileMode(den, index, mode){
+    const key = `${den}:${index}`;
+    if(!TEXT_MODES.includes(mode)) return;
+    if(mode === STATE.defaultMode){
+      delete STATE.tileModes[key];
+    }else{
+      STATE.tileModes[key] = mode;
+    }
+  }
+
+  function cycleTileMode(den, index){
+    const current = getTileMode(den, index);
+    const idx = TEXT_MODES.indexOf(current);
+    const next = TEXT_MODES[(idx + 1) % TEXT_MODES.length];
+    setTileMode(den, index, next);
+    render();
+  }
+
+  function formatFraction(den){
+    if(den === 1) return `1${FRACTION_SLASH}1`;
+    return `1${FRACTION_SLASH}${den}`;
+  }
+
+  const decimalFormatterCache = new Map();
+  function formatDecimal(value, digits){
+    const key = `${digits}`;
+    let formatter = decimalFormatterCache.get(key);
+    if(!formatter){
+      formatter = new Intl.NumberFormat('nb-NO', {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits
+      });
+      decimalFormatterCache.set(key, formatter);
+    }
+    return formatter.format(value);
+  }
+
+  function formatValue(mode, den){
+    switch(mode){
+      case 'percent':
+        return `${formatDecimal(100 / den, STATE.percentDigits)}%`;
+      case 'decimal':
+        return formatDecimal(1 / den, STATE.decimalDigits);
+      case 'fraction':
+      default:
+        return formatFraction(den);
+    }
+  }
+
+  function tileAriaLabel(den, index, mode){
+    const position = index + 1;
+    const total = den;
+    const label = MODE_LABELS[mode] || mode;
+    return `Del ${position} av ${total}. Viser ${label}. Klikk for å bytte visning.`;
+  }
+
+  function render(){
+    ensureStateDefaults();
+    cleanTileModes();
+    updateControlsFromState();
+
+    const denominators = STATE.denominators;
+    const labelWidth = STATE.showLabels ? LABEL_WIDTH : 0;
+    const contentHeight = denominators.length * ROW_HEIGHT + Math.max(0, denominators.length - 1) * ROW_GAP;
+    const totalHeight = contentHeight + MARGIN_Y * 2;
+    const totalWidth = MARGIN_X * 2 + labelWidth + TILE_AREA_WIDTH;
+
+    svg.setAttribute('viewBox', `0 0 ${totalWidth} ${Math.max(totalHeight, 120)}`);
+
+    const fragment = document.createDocumentFragment();
+    const title = createSvgElement('title', {id:'fractionWallTitle', textContent:'Brøkvegg'});
+    const descText = denominators.length ? `Viser rader for nevnerne ${denominators.join(', ')}.` : 'Ingen rader valgt.';
+    const desc = createSvgElement('desc', {id:'fractionWallDesc', textContent:descText});
+    fragment.appendChild(title);
+    fragment.appendChild(desc);
+
+    let y = MARGIN_Y;
+    denominators.forEach((den, rowIndex) => {
+      const rowGroup = createSvgElement('g', {transform:`translate(${MARGIN_X}, ${y})`});
+      const baseColor = COLOR_PALETTE[rowIndex % COLOR_PALETTE.length] || '#B25FE3';
+
+      if(STATE.showLabels){
+        const labelGroup = createSvgElement('g');
+        const rect = createSvgElement('rect', {
+          class: 'rowLabelRect',
+          x: 0,
+          y: 0,
+          width: LABEL_WIDTH,
+          height: ROW_HEIGHT,
+          rx: 12,
+          ry: 12,
+          fill: lightenColor(baseColor, 0.6),
+          stroke: lightenColor(baseColor, 0.25),
+          'stroke-width': 2,
+          'aria-hidden': 'true'
+        });
+        const labelText = createSvgElement('text', {
+          class: 'rowLabelText',
+          x: LABEL_WIDTH / 2,
+          y: ROW_HEIGHT / 2 - 6,
+          'aria-hidden': 'true'
+        });
+        labelText.textContent = String(den);
+        const subLabel = createSvgElement('text', {
+          class: 'rowLabelSub',
+          x: LABEL_WIDTH / 2,
+          y: ROW_HEIGHT / 2 + 4,
+          'aria-hidden': 'true'
+        });
+        subLabel.textContent = den === 1 ? 'hel' : `${den} deler`;
+        labelGroup.appendChild(rect);
+        labelGroup.appendChild(labelText);
+        labelGroup.appendChild(subLabel);
+        rowGroup.appendChild(labelGroup);
+      }
+
+      const tilesGroup = createSvgElement('g', {
+        transform: `translate(${STATE.showLabels ? LABEL_WIDTH : 0}, 0)`
+      });
+      const tileWidth = TILE_AREA_WIDTH / den;
+      for(let i=0;i<den;i++){
+        const mode = getTileMode(den, i);
+        const displayValue = formatValue(mode, den);
+        const tile = createSvgElement('g', {
+          class: 'tile',
+          tabindex: '0',
+          role: 'button',
+          'data-denominator': String(den),
+          'data-index': String(i),
+          'aria-label': tileAriaLabel(den, i, mode)
+        });
+        const tileX = tileWidth * i;
+        const color = i % 2 === 0 ? baseColor : lightenColor(baseColor, 0.12);
+        const tooltip = createSvgElement('title', {
+          textContent: `${displayValue} – ${MODE_LABELS[mode] || mode}`
+        });
+        const cornerRadius = Math.min(TILE_RADIUS, tileWidth / 2);
+        const rect = createSvgElement('rect', {
+          x: tileX,
+          y: 0,
+          width: tileWidth,
+          height: ROW_HEIGHT,
+          rx: cornerRadius,
+          ry: cornerRadius,
+          fill: color,
+          'aria-hidden': 'true'
+        });
+        const fontSize = Math.max(10, Math.min(ROW_HEIGHT * STATE.textScale, tileWidth * 0.8));
+        const text = createSvgElement('text', {
+          x: tileX + tileWidth / 2,
+          y: ROW_HEIGHT / 2,
+          'font-size': fontSize
+        });
+        text.textContent = displayValue;
+        tile.appendChild(tooltip);
+        tile.appendChild(rect);
+        tile.appendChild(text);
+        tile.addEventListener('click', (event)=>{
+          event.preventDefault();
+          cycleTileMode(den, i);
+        });
+        tile.addEventListener('keydown', (event)=>{
+          if(event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar'){
+            event.preventDefault();
+            cycleTileMode(den, i);
+          }
+        });
+        tilesGroup.appendChild(tile);
+      }
+
+      rowGroup.appendChild(tilesGroup);
+      fragment.appendChild(rowGroup);
+      y += ROW_HEIGHT + ROW_GAP;
+    });
+
+    svg.replaceChildren(fragment);
+  }
+
+  render();
+  window.render = render;
+
+  function setDenominatorsFromInput(raw){
+    const parsed = sanitizeDenominators(raw);
+    STATE.denominators = parsed.length ? parsed : DEFAULT_DENOMS.slice();
+    cleanTileModes();
+    render();
+  }
+
+  denomInput?.addEventListener('change', (event)=>{
+    setDenominatorsFromInput(event.target.value);
+  });
+  denomInput?.addEventListener('blur', (event)=>{
+    setDenominatorsFromInput(event.target.value);
+  });
+
+  presetButtons.forEach(btn => {
+    btn.addEventListener('click', ()=>{
+      const preset = btn.dataset.denomPreset || '';
+      setDenominatorsFromInput(preset);
+    });
+  });
+
+  showLabelsCheckbox?.addEventListener('change', ()=>{
+    STATE.showLabels = !!showLabelsCheckbox.checked;
+    render();
+  });
+
+  textScaleRange?.addEventListener('input', ()=>{
+    const value = Number(textScaleRange.value);
+    STATE.textScale = clamp(value, MIN_SCALE, MAX_SCALE);
+    updateTextScaleDisplay();
+    render();
+  });
+
+  decimalDigitsInput?.addEventListener('change', ()=>{
+    STATE.decimalDigits = clampInt(decimalDigitsInput.value, 0, MAX_DECIMAL_DIGITS, STATE.decimalDigits);
+    render();
+  });
+
+  percentDigitsInput?.addEventListener('change', ()=>{
+    STATE.percentDigits = clampInt(percentDigitsInput.value, 0, MAX_PERCENT_DIGITS, STATE.percentDigits);
+    render();
+  });
+
+  setModeButtons.forEach(btn => {
+    btn.addEventListener('click', ()=>{
+      const mode = btn.dataset.setMode;
+      if(!TEXT_MODES.includes(mode)) return;
+      STATE.defaultMode = mode;
+      STATE.tileModes = {};
+      render();
+    });
+  });
+
+  resetModesButton?.addEventListener('click', ()=>{
+    STATE.defaultMode = 'fraction';
+    STATE.tileModes = {};
+    render();
+  });
+
+  function svgToString(svgEl){
+    const clone = svgEl.cloneNode(true);
+    const styles = Array.from(document.querySelectorAll('style'))
+      .map(style => style.textContent)
+      .join('\n');
+    if(styles){
+      const styleEl = document.createElement('style');
+      styleEl.textContent = styles;
+      clone.insertBefore(styleEl, clone.firstChild);
+    }
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+    return `<?xml version="1.0" encoding="UTF-8"?>\n${new XMLSerializer().serializeToString(clone)}`;
+  }
+
+  function downloadSvg(svgEl, filename){
+    const data = svgToString(svgEl);
+    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename.endsWith('.svg') ? filename : `${filename}.svg`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setTimeout(()=>URL.revokeObjectURL(url), 1000);
+  }
+
+  function downloadPng(svgEl, filename, scale = 2){
+    const data = svgToString(svgEl);
+    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = ()=>{
+      const canvas = document.createElement('canvas');
+      const viewBox = svgEl.viewBox?.baseVal;
+      const width = viewBox ? viewBox.width : svgEl.clientWidth;
+      const height = viewBox ? viewBox.height : svgEl.clientHeight;
+      canvas.width = Math.round(width * scale);
+      canvas.height = Math.round(height * scale);
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = '#fff';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      URL.revokeObjectURL(url);
+      canvas.toBlob(blob => {
+        if(!blob) return;
+        const pngUrl = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = pngUrl;
+        link.download = filename.endsWith('.png') ? filename : `${filename}.png`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        setTimeout(()=>URL.revokeObjectURL(pngUrl), 1000);
+      }, 'image/png');
+    };
+    img.src = url;
+  }
+
+  downloadSvgButton?.addEventListener('click', ()=>{
+    downloadSvg(svg, 'brokvegg');
+  });
+
+  downloadPngButton?.addEventListener('click', ()=>{
+    downloadPng(svg, 'brokvegg');
+  });
+
+  window.addEventListener('examples:collect', (event)=>{
+    if(!event || !event.detail) return;
+    try{
+      event.detail.svgOverride = svgToString(svg);
+    }catch(_){ }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -168,6 +168,16 @@
         </a>
       </li>
       <li>
+        <a href="brøkvegg.html" target="content" title="Brøkvegg" aria-label="Brøkvegg">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <rect x="4" y="4" width="16" height="4" rx="1.5" fill="currentColor" stroke="none" />
+            <rect x="4" y="10" width="16" height="4" rx="1.5" />
+            <rect x="4" y="16" width="16" height="4" rx="1.5" />
+          </svg>
+          <span class="sr-only">Brøkvegg</span>
+        </a>
+      </li>
+      <li>
         <a href="figurtall.html" target="content" title="Figurtall" aria-label="Figurtall">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <rect x="3" y="15" width="6" height="6" fill="currentColor" stroke="none" />


### PR DESCRIPTION
## Summary
- legg til en ny side for brøkvegg med verktøylinje, innstillinger og eksportknapper
- implementer interaktiv brøkvegg med klikkbare brøkbiter, visningsmoduser og state-håndtering
- legg til snarvei til brøkveggen i hovednavigasjonen

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cbe7b02cb08324841e4cbf3815a927