### PR TITLE
Fix brick stacking transform order

### DIFF
--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -211,11 +211,11 @@
     const translateX = -minX;
     const translateY = -minY;
     const transforms = [];
-    if(translateX !== 0 || translateY !== 0){
-      transforms.push(`translate(${translateX},${translateY})`);
-    }
     if(scaleY !== 1){
       transforms.push(`scale(1,${scaleY})`);
+    }
+    if(translateX !== 0 || translateY !== 0){
+      transforms.push(`translate(${translateX},${translateY})`);
     }
     if(transforms.length){
       group.setAttribute('transform', transforms.join(' '));


### PR DESCRIPTION
## Summary
- fix the transform order when creating brick stacks so translations occur before scaling
- ensures that the generated SVG bricks all share the same height

## Testing
- no automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cc069d05948324bae2369776b8654b