### PR TITLE
Add option to trim trailing zeros on fraction wall

### DIFF
--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -242,6 +242,7 @@
                 <input id="percentDigits" type="number" min="0" max="3" value="1" />
               </label>
             </div>
+            <label class="checkbox"><input type="checkbox" id="trimTrailingZeros" /> <span>Fjern unødige nuller i prosent og desimaltall</span></label>
           </fieldset>
         </div>
 


### PR DESCRIPTION
## Summary
- add a checkbox in the text settings to control trimming of trailing zeros in percent and decimal displays
- update fraction wall formatting to optionally use fewer fractional digits while keeping rounding behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc0ef96328832480ca9c46ea3d7b79