### PR TITLE
Ensure fraction wall rows use uniform tile colors

### DIFF
--- a/brøkvegg.js
+++ b/brøkvegg.js
@@ -400,6 +400,8 @@
         transform: `translate(${STATE.showLabels ? LABEL_WIDTH : 0}, 0)`
       });
       const tileWidth = TILE_AREA_WIDTH / den;
+      const tileColor = lightenColor(baseColor, 0.12);
+      const tileTextColor = pickTileTextColor(tileColor);
       for(let i=0;i<den;i++){
         const mode = getTileMode(den, i);
         const displayValue = formatValue(mode, den);
@@ -412,8 +414,8 @@
           'aria-label': tileAriaLabel(den, i, mode)
         });
         const tileX = tileWidth * i;
-        const color = i % 2 === 0 ? baseColor : lightenColor(baseColor, 0.12);
-        const textColor = pickTileTextColor(color);
+        const color = tileColor;
+        const textColor = tileTextColor;
         const tooltip = createSvgElement('title', {
           textContent: `${displayValue} – ${MODE_LABELS[mode] || mode}`
         });


### PR DESCRIPTION
## Summary
- give each row in the fraction wall a single shared tile color and text color
- reuse the same tile text color across a row while keeping label styling unchanged

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc0fdf3af88324a6e35cb20284409c