### PR TITLE
Adjust think block sizing for stacked layout

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -41,6 +41,7 @@
       column-gap:0;
       padding:12px 4px 4px;
       width:100%;
+      align-items:flex-start;
     }
     .tb-row{display:flex;gap:0;width:100%;}
     .tb-panel{display:flex;flex-direction:column;align-items:stretch;gap:16px;width:100%;min-width:0;}

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -638,6 +638,29 @@ function draw(skipNormalization = false) {
     }
   }
 
+  const maxRowTotal = rowTotals.reduce((max, value) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric <= max) return max;
+    return numeric;
+  }, 0);
+
+  if (grid) {
+    const rowElements = grid.querySelectorAll('.tb-row');
+    rowElements.forEach((rowEl, index) => {
+      if (!rowEl) return;
+      if (maxRowTotal > 0) {
+        const total = Number(rowTotals[index]) || 0;
+        const ratio = total > 0 ? total / maxRowTotal : 0;
+        const clamped = Math.max(0, Math.min(ratio, 1));
+        rowEl.style.width = `${clamped * 100}%`;
+        rowEl.style.alignSelf = 'flex-start';
+      } else {
+        rowEl.style.width = '';
+        rowEl.style.alignSelf = '';
+      }
+    });
+  }
+
   for (const block of visibleBlocks) {
     const rowTotal = rowTotals[block.row];
     updateBlockPanelLayout(block, rowTotal);


### PR DESCRIPTION
## Summary
- align the think block grid rows to the start so their widths can reflect underlying values
- compute the maximum row total and scale each row width accordingly to keep stacked blocks proportional

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cbeb60e11c83249a02697486ab973f