### PR TITLE
Fix Kvikkbilder layout and examples

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -923,6 +923,7 @@
     const ensure = ()=>{
       let examples = getExamples();
       let updated = false;
+      const requireProvided = typeof window !== 'undefined' && window && window.__EXAMPLES_FORCE_PROVIDED__ === true;
 
       const deletedProvided = getDeletedProvidedExamples();
       let deletedUpdated = false;
@@ -955,6 +956,17 @@
         const key = normalizeKey(ex && ex.__builtinKey);
         return !key || !deletedProvided.has(key);
       });
+      if(requireProvided && availableDefaults.length > 0 && examples.length === 1){
+        const only = examples[0];
+        const onlyObj = only && typeof only === 'object' ? only : null;
+        const hasKey = onlyObj ? !!normalizeKey(onlyObj.__builtinKey) : false;
+        const hasSvg = onlyObj && typeof onlyObj.svg === 'string' ? onlyObj.svg.trim().length > 0 : false;
+        if(onlyObj && onlyObj.isDefault === true && !hasKey && !hasSvg){
+          examples = [];
+          currentExampleIndex = 0;
+          updated = true;
+        }
+      }
       if(examples.length === 0){
         if(availableDefaults.length > 0){
           let defaultIdx = availableDefaults.findIndex(ex => ex.isDefault);
@@ -1057,6 +1069,9 @@
             initialLoadPerformed = true;
           }
         }
+      }
+      if(requireProvided && typeof window !== 'undefined' && window){
+        window.__EXAMPLES_FORCE_PROVIDED__ = false;
       }
     };
     if(document.readyState === 'complete') setTimeout(ensure, 0);

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -27,16 +27,14 @@
     .figure-area{
       position:relative;
       width:min(80vmin,100%);
-      aspect-ratio:1;
       align-self:center;
       margin:0 auto;
     }
-    @supports not (aspect-ratio: 1 / 1) {
-      .figure-area::before {
-        content:"";
-        display:block;
-        padding-bottom:100%;
-      }
+    .figure-area::before {
+      content:"";
+      display:block;
+      padding-bottom:100%;
+      pointer-events:none;
     }
     #brickContainer{
       position:absolute;
@@ -59,7 +57,7 @@
       grid-auto-rows:minmax(0,1fr);
     }
     #patternContainer svg{width:100%;height:100%;display:block;}
-    #expression{text-align:center;font-size:24px;font-weight:600;}
+    #expression{text-align:center;font-size:24px;font-weight:600;margin-top:var(--gap);}
     label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     input[type="number"], select{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
     .field-row{display:grid;gap:10px;}

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -48,6 +48,108 @@
     }
   };
 
+  function deepClone(value){
+    if(value == null) return value;
+    if(typeof structuredClone === 'function'){
+      try{
+        return structuredClone(value);
+      }catch(_){ }
+    }
+    try{
+      return JSON.parse(JSON.stringify(value));
+    }catch(_){
+      return value;
+    }
+  }
+
+  function createExampleCfg(overrides){
+    const base = deepClone(DEFAULT_CFG) || {};
+    const normalized = overrides && typeof overrides === 'object' ? overrides : {};
+    if(typeof normalized.type === 'string'){
+      base.type = normalized.type === 'monster' ? 'monster' : 'klosser';
+    }
+    if(Object.prototype.hasOwnProperty.call(normalized, 'showExpression')){
+      base.showExpression = normalized.showExpression !== false;
+    }
+    if(normalized.klosser && typeof normalized.klosser === 'object'){
+      base.klosser = Object.assign({}, base.klosser, normalized.klosser);
+    }
+    if(normalized.monster && typeof normalized.monster === 'object'){
+      base.monster = Object.assign({}, base.monster, normalized.monster);
+    }
+    return base;
+  }
+
+  const DEFAULT_KVIKKBILDER_EXAMPLES = [
+    {
+      id: 'kvikkbilder-klosser-1',
+      exampleNumber: '1',
+      title: '4 · 2 · (2 · 3 · 2)',
+      isDefault: true,
+      config: {
+        CFG: createExampleCfg({
+          type: 'klosser',
+          showExpression: true,
+          klosser: {
+            antallX: 4,
+            antallY: 2,
+            bredde: 2,
+            hoyde: 3,
+            dybde: 2,
+            showBtn: false
+          }
+        })
+      }
+    },
+    {
+      id: 'kvikkbilder-klosser-2',
+      exampleNumber: '2',
+      title: '3 · 3 · (3 · 2 · 1)',
+      config: {
+        CFG: createExampleCfg({
+          type: 'klosser',
+          showExpression: true,
+          klosser: {
+            antallX: 3,
+            antallY: 3,
+            bredde: 3,
+            hoyde: 2,
+            dybde: 1,
+            showBtn: false
+          }
+        })
+      }
+    },
+    {
+      id: 'kvikkbilder-monster-3',
+      exampleNumber: '3',
+      title: 'Kvikkbilde 12',
+      config: {
+        CFG: createExampleCfg({
+          type: 'monster',
+          showExpression: true,
+          monster: {
+            antallX: 2,
+            antallY: 2,
+            antall: 12,
+            showBtn: false
+          }
+        })
+      }
+    }
+  ];
+
+  if(typeof window !== 'undefined'){
+    window.__EXAMPLES_FORCE_PROVIDED__ = true;
+    window.DEFAULT_EXAMPLES = DEFAULT_KVIKKBILDER_EXAMPLES.map(example => ({
+      ...example,
+      config: {
+        ...example.config,
+        CFG: deepClone(example.config?.CFG)
+      }
+    }));
+  }
+
   const globalCfg = (typeof window.CFG === 'object' && window.CFG) ? window.CFG : {};
   const CFG = window.CFG = globalCfg;
 


### PR DESCRIPTION
## Summary
- ensure the Kvikkbilder canvas keeps a square footprint and leaves space above the equation across browsers
- provide three built-in Kvikkbilder configurations and flag the page to prefer those defaults
- let the shared examples helper swap in provided defaults when a page explicitly requests them

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbec5b649083248f6f4b330499cd7f