### PR TITLE
Improve fortegnsskjema controls and styling

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -96,13 +96,17 @@
     .chart-overlay__input {
       position: absolute;
       transform: translate(-50%, -120%);
-      min-width: 64px;
-      padding: 6px 8px;
-      border-radius: 10px;
+      width: 44px;
+      height: 44px;
+      min-width: 0;
+      padding: 0;
+      border-radius: 12px;
       border: 1px solid #cbd5f5;
       background: #fff;
       box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
-      font-size: 14px;
+      font-size: 16px;
+      font-weight: 600;
+      line-height: 44px;
       text-align: center;
       color: #1f2937;
       pointer-events: auto;
@@ -115,6 +119,34 @@
     .chart-overlay__input--invalid {
       border-color: #f87171;
       box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.35);
+    }
+    .chart-overlay-actions {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      pointer-events: none;
+      z-index: 3;
+    }
+    .chart-overlay-action {
+      pointer-events: auto;
+      appearance: none;
+      border: 1px solid #d1d5db;
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.95);
+      padding: 6px 12px;
+      font-size: 13px;
+      font-weight: 600;
+      color: #1f2937;
+      box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
+      cursor: pointer;
+      transition: background 0.2s ease, box-shadow 0.2s ease;
+    }
+    .chart-overlay-action:hover {
+      background: #f3f4f6;
+      box-shadow: 0 4px 12px rgba(15, 23, 42, 0.14);
     }
     #chart {
       width: 100%;
@@ -235,6 +267,10 @@
         <div class="figure">
           <svg id="chart" role="img" aria-label="Fortegnsskjema"></svg>
           <div id="chartOverlay" class="chart-overlay"></div>
+          <div class="chart-overlay-actions" aria-hidden="false">
+            <button type="button" class="chart-overlay-action" id="overlayAddPoint">Legg til nullpunkt</button>
+            <button type="button" class="chart-overlay-action" id="overlayAddRow">Legg til fortegnslinje</button>
+          </div>
         </div>
         <div class="toolbar">
           <div class="toolbar-row">

--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -6,6 +6,8 @@
   const btnCheck = document.getElementById('btnCheck');
   const btnAddPoint = document.getElementById('btnAddPoint');
   const btnAddRow = document.getElementById('btnAddRow');
+  const overlayAddPoint = document.getElementById('overlayAddPoint');
+  const overlayAddRow = document.getElementById('overlayAddRow');
   const pointsList = document.getElementById('pointsList');
   const rowsList = document.getElementById('rowsList');
   const autoSyncInput = document.getElementById('autoSync');
@@ -765,7 +767,7 @@
           x2: endX,
           y2: y,
           stroke: sign > 0 ? '#111827' : '#dc2626',
-          'stroke-width': 8,
+          'stroke-width': 6,
           'stroke-linecap': 'round',
           'data-row-id': row.id,
           'data-index': i,
@@ -920,15 +922,29 @@
   svg.addEventListener('pointerup', stopDragging);
   svg.addEventListener('pointerleave', stopDragging);
 
-  btnAddPoint.addEventListener('click', () => {
+  function handleAddPoint() {
     addPoint('zero', 0);
     setCheckMessage('');
-  });
+  }
 
-  btnAddRow.addEventListener('click', () => {
+  function handleAddRow() {
     addRow();
     setCheckMessage('');
-  });
+  }
+
+  if (btnAddPoint) {
+    btnAddPoint.addEventListener('click', handleAddPoint);
+  }
+  if (overlayAddPoint) {
+    overlayAddPoint.addEventListener('click', handleAddPoint);
+  }
+
+  if (btnAddRow) {
+    btnAddRow.addEventListener('click', handleAddRow);
+  }
+  if (overlayAddRow) {
+    overlayAddRow.addEventListener('click', handleAddRow);
+  }
 
   btnGenerate.addEventListener('click', () => {
     try {


### PR DESCRIPTION
## Summary
- shrink the fortegnsskjema overlay inputs to a square shape sized for two digits
- add quick-access buttons on the diagram to add new null points and sign rows
- reduce the sign-line stroke width for a lighter appearance

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc1696a1788324bcaac389013fabf7