### PR TITLE
Ensure Safari compatibility by transpiling optional syntax

### DIFF
--- a/arealmodell0.js
+++ b/arealmodell0.js
@@ -1,11 +1,22 @@
+var _CFG$SIMPLE$challenge, _CFG$SIMPLE$challenge2, _CFG$SIMPLE$challenge3, _CFG$SIMPLE$challenge4, _CFG$SIMPLE$challenge5, _CFG$SIMPLE$challenge6;
 /* =========================================================
    AREALMODELL – rektangel m/ rutenett og håndtak
    ========================================================= */
 
 const CFG = {
   SIMPLE: {
-    length: { cells: 1, max: 12, show: true },   // x (bunn)
-    height: { cells: 1, max: 12, show: true },   // y (venstre)
+    length: {
+      cells: 1,
+      max: 12,
+      show: true
+    },
+    // x (bunn)
+    height: {
+      cells: 1,
+      max: 12,
+      show: true
+    },
+    // y (venstre)
     showGrid: true,
     snap: 1,
     // "areal" | "ruter" | "none" | egendefinert med ${N}
@@ -14,11 +25,11 @@ const CFG = {
     challenge: {
       enabled: false,
       area: 12,
-      dedupeOrderless: true,   // to kolonner (a · b og b · a)
-      autoExpandMax: true      // øk max slik at N lar seg representere
+      dedupeOrderless: true,
+      // to kolonner (a · b og b · a)
+      autoExpandMax: true // øk max slik at N lar seg representere
     }
   },
-
   ADV: {
     containerId: "box",
     colors: {
@@ -31,53 +42,67 @@ const CFG = {
     },
     opacity: 0.55,
     stroke: 2,
-    grid: { width: 1, dash: 2 },
-
+    grid: {
+      width: 1,
+      dash: 2
+    },
     // Marger i ruteenheter (rundt 0..max-området)
     // Økt top-marg for å gi plass til etiketter ved maksimal høyde
-    margin: { left: 0.9, right: 1.2, top: 2.6, bottomBase: 0.9 },
-
-    labelOutside: 0.6,   // avstand fra kant til sidekant-tall
-    labelRowGap: 1.0,    // avstand sidekant-tall ↔ “Areal: …”
+    margin: {
+      left: 0.9,
+      right: 1.2,
+      top: 2.6,
+      bottomBase: 0.9
+    },
+    labelOutside: 0.6,
+    // avstand fra kant til sidekant-tall
+    labelRowGap: 1.0,
+    // avstand sidekant-tall ↔ “Areal: …”
 
     // Minimum piksel-luft (hindrer klipp ved smale vinduer)
-    minPadPx: { left: 20, bottom: 40 },
-
+    minPadPx: {
+      left: 20,
+      bottom: 40
+    },
     fontSize: 18,
     responsive: true,
     keepAspect1to1: true,
     handleRadius: 14,
-    keyboardShortcuts: true, // r=reset, s=svg
+    keyboardShortcuts: true,
+    // r=reset, s=svg
     fileName: "arealmodell.svg",
-
     // Lister nederst inne i rammen (i ruteenheter)
     listsInside: {
-      insetX: 1.1,        // fra høyrekant til kolonne-senter
-      colGap: 3.2,        // senter-senter
-      listLineGap: 0.95,  // radavstand
-      bottomPad: 1.2      // luft under siste rad
+      insetX: 1.1,
+      // fra høyrekant til kolonne-senter
+      colGap: 3.2,
+      // senter-senter
+      listLineGap: 0.95,
+      // radavstand
+      bottomPad: 1.2 // luft under siste rad
     }
   }
 };
 const DEFAULT_SIMPLE_CFG = JSON.parse(JSON.stringify(CFG.SIMPLE));
-
-function ensureSimpleDefaults(){
-  const fill = (target, defaults)=>{
-    if(!defaults || typeof defaults !== 'object') return;
+function ensureSimpleDefaults() {
+  const fill = (target, defaults) => {
+    if (!defaults || typeof defaults !== 'object') return;
     Object.keys(defaults).forEach(key => {
       const defVal = defaults[key];
       const curVal = target[key];
-      if(defVal && typeof defVal === 'object' && !Array.isArray(defVal)){
-        if(!curVal || typeof curVal !== 'object'){
-          target[key] = Array.isArray(defVal) ? defVal.slice() : {...defVal};
+      if (defVal && typeof defVal === 'object' && !Array.isArray(defVal)) {
+        if (!curVal || typeof curVal !== 'object') {
+          target[key] = Array.isArray(defVal) ? defVal.slice() : {
+            ...defVal
+          };
         }
         fill(target[key], defVal);
-      }else if(!(key in target)){
+      } else if (!(key in target)) {
         target[key] = Array.isArray(defVal) ? defVal.slice() : defVal;
       }
     });
   };
-  if(!CFG.SIMPLE || typeof CFG.SIMPLE !== 'object') CFG.SIMPLE = {};
+  if (!CFG.SIMPLE || typeof CFG.SIMPLE !== 'object') CFG.SIMPLE = {};
   fill(CFG.SIMPLE, DEFAULT_SIMPLE_CFG);
 }
 
@@ -87,175 +112,203 @@ const S = {
   h: CFG.SIMPLE.height.cells,
   w0: CFG.SIMPLE.length.cells,
   h0: CFG.SIMPLE.height.cells,
-
-  maxW: Math.max(
-    CFG.SIMPLE.length.max,
-    (CFG.SIMPLE.challenge?.enabled && CFG.SIMPLE.challenge?.autoExpandMax) ? (CFG.SIMPLE.challenge?.area || 0) : 0
-  ),
-  maxH: Math.max(
-    CFG.SIMPLE.height.max,
-    (CFG.SIMPLE.challenge?.enabled && CFG.SIMPLE.challenge?.autoExpandMax) ? (CFG.SIMPLE.challenge?.area || 0) : 0
-  ),
-
+  maxW: Math.max(CFG.SIMPLE.length.max, (_CFG$SIMPLE$challenge = CFG.SIMPLE.challenge) !== null && _CFG$SIMPLE$challenge !== void 0 && _CFG$SIMPLE$challenge.enabled && (_CFG$SIMPLE$challenge2 = CFG.SIMPLE.challenge) !== null && _CFG$SIMPLE$challenge2 !== void 0 && _CFG$SIMPLE$challenge2.autoExpandMax ? ((_CFG$SIMPLE$challenge3 = CFG.SIMPLE.challenge) === null || _CFG$SIMPLE$challenge3 === void 0 ? void 0 : _CFG$SIMPLE$challenge3.area) || 0 : 0),
+  maxH: Math.max(CFG.SIMPLE.height.max, (_CFG$SIMPLE$challenge4 = CFG.SIMPLE.challenge) !== null && _CFG$SIMPLE$challenge4 !== void 0 && _CFG$SIMPLE$challenge4.enabled && (_CFG$SIMPLE$challenge5 = CFG.SIMPLE.challenge) !== null && _CFG$SIMPLE$challenge5 !== void 0 && _CFG$SIMPLE$challenge5.autoExpandMax ? ((_CFG$SIMPLE$challenge6 = CFG.SIMPLE.challenge) === null || _CFG$SIMPLE$challenge6 === void 0 ? void 0 : _CFG$SIMPLE$challenge6.area) || 0 : 0),
   board: null,
   handle: null,
-
   gridLines: [],
-  labelArea: null, labelLen: null, labelHei: null,
-
+  labelArea: null,
+  labelLen: null,
+  labelHei: null,
   // “tabell”-tekster
 
   // oppgave
   ch: {
     enabled: !!(CFG.SIMPLE.challenge && CFG.SIMPLE.challenge.enabled),
-    N: (CFG.SIMPLE.challenge && CFG.SIMPLE.challenge.area) || null,
+    N: CFG.SIMPLE.challenge && CFG.SIMPLE.challenge.area || null,
     allPairs: [],
-    oriented: new Set(),  // "a×b" som faktisk er laget
+    oriented: new Set(),
+    // "a×b" som faktisk er laget
     dedupeOrderless: !!(CFG.SIMPLE.challenge && CFG.SIMPLE.challenge.dedupeOrderless)
   },
-
   // UU
-  kb: { btn: null, live: null, focused: false, origHandleSize: null }
+  kb: {
+    btn: null,
+    live: null,
+    focused: false,
+    origHandleSize: null
+  }
 };
 
 /* ============================== Config fra HTML ============================== */
-function readConfigFromHtml(){
-  const len = parseInt(document.getElementById("lenCells")?.value,10);
-  if(Number.isFinite(len)) CFG.SIMPLE.length.cells = len;
-  const lenMax = parseInt(document.getElementById("lenMax")?.value,10);
-  if(Number.isFinite(lenMax)) CFG.SIMPLE.length.max = lenMax;
-  const hei = parseInt(document.getElementById("heiCells")?.value,10);
-  if(Number.isFinite(hei)) CFG.SIMPLE.height.cells = hei;
-  const heiMax = parseInt(document.getElementById("heiMax")?.value,10);
-  if(Number.isFinite(heiMax)) CFG.SIMPLE.height.max = heiMax;
-  CFG.SIMPLE.showGrid = document.getElementById("chkGrid")?.checked ?? CFG.SIMPLE.showGrid;
-  const snap = parseInt(document.getElementById("snap")?.value,10);
-  if(Number.isFinite(snap)) CFG.SIMPLE.snap = snap;
-  const areaLabel = document.getElementById("areaLabel")?.value;
-  if(areaLabel != null) CFG.SIMPLE.areaLabel = areaLabel;
-  if(!CFG.SIMPLE.challenge) CFG.SIMPLE.challenge = {};
-  CFG.SIMPLE.challenge.enabled = document.getElementById("chkChallenge")?.checked ?? false;
-  const chArea = parseInt(document.getElementById("challengeArea")?.value,10);
-  if(Number.isFinite(chArea)) CFG.SIMPLE.challenge.area = chArea;
+function readConfigFromHtml() {
+  var _document$getElementB, _document$getElementB2, _document$getElementB3, _document$getElementB4, _document$getElementB5, _document$getElementB6, _document$getElementB7, _document$getElementB8, _document$getElementB9, _document$getElementB0, _document$getElementB1;
+  const len = parseInt((_document$getElementB = document.getElementById("lenCells")) === null || _document$getElementB === void 0 ? void 0 : _document$getElementB.value, 10);
+  if (Number.isFinite(len)) CFG.SIMPLE.length.cells = len;
+  const lenMax = parseInt((_document$getElementB2 = document.getElementById("lenMax")) === null || _document$getElementB2 === void 0 ? void 0 : _document$getElementB2.value, 10);
+  if (Number.isFinite(lenMax)) CFG.SIMPLE.length.max = lenMax;
+  const hei = parseInt((_document$getElementB3 = document.getElementById("heiCells")) === null || _document$getElementB3 === void 0 ? void 0 : _document$getElementB3.value, 10);
+  if (Number.isFinite(hei)) CFG.SIMPLE.height.cells = hei;
+  const heiMax = parseInt((_document$getElementB4 = document.getElementById("heiMax")) === null || _document$getElementB4 === void 0 ? void 0 : _document$getElementB4.value, 10);
+  if (Number.isFinite(heiMax)) CFG.SIMPLE.height.max = heiMax;
+  CFG.SIMPLE.showGrid = (_document$getElementB5 = (_document$getElementB6 = document.getElementById("chkGrid")) === null || _document$getElementB6 === void 0 ? void 0 : _document$getElementB6.checked) !== null && _document$getElementB5 !== void 0 ? _document$getElementB5 : CFG.SIMPLE.showGrid;
+  const snap = parseInt((_document$getElementB7 = document.getElementById("snap")) === null || _document$getElementB7 === void 0 ? void 0 : _document$getElementB7.value, 10);
+  if (Number.isFinite(snap)) CFG.SIMPLE.snap = snap;
+  const areaLabel = (_document$getElementB8 = document.getElementById("areaLabel")) === null || _document$getElementB8 === void 0 ? void 0 : _document$getElementB8.value;
+  if (areaLabel != null) CFG.SIMPLE.areaLabel = areaLabel;
+  if (!CFG.SIMPLE.challenge) CFG.SIMPLE.challenge = {};
+  CFG.SIMPLE.challenge.enabled = (_document$getElementB9 = (_document$getElementB0 = document.getElementById("chkChallenge")) === null || _document$getElementB0 === void 0 ? void 0 : _document$getElementB0.checked) !== null && _document$getElementB9 !== void 0 ? _document$getElementB9 : false;
+  const chArea = parseInt((_document$getElementB1 = document.getElementById("challengeArea")) === null || _document$getElementB1 === void 0 ? void 0 : _document$getElementB1.value, 10);
+  if (Number.isFinite(chArea)) CFG.SIMPLE.challenge.area = chArea;
 }
-
-function applySimpleConfig(){
+function applySimpleConfig() {
+  var _CFG$SIMPLE$challenge7, _CFG$SIMPLE$challenge8, _CFG$SIMPLE$challenge9, _CFG$SIMPLE$challenge0, _CFG$SIMPLE$challenge1, _CFG$SIMPLE$challenge10;
   S.w = CFG.SIMPLE.length.cells;
   S.h = CFG.SIMPLE.height.cells;
   S.w0 = S.w;
   S.h0 = S.h;
-  S.maxW = Math.max(
-    CFG.SIMPLE.length.max,
-    (CFG.SIMPLE.challenge?.enabled && CFG.SIMPLE.challenge?.autoExpandMax) ? (CFG.SIMPLE.challenge?.area || 0) : 0
-  );
-  S.maxH = Math.max(
-    CFG.SIMPLE.height.max,
-    (CFG.SIMPLE.challenge?.enabled && CFG.SIMPLE.challenge?.autoExpandMax) ? (CFG.SIMPLE.challenge?.area || 0) : 0
-  );
+  S.maxW = Math.max(CFG.SIMPLE.length.max, (_CFG$SIMPLE$challenge7 = CFG.SIMPLE.challenge) !== null && _CFG$SIMPLE$challenge7 !== void 0 && _CFG$SIMPLE$challenge7.enabled && (_CFG$SIMPLE$challenge8 = CFG.SIMPLE.challenge) !== null && _CFG$SIMPLE$challenge8 !== void 0 && _CFG$SIMPLE$challenge8.autoExpandMax ? ((_CFG$SIMPLE$challenge9 = CFG.SIMPLE.challenge) === null || _CFG$SIMPLE$challenge9 === void 0 ? void 0 : _CFG$SIMPLE$challenge9.area) || 0 : 0);
+  S.maxH = Math.max(CFG.SIMPLE.height.max, (_CFG$SIMPLE$challenge0 = CFG.SIMPLE.challenge) !== null && _CFG$SIMPLE$challenge0 !== void 0 && _CFG$SIMPLE$challenge0.enabled && (_CFG$SIMPLE$challenge1 = CFG.SIMPLE.challenge) !== null && _CFG$SIMPLE$challenge1 !== void 0 && _CFG$SIMPLE$challenge1.autoExpandMax ? ((_CFG$SIMPLE$challenge10 = CFG.SIMPLE.challenge) === null || _CFG$SIMPLE$challenge10 === void 0 ? void 0 : _CFG$SIMPLE$challenge10.area) || 0 : 0);
   S.ch.enabled = !!(CFG.SIMPLE.challenge && CFG.SIMPLE.challenge.enabled);
-  S.ch.N = (CFG.SIMPLE.challenge && CFG.SIMPLE.challenge.area) || null;
+  S.ch.N = CFG.SIMPLE.challenge && CFG.SIMPLE.challenge.area || null;
   S.ch.dedupeOrderless = !!(CFG.SIMPLE.challenge && CFG.SIMPLE.challenge.dedupeOrderless);
 }
-
-function syncSimpleConfigFromState(){
+function syncSimpleConfigFromState() {
   CFG.SIMPLE.length.cells = S.w;
   CFG.SIMPLE.height.cells = S.h;
   S.w0 = S.w;
   S.h0 = S.h;
   const lenInput = document.getElementById("lenCells");
-  if(lenInput) lenInput.value = String(S.w);
+  if (lenInput) lenInput.value = String(S.w);
   const heiInput = document.getElementById("heiCells");
-  if(heiInput) heiInput.value = String(S.h);
+  if (heiInput) heiInput.value = String(S.h);
 }
-
-function rebuildFromConfig(){
+function rebuildFromConfig() {
   ensureSimpleDefaults();
   applySimpleConfig();
-  if(S.board) JXG.JSXGraph.freeBoard(S.board);
+  if (S.board) JXG.JSXGraph.freeBoard(S.board);
   createBoard();
 }
-
-function initFromHtml(){
+function initFromHtml() {
   readConfigFromHtml();
   rebuildFromConfig();
 }
 
 /* ============================== Hjelpere ============================== */
-const clamp=(v,lo,hi)=>Math.max(lo,Math.min(hi,v));
-const quantize=(v,step)=>(step<=0?v:Math.round(v/step)*step);
-const debounced=(fn,ms=80)=>{let t=null;return(...a)=>{clearTimeout(t);t=setTimeout(()=>fn(...a),ms);};};
-
-function areaLabelText(n){
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+const quantize = (v, step) => step <= 0 ? v : Math.round(v / step) * step;
+const debounced = (fn, ms = 80) => {
+  let t = null;
+  return (...a) => {
+    clearTimeout(t);
+    t = setTimeout(() => fn(...a), ms);
+  };
+};
+function areaLabelText(n) {
   const m = CFG.SIMPLE.areaLabel;
   if (m == null) return "Areal: " + n;
   const s = String(m).toLowerCase();
-  if (s==="none"||s==="off"||s==="hide") return null;
-  if (s==="areal") return "Areal: " + n;
-  if (s==="ruter"||s==="tiles"||s==="antall") return "Ruter: " + n;
+  if (s === "none" || s === "off" || s === "hide") return null;
+  if (s === "areal") return "Areal: " + n;
+  if (s === "ruter" || s === "tiles" || s === "antall") return "Ruter: " + n;
   return String(m).includes("${N}") ? String(m).replace("${N}", String(n)) : String(m);
 }
-function factorPairsSorted(N){ const out=[]; for(let a=1;a*a<=N;a++){ if(N%a===0) out.push([a,N/a]); } return out; }
+function factorPairsSorted(N) {
+  const out = [];
+  for (let a = 1; a * a <= N; a++) {
+    if (N % a === 0) out.push([a, N / a]);
+  }
+  return out;
+}
 
 /* ============================== UU ============================== */
-function injectSrOnlyCSS(){
+function injectSrOnlyCSS() {
   if (document.getElementById("sr-only-style")) return;
-  const style=document.createElement("style");
-  style.id="sr-only-style";
-  style.textContent=".sr-only{position:absolute!important;width:1px!important;height:1px!important;padding:0!important;margin:-1px!important;overflow:hidden!important;clip:rect(0 0 0 0)!important;white-space:nowrap!important;border:0!important;}";
+  const style = document.createElement("style");
+  style.id = "sr-only-style";
+  style.textContent = ".sr-only{position:absolute!important;width:1px!important;height:1px!important;padding:0!important;margin:-1px!important;overflow:hidden!important;clip:rect(0 0 0 0)!important;white-space:nowrap!important;border:0!important;}";
   document.head.appendChild(style);
 }
-function ensureA11yControls(){
+function ensureA11yControls() {
   injectSrOnlyCSS();
-  const box=document.getElementById(CFG.ADV.containerId);
-
-  if(!S.kb.btn){
-    const btn=document.createElement("button");
-    btn.className="sr-only";
-    btn.type="button";
-    btn.title="Håndtak – bruk piltaster (Shift=5). Home/End setter min/maks.";
-    btn.setAttribute("aria-label","Håndtak for rektangelet. Bruk piltaster for å endre størrelse. Hold Shift for å flytte 5 ruter. Home/End til min/maks.");
+  const box = document.getElementById(CFG.ADV.containerId);
+  if (!S.kb.btn) {
+    const btn = document.createElement("button");
+    btn.className = "sr-only";
+    btn.type = "button";
+    btn.title = "Håndtak – bruk piltaster (Shift=5). Home/End setter min/maks.";
+    btn.setAttribute("aria-label", "Håndtak for rektangelet. Bruk piltaster for å endre størrelse. Hold Shift for å flytte 5 ruter. Home/End til min/maks.");
     box.insertAdjacentElement("afterend", btn);
-    S.kb.btn=btn;
-
-    btn.addEventListener("focus",()=>{
-      S.kb.focused=true;
-      if(S.handle && S.kb.origHandleSize==null) S.kb.origHandleSize=S.handle.getAttribute("size");
-      if(S.handle) S.handle.setAttribute({size:(CFG.ADV.handleRadius*1.25)});
+    S.kb.btn = btn;
+    btn.addEventListener("focus", () => {
+      S.kb.focused = true;
+      if (S.handle && S.kb.origHandleSize == null) S.kb.origHandleSize = S.handle.getAttribute("size");
+      if (S.handle) S.handle.setAttribute({
+        size: CFG.ADV.handleRadius * 1.25
+      });
     });
-    btn.addEventListener("blur",()=>{
-      S.kb.focused=false;
-      if(S.handle && S.kb.origHandleSize!=null) S.handle.setAttribute({size:S.kb.origHandleSize});
+    btn.addEventListener("blur", () => {
+      S.kb.focused = false;
+      if (S.handle && S.kb.origHandleSize != null) S.handle.setAttribute({
+        size: S.kb.origHandleSize
+      });
     });
-
-    btn.addEventListener("keydown",(e)=>{
-      const stepBase=Math.max(1,CFG.SIMPLE.snap);
-      const step=(e.shiftKey?5:1)*stepBase;
-      let dx=0,dy=0;
-      if(e.key==="ArrowRight"){dx=step;e.preventDefault();}
-      else if(e.key==="ArrowLeft"){dx=-step;e.preventDefault();}
-      else if(e.key==="ArrowUp"){dy=step;e.preventDefault();}
-      else if(e.key==="ArrowDown"){dy=-step;e.preventDefault();}
-      else if(e.key==="Home"){ if(e.ctrlKey||e.metaKey){S.w=1;S.h=1;} else {S.w=1;} moveHandleTo(S.w,S.h); e.preventDefault(); }
-      else if(e.key==="End"){ if(e.ctrlKey||e.metaKey){S.w=S.maxW;S.h=S.maxH;} else {S.w=S.maxW;} moveHandleTo(S.w,S.h); e.preventDefault(); }
-      if(dx||dy) moveHandleTo(clamp(S.w+dx,1,S.maxW), clamp(S.h+dy,1,S.maxH));
+    btn.addEventListener("keydown", e => {
+      const stepBase = Math.max(1, CFG.SIMPLE.snap);
+      const step = (e.shiftKey ? 5 : 1) * stepBase;
+      let dx = 0,
+        dy = 0;
+      if (e.key === "ArrowRight") {
+        dx = step;
+        e.preventDefault();
+      } else if (e.key === "ArrowLeft") {
+        dx = -step;
+        e.preventDefault();
+      } else if (e.key === "ArrowUp") {
+        dy = step;
+        e.preventDefault();
+      } else if (e.key === "ArrowDown") {
+        dy = -step;
+        e.preventDefault();
+      } else if (e.key === "Home") {
+        if (e.ctrlKey || e.metaKey) {
+          S.w = 1;
+          S.h = 1;
+        } else {
+          S.w = 1;
+        }
+        moveHandleTo(S.w, S.h);
+        e.preventDefault();
+      } else if (e.key === "End") {
+        if (e.ctrlKey || e.metaKey) {
+          S.w = S.maxW;
+          S.h = S.maxH;
+        } else {
+          S.w = S.maxW;
+        }
+        moveHandleTo(S.w, S.h);
+        e.preventDefault();
+      }
+      if (dx || dy) moveHandleTo(clamp(S.w + dx, 1, S.maxW), clamp(S.h + dy, 1, S.maxH));
     });
   }
-
-  if(!S.kb.live){
-    const live=document.createElement("div");
-    live.className="sr-only";
-    live.setAttribute("aria-live","polite");
-    (S.kb.btn||box).insertAdjacentElement("afterend", live);
-    S.kb.live=live;
+  if (!S.kb.live) {
+    const live = document.createElement("div");
+    live.className = "sr-only";
+    live.setAttribute("aria-live", "polite");
+    (S.kb.btn || box).insertAdjacentElement("afterend", live);
+    S.kb.live = live;
   }
   updateLive();
 }
-function updateLive(){ if(S.kb.live) S.kb.live.textContent=`Bredde ${S.w}, høyde ${S.h}, areal ${S.w*S.h}.`; }
-function moveHandleTo(nx,ny){
-  S.w=Math.round(nx);
-  S.h=Math.round(ny);
-  if(S.handle) S.handle.moveTo([S.w,S.h]);
-  tryRegisterFound(S.w,S.h);
+function updateLive() {
+  if (S.kb.live) S.kb.live.textContent = `Bredde ${S.w}, høyde ${S.h}, areal ${S.w * S.h}.`;
+}
+function moveHandleTo(nx, ny) {
+  S.w = Math.round(nx);
+  S.h = Math.round(ny);
+  if (S.handle) S.handle.moveTo([S.w, S.h]);
+  tryRegisterFound(S.w, S.h);
   drawInnerGrid();
   updateLive();
   syncSimpleConfigFromState();
@@ -264,224 +317,304 @@ function moveHandleTo(nx,ny){
 
 /* ============================== Grid inni rektangelet ============================== */
 /* Viktig: layer=9 -> over fyllet (fill ligger på 7) */
-function clearInnerGrid(){ for(const g of S.gridLines){ S.board.removeObject(g); } S.gridLines.length=0; }
-function drawInnerGrid(){
+function clearInnerGrid() {
+  for (const g of S.gridLines) {
+    S.board.removeObject(g);
+  }
+  S.gridLines.length = 0;
+}
+function drawInnerGrid() {
   clearInnerGrid();
-  if(!CFG.SIMPLE.showGrid) return;
-  const C=CFG.ADV.colors;
-  for(let j=1;j<S.h;j++){
-    S.gridLines.push(S.board.create("segment", [[0,j],[S.w,j]], {
-      strokeColor:C.grid, strokeWidth:CFG.ADV.grid.width, dash:CFG.ADV.grid.dash,
-      fixed:true, highlight:false, layer:9
+  if (!CFG.SIMPLE.showGrid) return;
+  const C = CFG.ADV.colors;
+  for (let j = 1; j < S.h; j++) {
+    S.gridLines.push(S.board.create("segment", [[0, j], [S.w, j]], {
+      strokeColor: C.grid,
+      strokeWidth: CFG.ADV.grid.width,
+      dash: CFG.ADV.grid.dash,
+      fixed: true,
+      highlight: false,
+      layer: 9
     }));
   }
-  for(let i=1;i<S.w;i++){
-    S.gridLines.push(S.board.create("segment", [[i,0],[i,S.h]], {
-      strokeColor:C.grid, strokeWidth:CFG.ADV.grid.width, dash:CFG.ADV.grid.dash,
-      fixed:true, highlight:false, layer:9
+  for (let i = 1; i < S.w; i++) {
+    S.gridLines.push(S.board.create("segment", [[i, 0], [i, S.h]], {
+      strokeColor: C.grid,
+      strokeWidth: CFG.ADV.grid.width,
+      dash: CFG.ADV.grid.dash,
+      fixed: true,
+      highlight: false,
+      layer: 9
     }));
   }
 }
 
 /* ============================== Lister (“tabell”) ============================== */
-function getListContainers(){
-  const box=document.getElementById(CFG.ADV.containerId);
-  let wrap=box.querySelector('.pairs-list');
-  if(!wrap){
-    wrap=document.createElement('div');
-    wrap.className='pairs-list';
-    const a=document.createElement('div'); a.id='listA'; a.className='col';
-    const b=document.createElement('div'); b.id='listB'; b.className='col';
-    wrap.appendChild(a); wrap.appendChild(b);
+function getListContainers() {
+  const box = document.getElementById(CFG.ADV.containerId);
+  let wrap = box.querySelector('.pairs-list');
+  if (!wrap) {
+    wrap = document.createElement('div');
+    wrap.className = 'pairs-list';
+    const a = document.createElement('div');
+    a.id = 'listA';
+    a.className = 'col';
+    const b = document.createElement('div');
+    b.id = 'listB';
+    b.className = 'col';
+    wrap.appendChild(a);
+    wrap.appendChild(b);
     box.appendChild(wrap);
   }
   return [wrap.querySelector('#listA'), wrap.querySelector('#listB')];
 }
-
-function renderInBoardLists(){
-  const [colA, colB]=getListContainers();
-  if(!S.ch.enabled){
-    colA.innerHTML='';
-    colB.innerHTML='';
+function renderInBoardLists() {
+  const [colA, colB] = getListContainers();
+  if (!S.ch.enabled) {
+    colA.innerHTML = '';
+    colB.innerHTML = '';
     adaptView();
     return;
   }
-
-  const linesA=[], linesB=[];
-  if(S.ch.dedupeOrderless){
-    for(const [a,b] of S.ch.allPairs){
-      if(S.ch.oriented.has(`${a}×${b}`)) linesA.push(`${a} · ${b} = ${S.ch.N}`);
-      if(a!==b && S.ch.oriented.has(`${b}×${a}`)) linesB.push(`${b} · ${a} = ${S.ch.N}`);
+  const linesA = [],
+    linesB = [];
+  if (S.ch.dedupeOrderless) {
+    for (const [a, b] of S.ch.allPairs) {
+      if (S.ch.oriented.has(`${a}×${b}`)) linesA.push(`${a} · ${b} = ${S.ch.N}`);
+      if (a !== b && S.ch.oriented.has(`${b}×${a}`)) linesB.push(`${b} · ${a} = ${S.ch.N}`);
     }
   } else {
-    const items=[...S.ch.oriented].map(s=>s.split('×').map(n=>parseInt(n,10)))
-      .sort((p,q)=>(p[0]-q[0])||(p[1]-q[1]));
-    for(const [a,b] of items) linesA.push(`${a} · ${b} = ${S.ch.N}`);
+    const items = [...S.ch.oriented].map(s => s.split('×').map(n => parseInt(n, 10))).sort((p, q) => p[0] - q[0] || p[1] - q[1]);
+    for (const [a, b] of items) linesA.push(`${a} · ${b} = ${S.ch.N}`);
   }
-
-  colA.innerHTML=linesA.map(t=>`<div>${t}</div>`).join('');
-  colB.innerHTML=linesB.map(t=>`<div>${t}</div>`).join('');
+  colA.innerHTML = linesA.map(t => `<div>${t}</div>`).join('');
+  colB.innerHTML = linesB.map(t => `<div>${t}</div>`).join('');
   adaptView();
 }
 
 /* ============================== Board/tegn ============================== */
-function drawAll(){
-  const C=CFG.ADV.colors;
+function drawAll() {
+  const C = CFG.ADV.colors;
   const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-  const HANDLE_R = isMobile ? Math.round(CFG.ADV.handleRadius*1.3) : CFG.ADV.handleRadius;
-  const FONT = isMobile ? Math.round(CFG.ADV.fontSize*1.15) : CFG.ADV.fontSize;
+  const HANDLE_R = isMobile ? Math.round(CFG.ADV.handleRadius * 1.3) : CFG.ADV.handleRadius;
+  const FONT = isMobile ? Math.round(CFG.ADV.fontSize * 1.15) : CFG.ADV.fontSize;
 
   // Håndtak
-  S.handle=S.board.create("point",[S.w,S.h],{
-    name:"", size:HANDLE_R, strokeColor:C.handleEdge, fillColor:C.handleFill,
-    face:"circle", fixed:false, showInfobox:false, withLabel:false, highlight:true, layer:12
+  S.handle = S.board.create("point", [S.w, S.h], {
+    name: "",
+    size: HANDLE_R,
+    strokeColor: C.handleEdge,
+    fillColor: C.handleFill,
+    face: "circle",
+    fixed: false,
+    showInfobox: false,
+    withLabel: false,
+    highlight: true,
+    layer: 12
   });
 
   // Hjørner (usynlige og faste)
-  const A=S.board.create("point",[0,0],{visible:false,fixed:true});
-  const B=S.board.create("point",[()=>S.handle.X(),0],{visible:false,fixed:true});
-  const Cc=S.board.create("point",[()=>S.handle.X(),()=>S.handle.Y()],{visible:false,fixed:true});
-  const D=S.board.create("point",[0,()=>S.handle.Y()],{visible:false,fixed:true});
+  const A = S.board.create("point", [0, 0], {
+    visible: false,
+    fixed: true
+  });
+  const B = S.board.create("point", [() => S.handle.X(), 0], {
+    visible: false,
+    fixed: true
+  });
+  const Cc = S.board.create("point", [() => S.handle.X(), () => S.handle.Y()], {
+    visible: false,
+    fixed: true
+  });
+  const D = S.board.create("point", [0, () => S.handle.Y()], {
+    visible: false,
+    fixed: true
+  });
 
   // Rektangel
-  const poly=S.board.create("polygon",[A,B,Cc,D],{
-    withLines:true, fillColor:C.fill, fillOpacity:CFG.ADV.opacity,
-    borders:{strokeColor:C.edge,strokeWidth:CFG.ADV.stroke,highlight:false,fixed:true},
-    fixed:true, highlight:false, hasInnerPoints:false, layer:7
+  const poly = S.board.create("polygon", [A, B, Cc, D], {
+    withLines: true,
+    fillColor: C.fill,
+    fillOpacity: CFG.ADV.opacity,
+    borders: {
+      strokeColor: C.edge,
+      strokeWidth: CFG.ADV.stroke,
+      highlight: false,
+      fixed: true
+    },
+    fixed: true,
+    highlight: false,
+    hasInnerPoints: false,
+    layer: 7
   });
-  poly.borders.forEach(b=>b.setAttribute({layer:8,highlight:false,fixed:true}));
-
+  poly.borders.forEach(b => b.setAttribute({
+    layer: 8,
+    highlight: false,
+    fixed: true
+  }));
   updateCountsFromHandle();
   drawInnerGrid();
 
   // Etiketter
-  const out=CFG.ADV.labelOutside, gap=CFG.ADV.labelRowGap;
-  S.labelLen=S.board.create("text",[()=>S.w/2,()=>-out,()=>String(S.w)],{anchorX:"middle",anchorY:"top",fixed:true,fontSize:FONT,strokeColor:CFG.ADV.colors.text,layer:10});
-  S.labelHei=S.board.create("text",[()=>-out,()=>S.h/2,()=>String(S.h)],{anchorX:"right",anchorY:"middle",fixed:true,fontSize:FONT,strokeColor:CFG.ADV.colors.text,layer:10});
-  S.labelArea=S.board.create("text",[()=>-out,()=>-(out+gap),()=>{const t=areaLabelText(S.w*S.h);return t===null?"":t;}],{anchorX:"left",anchorY:"top",fixed:true,fontSize:FONT,strokeColor:CFG.ADV.colors.text,layer:10});
+  const out = CFG.ADV.labelOutside,
+    gap = CFG.ADV.labelRowGap;
+  S.labelLen = S.board.create("text", [() => S.w / 2, () => -out, () => String(S.w)], {
+    anchorX: "middle",
+    anchorY: "top",
+    fixed: true,
+    fontSize: FONT,
+    strokeColor: CFG.ADV.colors.text,
+    layer: 10
+  });
+  S.labelHei = S.board.create("text", [() => -out, () => S.h / 2, () => String(S.h)], {
+    anchorX: "right",
+    anchorY: "middle",
+    fixed: true,
+    fontSize: FONT,
+    strokeColor: CFG.ADV.colors.text,
+    layer: 10
+  });
+  S.labelArea = S.board.create("text", [() => -out, () => -(out + gap), () => {
+    const t = areaLabelText(S.w * S.h);
+    return t === null ? "" : t;
+  }], {
+    anchorX: "left",
+    anchorY: "top",
+    fixed: true,
+    fontSize: FONT,
+    strokeColor: CFG.ADV.colors.text,
+    layer: 10
+  });
 
   // Drag
-  S.handle.on("drag",()=>{
+  S.handle.on("drag", () => {
     snapHandleToCells();
     updateCountsFromHandle();
     drawInnerGrid();
-    tryRegisterFound(S.w,S.h);
+    tryRegisterFound(S.w, S.h);
     updateLive();
     renderInBoardLists();
   });
-  S.handle.on("up",()=>{
+  S.handle.on("up", () => {
     snapHandleToCells();
     updateCountsFromHandle();
     drawInnerGrid();
-    tryRegisterFound(S.w,S.h);
+    tryRegisterFound(S.w, S.h);
     updateLive();
     renderInBoardLists();
   });
 }
-
-function createBoard(){
-  if(S.ch.enabled && S.ch.N) S.ch.allPairs=factorPairsSorted(S.ch.N);
-
+function createBoard() {
+  if (S.ch.enabled && S.ch.N) S.ch.allPairs = factorPairsSorted(S.ch.N);
   S.board = JXG.JSXGraph.initBoard(CFG.ADV.containerId, {
-    boundingbox:[0,1,1,0],
+    boundingbox: [0, 1, 1, 0],
     renderer: "svg",
-    keepaspectratio:!!CFG.ADV.keepAspect1to1,
-    axis:false, showNavigation:false,
-    showCopyright:false,
-    pan:{enabled:false}, zoom:{enabled:false}
+    keepaspectratio: !!CFG.ADV.keepAspect1to1,
+    axis: false,
+    showNavigation: false,
+    showCopyright: false,
+    pan: {
+      enabled: false
+    },
+    zoom: {
+      enabled: false
+    }
   });
-
   drawAll();
   ensureA11yControls();
   renderInBoardLists();
-
-  if(CFG.ADV.responsive){
-    window.addEventListener("resize", debounced(()=>{
+  if (CFG.ADV.responsive) {
+    window.addEventListener("resize", debounced(() => {
       renderInBoardLists();
       drawInnerGrid();
       S.board.update();
     }, 100));
   }
-
-  const btnReset=document.getElementById("btnReset");
-  if(btnReset) btnReset.onclick=doReset;
-  const btnSvg=document.getElementById("btnSvg");
-  if(btnSvg) btnSvg.onclick=downloadSvg;
-  const btnPng=document.getElementById("btnPng");
-  if(btnPng) btnPng.onclick=downloadPng;
-  const btnSvgInt=document.getElementById("btnSvgInteractive");
-  if(btnSvgInt) btnSvgInt.onclick=downloadInteractiveSVG;
-  const btnHtml=document.getElementById("btnHtml");
-  if(btnHtml) btnHtml.onclick=downloadInteractiveHTML;
-
-  if(CFG.ADV.keyboardShortcuts){
-    window.addEventListener("keydown",(e)=>{
-      if(e.key.toLowerCase()==="r") doReset();
-      if(e.key.toLowerCase()==="s") downloadSvg();
+  const btnReset = document.getElementById("btnReset");
+  if (btnReset) btnReset.onclick = doReset;
+  const btnSvg = document.getElementById("btnSvg");
+  if (btnSvg) btnSvg.onclick = downloadSvg;
+  const btnPng = document.getElementById("btnPng");
+  if (btnPng) btnPng.onclick = downloadPng;
+  const btnSvgInt = document.getElementById("btnSvgInteractive");
+  if (btnSvgInt) btnSvgInt.onclick = downloadInteractiveSVG;
+  const btnHtml = document.getElementById("btnHtml");
+  if (btnHtml) btnHtml.onclick = downloadInteractiveHTML;
+  if (CFG.ADV.keyboardShortcuts) {
+    window.addEventListener("keydown", e => {
+      if (e.key.toLowerCase() === "r") doReset();
+      if (e.key.toLowerCase() === "s") downloadSvg();
     });
   }
 }
 
 /* ============================== Verdier/snap ============================== */
-function snapHandleToCells(){
-  const step=Math.max(1,CFG.SIMPLE.snap);
-  const x=clamp(quantize(S.handle.X(),step),1,S.maxW);
-  const y=clamp(quantize(S.handle.Y(),step),1,S.maxH);
-  S.handle.moveTo([x,y]);
+function snapHandleToCells() {
+  const step = Math.max(1, CFG.SIMPLE.snap);
+  const x = clamp(quantize(S.handle.X(), step), 1, S.maxW);
+  const y = clamp(quantize(S.handle.Y(), step), 1, S.maxH);
+  S.handle.moveTo([x, y]);
 }
-function updateCountsFromHandle(){
-  S.w=Math.round(S.handle.X());
-  S.h=Math.round(S.handle.Y());
+function updateCountsFromHandle() {
+  S.w = Math.round(S.handle.X());
+  S.h = Math.round(S.handle.Y());
   syncSimpleConfigFromState();
 }
 
 /* ============================== Bounding – alltid plass til alt ============================== */
-function adaptView(){
+function adaptView() {
+  var _S$board$renderer$can, _S$board$renderer$can2;
   const M = CFG.ADV.margin;
-  const out=CFG.ADV.labelOutside, gap=CFG.ADV.labelRowGap;
+  const out = CFG.ADV.labelOutside,
+    gap = CFG.ADV.labelRowGap;
   const bbWanted = [-M.left, S.maxH + M.top, S.maxW + M.right, -M.bottomBase];
   S.board.setBoundingBox(bbWanted, true);
-
-  const needL=CFG.ADV.minPadPx.left, needB=CFG.ADV.minPadPx.bottom;
-  const Wpx=S.board.canvasWidth||S.board.renderer.canvasRoot?.clientWidth||0;
-  const Hpx=S.board.canvasHeight||S.board.renderer.canvasRoot?.clientHeight||0;
-  if(Wpx>0 && Hpx>0){
-    let [x1,y2,x2,y1]=S.board.getBoundingBox();
-    const pxPerX=Wpx/(x2-x1);
-    const pxPerY=Hpx/(y2-y1);
-    const leftGapPx=(-out - x1)*pxPerX;
-    if(leftGapPx<needL){ x1 -= (needL-leftGapPx)/pxPerX; }
-    const yTextTop=-(out+gap);
-    const bottomGapPx=(yTextTop - y1)*pxPerY;
-    if(bottomGapPx<needB){ y1 -= (needB-bottomGapPx)/pxPerY; }
-    S.board.setBoundingBox([x1,y2,x2,y1], true);
+  const needL = CFG.ADV.minPadPx.left,
+    needB = CFG.ADV.minPadPx.bottom;
+  const Wpx = S.board.canvasWidth || ((_S$board$renderer$can = S.board.renderer.canvasRoot) === null || _S$board$renderer$can === void 0 ? void 0 : _S$board$renderer$can.clientWidth) || 0;
+  const Hpx = S.board.canvasHeight || ((_S$board$renderer$can2 = S.board.renderer.canvasRoot) === null || _S$board$renderer$can2 === void 0 ? void 0 : _S$board$renderer$can2.clientHeight) || 0;
+  if (Wpx > 0 && Hpx > 0) {
+    let [x1, y2, x2, y1] = S.board.getBoundingBox();
+    const pxPerX = Wpx / (x2 - x1);
+    const pxPerY = Hpx / (y2 - y1);
+    const leftGapPx = (-out - x1) * pxPerX;
+    if (leftGapPx < needL) {
+      x1 -= (needL - leftGapPx) / pxPerX;
+    }
+    const yTextTop = -(out + gap);
+    const bottomGapPx = (yTextTop - y1) * pxPerY;
+    if (bottomGapPx < needB) {
+      y1 -= (needB - bottomGapPx) / pxPerY;
+    }
+    S.board.setBoundingBox([x1, y2, x2, y1], true);
   }
   S.board.update();
 }
 
 /* ============================== Oppgave/logikk ============================== */
-function tryRegisterFound(a,b){
-  if(!S.ch.enabled || !S.ch.N) return;
-  if(a*b!==S.ch.N) return;
+function tryRegisterFound(a, b) {
+  if (!S.ch.enabled || !S.ch.N) return;
+  if (a * b !== S.ch.N) return;
   S.ch.oriented.add(`${a}×${b}`);
 }
 
 /* ============================== Reset & Eksport ============================== */
-function doReset(){
-  S.w=S.w0; S.h=S.h0;
-  if(S.handle) S.handle.moveTo([S.w,S.h]);
+function doReset() {
+  S.w = S.w0;
+  S.h = S.h0;
+  if (S.handle) S.handle.moveTo([S.w, S.h]);
   S.ch.oriented.clear();
   drawInnerGrid();
   updateLive();
   renderInBoardLists();
   syncSimpleConfigFromState();
 }
-
-function serializeSvgFromBoard(board){
-  if (board?.renderer && typeof board.renderer.dumpToSVG === "function") {
+function serializeSvgFromBoard(board) {
+  var _board$renderer;
+  if (board !== null && board !== void 0 && board.renderer && typeof board.renderer.dumpToSVG === "function") {
     return board.renderer.dumpToSVG();
   }
-  const root = board?.renderer?.svgRoot || document.querySelector(`#${board?.container} svg`);
+  const root = (board === null || board === void 0 || (_board$renderer = board.renderer) === null || _board$renderer === void 0 ? void 0 : _board$renderer.svgRoot) || document.querySelector(`#${board === null || board === void 0 ? void 0 : board.container} svg`);
   if (root) {
     let xml = new XMLSerializer().serializeToString(root);
     if (!xml.startsWith("<?xml")) xml = '<?xml version="1.0" encoding="UTF-8"?>\n' + xml;
@@ -489,177 +622,185 @@ function serializeSvgFromBoard(board){
   }
   throw new Error("SVG-renderer ikke tilgjengelig.");
 }
-function downloadSvg(){
+function downloadSvg() {
   try {
     const svgText = serializeSvgFromBoard(S.board);
-    const blob=new Blob([svgText],{type:"image/svg+xml;charset=utf-8"});
+    const blob = new Blob([svgText], {
+      type: "image/svg+xml;charset=utf-8"
+    });
     const url = URL.createObjectURL(blob);
-    const a=document.createElement("a");
+    const a = document.createElement("a");
     if ("download" in HTMLAnchorElement.prototype) {
-      a.href=url; a.download=CFG.ADV.fileName;
-      document.body.appendChild(a); a.click(); a.remove();
-      setTimeout(()=>URL.revokeObjectURL(url),0);
+      a.href = url;
+      a.download = CFG.ADV.fileName;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
     } else {
       window.open(url, "_blank");
-      setTimeout(()=>URL.revokeObjectURL(url),4000);
+      setTimeout(() => URL.revokeObjectURL(url), 4000);
     }
   } catch (e) {
     console.error(e);
     alert("Kunne ikke eksportere SVG: " + e.message);
   }
 }
-
-function downloadPng(){
+function downloadPng() {
   try {
     const svgText = serializeSvgFromBoard(S.board);
-    const blob=new Blob([svgText],{type:"image/svg+xml;charset=utf-8"});
+    const blob = new Blob([svgText], {
+      type: "image/svg+xml;charset=utf-8"
+    });
     const url = URL.createObjectURL(blob);
     const img = new Image();
     img.onload = () => {
-      const w = img.width, h = img.height;
+      const w = img.width,
+        h = img.height;
       const canvas = document.createElement('canvas');
-      canvas.width = w; canvas.height = h;
+      canvas.width = w;
+      canvas.height = h;
       const ctx = canvas.getContext('2d');
       ctx.fillStyle = '#fff';
-      ctx.fillRect(0,0,w,h);
-      ctx.drawImage(img,0,0,w,h);
+      ctx.fillRect(0, 0, w, h);
+      ctx.drawImage(img, 0, 0, w, h);
       URL.revokeObjectURL(url);
       canvas.toBlob(b => {
         const urlPng = URL.createObjectURL(b);
-        const a=document.createElement('a');
+        const a = document.createElement('a');
         if ("download" in HTMLAnchorElement.prototype) {
-          a.href=urlPng; a.download=CFG.ADV.fileName.replace(/\.svg$/i,'.png');
-          document.body.appendChild(a); a.click(); a.remove();
-          setTimeout(()=>URL.revokeObjectURL(urlPng),0);
+          a.href = urlPng;
+          a.download = CFG.ADV.fileName.replace(/\.svg$/i, '.png');
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          setTimeout(() => URL.revokeObjectURL(urlPng), 0);
         } else {
           window.open(urlPng, "_blank");
-          setTimeout(()=>URL.revokeObjectURL(urlPng),4000);
+          setTimeout(() => URL.revokeObjectURL(urlPng), 4000);
         }
       }, 'image/png');
     };
     img.src = url;
-  } catch(e) {
+  } catch (e) {
     console.error(e);
     alert("Kunne ikke eksportere PNG: " + e.message);
   }
 }
 
 /* ===== Interaktiv SVG – robust: ingen <link>, venter på JXG før start ===== */
-function buildInnerJS(E){
+function buildInnerJS(E) {
   // *** LISTE-FIKS INNARBEIDET HER ***
-  return [
-'!function(){',
-'var E='+JSON.stringify(E)+';',
-'function clamp(v,lo,hi){return Math.max(lo,Math.min(hi,v));}',
-'function quantize(v,s){return s<=0?v:Math.round(v/s)*s;}',
-'function areaLabelText(mode,n){if(mode==null)return "Areal: "+n;var s=String(mode).toLowerCase();if(s==="none"||s==="off"||s==="hide")return "";if(s==="areal")return "Areal: "+n;if(s==="ruter"||s==="tiles"||s==="antall")return "Ruter: "+n;return String(mode).indexOf("${N}")>-1?String(mode).replace("${N}",String(n)):String(mode);}',
-'var S={w:E.startW,h:E.startH,board:null,handle:null,grid:[],colA:[],colB:[]};',
-'function clearGrid(){for(var i=0;i<S.grid.length;i++){S.board.removeObject(S.grid[i]);}S.grid.length=0;}',
-'function drawGrid(){clearGrid();if(!E.showGrid)return;for(var j=1;j<S.h;j++){S.grid.push(S.board.create("segment",[[0,j],[S.w,j]],{strokeColor:E.colors.grid,strokeWidth:E.grid.width,dash:E.grid.dash,layer:9,fixed:true,highlight:false}));}for(var i=1;i<S.w;i++){S.grid.push(S.board.create("segment",[[i,0],[i,S.h]],{strokeColor:E.colors.grid,strokeWidth:E.grid.width,dash:E.grid.dash,layer:9,fixed:true,highlight:false}));}}',
-'function ensureLine(arr,i,xFn,yFn,ax){if(!arr[i])arr[i]=S.board.create("text",[xFn,yFn,function(){return "";}],{anchorX:ax,anchorY:"top",fixed:true,fontSize:E.fontSize,strokeColor:E.colors.text,highlight:false});return arr[i];}',
-'function clearExtra(arr,k){for(var i=k;i<arr.length;i++){arr[i].setText(function(){return "";});}}',
-'function adaptView(rows){var M=E.margin,out=E.labelOutside,gap=E.labelRowGap,LI=E.listsInside;var yTop=-(out+gap);var yLow=rows>0?(yTop-(rows-1)*LI.listLineGap):yTop;var y1=yLow-LI.bottomPad;S.board.setBoundingBox([-M.left,E.maxH+M.top,E.maxW+M.right,y1],true);var needL=E.minPadPx.left||20,needB=E.minPadPx.bottom||40;var W=S.board.canvasWidth||S.board.renderer.canvasRoot.clientWidth||0;var H=S.board.canvasHeight||S.board.renderer.canvasRoot.clientHeight||0;if(W>0&&H>0){var bb=S.board.getBoundingBox(),x1=bb[0],y2=bb[1],x2=bb[2],yb=bb[3];var pxX=W/(x2-x1),pxY=H/(y2-yb);var leftPx=(-out - x1)*pxX;if(leftPx<needL){x1-=(needL-leftPx)/pxX;}var rowsDepth=rows>0?(rows-1)*LI.listLineGap:0;var yLow2=yTop-rowsDepth;var bottomPx=(yLow2-yb)*pxY;if(bottomPx<needB){yb-=(needB-bottomPx)/pxY;}S.board.setBoundingBox([x1,y2,x2,yb],true);}S.board.update();}',
-'function renderLists(){if(!E.challenge.enabled)return;var out=E.labelOutside,gap=E.labelRowGap,LI=E.listsInside;var y0=function(){return -(out+gap);},xR=function(){return E.maxW-LI.insetX;},xL=function(){return E.maxW-LI.insetX-LI.colGap;};var A=[],B=[];for(var t=0;t<E.challenge.allPairs.length;t++){var a=E.challenge.allPairs[t][0],b=E.challenge.allPairs[t][1];if(window._oriented&&window._oriented.has(a+"x"+b))A.push(a+" · "+b+" = "+E.challenge.N);if(a!==b&&window._oriented&&window._oriented.has(b+"x"+a))B.push(b+" · "+a+" = "+E.challenge.N);}for(var i=0;i<A.length;i++){(function(k){var yF=function(){return y0()-k*LI.listLineGap;};ensureLine(S.colA,k,xL,yF,"right").setText(function(){return A[k];});})(i);}clearExtra(S.colA,A.length);for(i=0;i<B.length;i++){(function(k){var yF=function(){return y0()-k*LI.listLineGap;};ensureLine(S.colB,k,xR,yF,"right").setText(function(){return B[k];});})(i);}clearExtra(S.colB,B.length);adaptView(Math.max(A.length,B.length));}',
-'// === SPOR FUNN I INNEBYGD MOTOR ===',
-'window._oriented=new Set();',
-'function registerIfMatch(){var W=Math.round(H.X()),Hh=Math.round(H.Y());if(E.challenge&&E.challenge.enabled&&E.challenge.N&&W*Hh===E.challenge.N){window._oriented.add(W+"x"+Hh);}}',
-'// === Board ===',
-'S.board=JXG.JSXGraph.initBoard("jxgbox",{boundingbox:[0,1,1,0],renderer:"svg",keepaspectratio:true,axis:false,showNavigation:false,showCopyright:false,pan:{enabled:false},zoom:{enabled:false}});',
-'var A=S.board.create("point",[0,0],{visible:false,fixed:true});',
-'var H=S.board.create("point",[E.startW,E.startH],{withLabel:false,showInfobox:false,face:"circle",size:E.handleRadius,strokeColor:E.colors.handleEdge,fillColor:E.colors.handleFill});',
-'var B=S.board.create("point",[function(){return H.X();},0],{visible:false,fixed:true});',
-'var C=S.board.create("point",[function(){return H.X();},function(){return H.Y();}],{visible:false,fixed:true});',
-'var D=S.board.create("point",[0,function(){return H.Y();}],{visible:false,fixed:true});',
-'var poly=S.board.create("polygon",[A,B,C,D],{withLines:true,fillColor:E.colors.fill,fillOpacity:E.opacity,borders:{strokeColor:E.colors.edge,strokeWidth:E.stroke,highlight:false,fixed:true},fixed:true,highlight:false,layer:7});',
-'poly.borders.forEach(function(b){b.setAttribute({highlight:false,fixed:true,layer:8});});',
-'var out=E.labelOutside,gap=E.labelRowGap;',
-'S.board.create("text",[function(){return H.X()/2;},function(){return -out;},function(){return String(Math.round(H.X()));}],{anchorX:"middle",anchorY:"top",fixed:true,fontSize:E.fontSize,strokeColor:E.colors.text});',
-'S.board.create("text",[function(){return -out;},function(){return H.Y()/2;},function(){return String(Math.round(H.Y()));}],{anchorX:"right",anchorY:"middle",fixed:true,fontSize:E.fontSize,strokeColor:E.colors.text});',
-'S.board.create("text",[function(){return -out;},function(){return -(out+gap);},function(){return areaLabelText(E.areaLabelMode,Math.round(H.X())*Math.round(H.Y()));}],{anchorX:"left",anchorY:"top",fixed:true,fontSize:E.fontSize,strokeColor:E.colors.text});',
-'function sync(){S.w=Math.round(H.X());S.h=Math.round(H.Y());drawGrid();registerIfMatch();renderLists();}',
-'H.on("drag",function(){var x=Math.max(1,Math.min(E.maxW,quantize(H.X(),E.snap)));var y=Math.max(1,Math.min(E.maxH,quantize(H.Y(),E.snap)));H.moveTo([x,y]);S.w=Math.round(x);S.h=Math.round(y);sync();});',
-'H.on("up",function(){H.fire("drag");});',
-'sync();',
-'}();'
-  ].join("\n");
+  return ['!function(){', 'var E=' + JSON.stringify(E) + ';', 'function clamp(v,lo,hi){return Math.max(lo,Math.min(hi,v));}', 'function quantize(v,s){return s<=0?v:Math.round(v/s)*s;}', 'function areaLabelText(mode,n){if(mode==null)return "Areal: "+n;var s=String(mode).toLowerCase();if(s==="none"||s==="off"||s==="hide")return "";if(s==="areal")return "Areal: "+n;if(s==="ruter"||s==="tiles"||s==="antall")return "Ruter: "+n;return String(mode).indexOf("${N}")>-1?String(mode).replace("${N}",String(n)):String(mode);}', 'var S={w:E.startW,h:E.startH,board:null,handle:null,grid:[],colA:[],colB:[]};', 'function clearGrid(){for(var i=0;i<S.grid.length;i++){S.board.removeObject(S.grid[i]);}S.grid.length=0;}', 'function drawGrid(){clearGrid();if(!E.showGrid)return;for(var j=1;j<S.h;j++){S.grid.push(S.board.create("segment",[[0,j],[S.w,j]],{strokeColor:E.colors.grid,strokeWidth:E.grid.width,dash:E.grid.dash,layer:9,fixed:true,highlight:false}));}for(var i=1;i<S.w;i++){S.grid.push(S.board.create("segment",[[i,0],[i,S.h]],{strokeColor:E.colors.grid,strokeWidth:E.grid.width,dash:E.grid.dash,layer:9,fixed:true,highlight:false}));}}', 'function ensureLine(arr,i,xFn,yFn,ax){if(!arr[i])arr[i]=S.board.create("text",[xFn,yFn,function(){return "";}],{anchorX:ax,anchorY:"top",fixed:true,fontSize:E.fontSize,strokeColor:E.colors.text,highlight:false});return arr[i];}', 'function clearExtra(arr,k){for(var i=k;i<arr.length;i++){arr[i].setText(function(){return "";});}}', 'function adaptView(rows){var M=E.margin,out=E.labelOutside,gap=E.labelRowGap,LI=E.listsInside;var yTop=-(out+gap);var yLow=rows>0?(yTop-(rows-1)*LI.listLineGap):yTop;var y1=yLow-LI.bottomPad;S.board.setBoundingBox([-M.left,E.maxH+M.top,E.maxW+M.right,y1],true);var needL=E.minPadPx.left||20,needB=E.minPadPx.bottom||40;var W=S.board.canvasWidth||S.board.renderer.canvasRoot.clientWidth||0;var H=S.board.canvasHeight||S.board.renderer.canvasRoot.clientHeight||0;if(W>0&&H>0){var bb=S.board.getBoundingBox(),x1=bb[0],y2=bb[1],x2=bb[2],yb=bb[3];var pxX=W/(x2-x1),pxY=H/(y2-yb);var leftPx=(-out - x1)*pxX;if(leftPx<needL){x1-=(needL-leftPx)/pxX;}var rowsDepth=rows>0?(rows-1)*LI.listLineGap:0;var yLow2=yTop-rowsDepth;var bottomPx=(yLow2-yb)*pxY;if(bottomPx<needB){yb-=(needB-bottomPx)/pxY;}S.board.setBoundingBox([x1,y2,x2,yb],true);}S.board.update();}', 'function renderLists(){if(!E.challenge.enabled)return;var out=E.labelOutside,gap=E.labelRowGap,LI=E.listsInside;var y0=function(){return -(out+gap);},xR=function(){return E.maxW-LI.insetX;},xL=function(){return E.maxW-LI.insetX-LI.colGap;};var A=[],B=[];for(var t=0;t<E.challenge.allPairs.length;t++){var a=E.challenge.allPairs[t][0],b=E.challenge.allPairs[t][1];if(window._oriented&&window._oriented.has(a+"x"+b))A.push(a+" · "+b+" = "+E.challenge.N);if(a!==b&&window._oriented&&window._oriented.has(b+"x"+a))B.push(b+" · "+a+" = "+E.challenge.N);}for(var i=0;i<A.length;i++){(function(k){var yF=function(){return y0()-k*LI.listLineGap;};ensureLine(S.colA,k,xL,yF,"right").setText(function(){return A[k];});})(i);}clearExtra(S.colA,A.length);for(i=0;i<B.length;i++){(function(k){var yF=function(){return y0()-k*LI.listLineGap;};ensureLine(S.colB,k,xR,yF,"right").setText(function(){return B[k];});})(i);}clearExtra(S.colB,B.length);adaptView(Math.max(A.length,B.length));}', '// === SPOR FUNN I INNEBYGD MOTOR ===', 'window._oriented=new Set();', 'function registerIfMatch(){var W=Math.round(H.X()),Hh=Math.round(H.Y());if(E.challenge&&E.challenge.enabled&&E.challenge.N&&W*Hh===E.challenge.N){window._oriented.add(W+"x"+Hh);}}', '// === Board ===', 'S.board=JXG.JSXGraph.initBoard("jxgbox",{boundingbox:[0,1,1,0],renderer:"svg",keepaspectratio:true,axis:false,showNavigation:false,showCopyright:false,pan:{enabled:false},zoom:{enabled:false}});', 'var A=S.board.create("point",[0,0],{visible:false,fixed:true});', 'var H=S.board.create("point",[E.startW,E.startH],{withLabel:false,showInfobox:false,face:"circle",size:E.handleRadius,strokeColor:E.colors.handleEdge,fillColor:E.colors.handleFill});', 'var B=S.board.create("point",[function(){return H.X();},0],{visible:false,fixed:true});', 'var C=S.board.create("point",[function(){return H.X();},function(){return H.Y();}],{visible:false,fixed:true});', 'var D=S.board.create("point",[0,function(){return H.Y();}],{visible:false,fixed:true});', 'var poly=S.board.create("polygon",[A,B,C,D],{withLines:true,fillColor:E.colors.fill,fillOpacity:E.opacity,borders:{strokeColor:E.colors.edge,strokeWidth:E.stroke,highlight:false,fixed:true},fixed:true,highlight:false,layer:7});', 'poly.borders.forEach(function(b){b.setAttribute({highlight:false,fixed:true,layer:8});});', 'var out=E.labelOutside,gap=E.labelRowGap;', 'S.board.create("text",[function(){return H.X()/2;},function(){return -out;},function(){return String(Math.round(H.X()));}],{anchorX:"middle",anchorY:"top",fixed:true,fontSize:E.fontSize,strokeColor:E.colors.text});', 'S.board.create("text",[function(){return -out;},function(){return H.Y()/2;},function(){return String(Math.round(H.Y()));}],{anchorX:"right",anchorY:"middle",fixed:true,fontSize:E.fontSize,strokeColor:E.colors.text});', 'S.board.create("text",[function(){return -out;},function(){return -(out+gap);},function(){return areaLabelText(E.areaLabelMode,Math.round(H.X())*Math.round(H.Y()));}],{anchorX:"left",anchorY:"top",fixed:true,fontSize:E.fontSize,strokeColor:E.colors.text});', 'function sync(){S.w=Math.round(H.X());S.h=Math.round(H.Y());drawGrid();registerIfMatch();renderLists();}', 'H.on("drag",function(){var x=Math.max(1,Math.min(E.maxW,quantize(H.X(),E.snap)));var y=Math.max(1,Math.min(E.maxH,quantize(H.Y(),E.snap)));H.moveTo([x,y]);S.w=Math.round(x);S.h=Math.round(y);sync();});', 'H.on("up",function(){H.fire("drag");});', 'sync();', '}();'].join("\n");
 }
 
 /* === Interaktiv SVG (ingen <link>, poller JXG før start; unngår XML-feil) === */
-function downloadInteractiveSVG(){
-  const isMobile=/iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-  const E={
-    maxW:S.maxW,maxH:S.maxH,startW:Math.max(1,S.w||1),startH:Math.max(1,S.h||1),
-    snap:Math.max(1,CFG.SIMPLE.snap),
-    showGrid:CFG.SIMPLE.showGrid,
-    colors:CFG.ADV.colors,opacity:CFG.ADV.opacity,stroke:CFG.ADV.stroke,
-    grid:CFG.ADV.grid,margin:CFG.ADV.margin,labelOutside:CFG.ADV.labelOutside,
-    labelRowGap:CFG.ADV.labelRowGap,listsInside:CFG.ADV.listsInside,
-    fontSize:isMobile?Math.round(CFG.ADV.fontSize*1.15):CFG.ADV.fontSize,
-    handleRadius:isMobile?Math.round(CFG.ADV.handleRadius*1.3):CFG.ADV.handleRadius,
-    areaLabelMode:CFG.SIMPLE.areaLabel,
+function downloadInteractiveSVG() {
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+  const E = {
+    maxW: S.maxW,
+    maxH: S.maxH,
+    startW: Math.max(1, S.w || 1),
+    startH: Math.max(1, S.h || 1),
+    snap: Math.max(1, CFG.SIMPLE.snap),
+    showGrid: CFG.SIMPLE.showGrid,
+    colors: CFG.ADV.colors,
+    opacity: CFG.ADV.opacity,
+    stroke: CFG.ADV.stroke,
+    grid: CFG.ADV.grid,
+    margin: CFG.ADV.margin,
+    labelOutside: CFG.ADV.labelOutside,
+    labelRowGap: CFG.ADV.labelRowGap,
+    listsInside: CFG.ADV.listsInside,
+    fontSize: isMobile ? Math.round(CFG.ADV.fontSize * 1.15) : CFG.ADV.fontSize,
+    handleRadius: isMobile ? Math.round(CFG.ADV.handleRadius * 1.3) : CFG.ADV.handleRadius,
+    areaLabelMode: CFG.SIMPLE.areaLabel,
     minPadPx: CFG.ADV.minPadPx,
-    challenge:{enabled:S.ch.enabled,N:S.ch.N,dedupeOrderless:S.ch.dedupeOrderless,allPairs:S.ch.allPairs}
+    challenge: {
+      enabled: S.ch.enabled,
+      N: S.ch.N,
+      dedupeOrderless: S.ch.dedupeOrderless,
+      allPairs: S.ch.allPairs
+    }
   };
-
   const innerJS = buildInnerJS(E);
   const b64 = btoa(innerJS);
-
-  const parts=[];
+  const parts = [];
   parts.push('<?xml version="1.0" encoding="UTF-8"?>');
   parts.push('<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="750" viewBox="0 0 1100 750">');
   parts.push('<foreignObject x="0" y="0" width="100%" height="100%">');
   parts.push('<div xmlns="http://www.w3.org/1999/xhtml" style="width:100%;height:100%;position:relative">');
   parts.push('<div id="jxgbox" class="jxgbox" style="width:100%;height:100%"></div>');
-  parts.push('<'+'script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js">'+'</'+'script>');
+  parts.push('<' + 'script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js">' + '</' + 'script>');
   // vent til JXG finnes, deretter eval innerJS (base64) – kun trygge ASCII-tegn i elementet
-  parts.push('<'+'script>(function(){var s="'+b64+'";(function start(){if(window.JXG&&document.getElementById("jxgbox")){eval(atob(s));}else{setTimeout(start,50);}})();})();</'+'script>');
+  parts.push('<' + 'script>(function(){var s="' + b64 + '";(function start(){if(window.JXG&&document.getElementById("jxgbox")){eval(atob(s));}else{setTimeout(start,50);}})();})();</' + 'script>');
   parts.push('</div></foreignObject></svg>');
-
   const svg = parts.join('');
-  const blob=new Blob([svg],{type:"image/svg+xml;charset=utf-8"});
-  const url=URL.createObjectURL(blob);
-  const a=document.createElement("a");
-  a.href=url; a.download="arealmodell_interaktiv.svg";
-  document.body.appendChild(a); a.click(); a.remove();
-  setTimeout(()=>URL.revokeObjectURL(url),0);
+  const blob = new Blob([svg], {
+    type: "image/svg+xml;charset=utf-8"
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "arealmodell_interaktiv.svg";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 /* ===== Single-file HTML – samme motor som over ===== */
-function downloadInteractiveHTML(){
-  const isMobile=/iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-  const E={
-    maxW:S.maxW,maxH:S.maxH,startW:S.w,startH:S.h,
-    snap:Math.max(1,CFG.SIMPLE.snap),
-    showGrid:CFG.SIMPLE.showGrid,
-    colors:CFG.ADV.colors,opacity:CFG.ADV.opacity,stroke:CFG.ADV.stroke,
-    grid:CFG.ADV.grid,margin:CFG.ADV.margin,labelOutside:CFG.ADV.labelOutside,
-    labelRowGap:CFG.ADV.labelRowGap,listsInside:CFG.ADV.listsInside,
-    fontSize:isMobile?Math.round(CFG.ADV.fontSize*1.15):CFG.ADV.fontSize,
-    handleRadius:isMobile?Math.round(CFG.ADV.handleRadius*1.3):CFG.ADV.handleRadius,
-    areaLabelMode:CFG.SIMPLE.areaLabel,
+function downloadInteractiveHTML() {
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+  const E = {
+    maxW: S.maxW,
+    maxH: S.maxH,
+    startW: S.w,
+    startH: S.h,
+    snap: Math.max(1, CFG.SIMPLE.snap),
+    showGrid: CFG.SIMPLE.showGrid,
+    colors: CFG.ADV.colors,
+    opacity: CFG.ADV.opacity,
+    stroke: CFG.ADV.stroke,
+    grid: CFG.ADV.grid,
+    margin: CFG.ADV.margin,
+    labelOutside: CFG.ADV.labelOutside,
+    labelRowGap: CFG.ADV.labelRowGap,
+    listsInside: CFG.ADV.listsInside,
+    fontSize: isMobile ? Math.round(CFG.ADV.fontSize * 1.15) : CFG.ADV.fontSize,
+    handleRadius: isMobile ? Math.round(CFG.ADV.handleRadius * 1.3) : CFG.ADV.handleRadius,
+    areaLabelMode: CFG.SIMPLE.areaLabel,
     minPadPx: CFG.ADV.minPadPx,
-    challenge:{enabled:S.ch.enabled,N:S.ch.N,dedupeOrderless:S.ch.dedupeOrderless,allPairs:S.ch.allPairs}
+    challenge: {
+      enabled: S.ch.enabled,
+      N: S.ch.N,
+      dedupeOrderless: S.ch.dedupeOrderless,
+      allPairs: S.ch.allPairs
+    }
   };
   const innerJS = buildInnerJS(E);
   const b64 = btoa(innerJS);
-
-  const html=[];
+  const html = [];
   html.push('<!doctype html><html><head><meta charset="utf-8">');
   html.push('<meta name="viewport" content="width=device-width,initial-scale=1">');
   html.push('<title>Arealmodell interaktiv</title>');
   html.push('<style>html,body{height:100%;margin:0}#jxgbox{width:100%;height:100%}</style>');
   html.push('</head><body>');
   html.push('<div id="jxgbox" class="jxgbox"></div>');
-  html.push('<'+'script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js">'+'</'+'script>');
-  html.push('<'+'script>(function(){var s="'+b64+'";(function start(){if(window.JXG&&document.getElementById("jxgbox")){eval(atob(s));}else{setTimeout(start,50);}})();})();</'+'script>');
+  html.push('<' + 'script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js">' + '</' + 'script>');
+  html.push('<' + 'script>(function(){var s="' + b64 + '";(function start(){if(window.JXG&&document.getElementById("jxgbox")){eval(atob(s));}else{setTimeout(start,50);}})();})();</' + 'script>');
   html.push('</body></html>');
-
-  const blob=new Blob([html.join("")],{type:"text/html;charset=utf-8"});
-  const url=URL.createObjectURL(blob);
-  const a=document.createElement("a");
-  a.href=url; a.download="arealmodell_interaktiv.html";
-  document.body.appendChild(a); a.click(); a.remove();
-  setTimeout(()=>URL.revokeObjectURL(url),0);
+  const blob = new Blob([html.join("")], {
+    type: "text/html;charset=utf-8"
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "arealmodell_interaktiv.html";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 /* ============================== Init ============================== */
@@ -670,45 +811,43 @@ document.addEventListener("DOMContentLoaded", () => {
     el.addEventListener('input', initFromHtml);
   });
 });
-
-function applyConfigToInputs(){
+function applyConfigToInputs() {
   ensureSimpleDefaults();
-  const simple = CFG?.SIMPLE || {};
+  const simple = (CFG === null || CFG === void 0 ? void 0 : CFG.SIMPLE) || {};
   const len = simple.length || {};
   const hei = simple.height || {};
   const challenge = simple.challenge || {};
-  const setVal = (id, value)=>{
-    const el=document.getElementById(id);
-    if(el && value!=null && value!=="") el.value=String(value);
+  const setVal = (id, value) => {
+    const el = document.getElementById(id);
+    if (el && value != null && value !== "") el.value = String(value);
   };
-  const setChk = (id, value)=>{
-    const el=document.getElementById(id);
-    if(el) el.checked=!!value;
+  const setChk = (id, value) => {
+    const el = document.getElementById(id);
+    if (el) el.checked = !!value;
   };
-
   setVal("lenCells", len.cells);
   setVal("lenMax", len.max);
   setVal("heiCells", hei.cells);
   setVal("heiMax", hei.max);
   setChk("chkGrid", simple.showGrid !== false);
-  if(simple.snap != null) setVal("snap", simple.snap);
-  const areaInput=document.getElementById("areaLabel");
-  if(areaInput && simple.areaLabel != null) areaInput.value=String(simple.areaLabel);
+  if (simple.snap != null) setVal("snap", simple.snap);
+  const areaInput = document.getElementById("areaLabel");
+  if (areaInput && simple.areaLabel != null) areaInput.value = String(simple.areaLabel);
   setChk("chkChallenge", !!challenge.enabled);
-  if(challenge.area != null) setVal("challengeArea", challenge.area);
+  if (challenge.area != null) setVal("challengeArea", challenge.area);
 }
-
-function applyExamplesConfig(){
-  if(document.readyState === "loading"){
-    document.addEventListener("DOMContentLoaded", applyExamplesConfig, {once:true});
+function applyExamplesConfig() {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", applyExamplesConfig, {
+      once: true
+    });
     return;
   }
   ensureSimpleDefaults();
   applyConfigToInputs();
   rebuildFromConfig();
 }
-
-if(typeof window !== 'undefined'){
+if (typeof window !== 'undefined') {
   window.applyConfig = applyExamplesConfig;
   window.applyState = applyExamplesConfig;
   window.render = applyExamplesConfig;

--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -3,27 +3,46 @@
    ========================================================= */
 const CFG = {
   SIMPLE: {
-    height: { cells: 16, handle: 5, show: true, showHandle: true }, // rader, horisontal deling (fra bunn)
-    length: { cells: 17, handle: 3, show: true, showHandle: true }, // kolonner, vertikal deling (fra venstre)
+    height: {
+      cells: 16,
+      handle: 5,
+      show: true,
+      showHandle: true
+    },
+    // rader, horisontal deling (fra bunn)
+    length: {
+      cells: 17,
+      handle: 3,
+      show: true,
+      showHandle: true
+    } // kolonner, vertikal deling (fra venstre)
   },
   ADV: {
     svgId: "area",
     unit: 40,
-    margins: { l: 80, r: 40, t: 40, b: 120 },
-
+    margins: {
+      l: 80,
+      r: 40,
+      t: 40,
+      b: 120
+    },
     grid: false,
     splitLines: true,
     clickToMove: true,
-    drag: { vertical: true, horizontal: true },
-    limits: { minColsEachSide: 1, minRowsEachSide: 1 },
-
+    drag: {
+      vertical: true,
+      horizontal: true
+    },
+    limits: {
+      minColsEachSide: 1,
+      minRowsEachSide: 1
+    },
     // Håndtak (piler)
     handleIcons: {
-      vert:  "https://test.kikora.no/img/drive/figures/UIclientObjects/arrows/moveV.svg",
+      vert: "https://test.kikora.no/img/drive/figures/UIclientObjects/arrows/moveV.svg",
       horiz: "https://test.kikora.no/img/drive/figures/UIclientObjects/arrows/moveH.svg",
       size: 84
     },
-
     classes: {
       outer: "outer",
       grid: "grid",
@@ -31,31 +50,36 @@ const CFG = {
       handle: "handleImg",
       labelCell: "labelCell",
       labelEdge: "labelEdge",
-      cells: ["c1","c2","c3","c4"]
+      cells: ["c1", "c2", "c3", "c4"]
     },
-
     colors: ["#e07c7c", "#f0c667", "#7fb2d6", "#8bb889"],
-
     fit: {
       maxVh: 100,
       maxVw: 100,
-      safePad: { top: 8, right: 8, bottom: 64, left: 8 } // ekstra plass i vinduet
+      safePad: {
+        top: 8,
+        right: 8,
+        bottom: 64,
+        left: 8
+      } // ekstra plass i vinduet
     },
-
     labels: {
-      cellMode: "factors",   // "factors" | "area" | "both" | "none"
-      edgeMode: "counts",    // "counts" | "none"
-      edgeInside: false,     // utenfor rektangelet
+      cellMode: "factors",
+      // "factors" | "area" | "both" | "none"
+      edgeMode: "counts",
+      // "counts" | "none"
+      edgeInside: false,
+      // utenfor rektangelet
       dot: " · ",
       equals: " = "
     },
-
-    check: { ten: 10 },
-
+    check: {
+      ten: 10
+    },
     export: {
       filename: "arealmodell_interaktiv.svg",
       includeGrid: false,
-      includeHandlesIfHidden: true,
+      includeHandlesIfHidden: true
       // valgfri – brukes hvis satt:
       // filenameHtml: "arealmodell_interaktiv.html"
     }
@@ -63,140 +87,137 @@ const CFG = {
 };
 const DEFAULT_SIMPLE_CFG = JSON.parse(JSON.stringify(CFG.SIMPLE));
 const DEFAULT_ADV_CFG = JSON.parse(JSON.stringify(CFG.ADV));
-
-function ensureCfgDefaults(){
-  const fill = (target, defaults)=>{
-    if(!defaults || typeof defaults !== 'object') return;
+function ensureCfgDefaults() {
+  const fill = (target, defaults) => {
+    if (!defaults || typeof defaults !== 'object') return;
     Object.keys(defaults).forEach(key => {
       const defVal = defaults[key];
       const curVal = target[key];
-      if(defVal && typeof defVal === 'object' && !Array.isArray(defVal)){
-        if(!curVal || typeof curVal !== 'object'){
-          target[key] = Array.isArray(defVal) ? defVal.slice() : {...defVal};
+      if (defVal && typeof defVal === 'object' && !Array.isArray(defVal)) {
+        if (!curVal || typeof curVal !== 'object') {
+          target[key] = Array.isArray(defVal) ? defVal.slice() : {
+            ...defVal
+          };
         }
         fill(target[key], defVal);
-      }else if(!(key in target)){
+      } else if (!(key in target)) {
         target[key] = Array.isArray(defVal) ? defVal.slice() : defVal;
       }
     });
   };
-  if(!CFG.SIMPLE || typeof CFG.SIMPLE !== 'object') CFG.SIMPLE = {};
-  if(!CFG.ADV || typeof CFG.ADV !== 'object') CFG.ADV = {};
+  if (!CFG.SIMPLE || typeof CFG.SIMPLE !== 'object') CFG.SIMPLE = {};
+  if (!CFG.ADV || typeof CFG.ADV !== 'object') CFG.ADV = {};
   fill(CFG.SIMPLE, DEFAULT_SIMPLE_CFG);
   fill(CFG.ADV, DEFAULT_ADV_CFG);
 }
 /* ========================================================= */
 
-function readConfigFromHtml(){
+function readConfigFromHtml() {
+  var _document$getElementB, _document$getElementB2, _document$getElementB3, _document$getElementB4, _document$getElementB5, _document$getElementB6, _document$getElementB7, _document$getElementB8, _document$getElementB9, _document$getElementB0, _document$getElementB1, _document$getElementB10;
   ensureCfgDefaults();
-  const height = parseInt(document.getElementById("height")?.value,10);
-  if(Number.isFinite(height)) CFG.SIMPLE.height.cells = height;
-  const length = parseInt(document.getElementById("length")?.value,10);
-  if(Number.isFinite(length)) CFG.SIMPLE.length.cells = length;
-  const hStart = parseInt(document.getElementById("heightStart")?.value,10);
-  if(Number.isFinite(hStart)) CFG.SIMPLE.height.handle = hStart;
-  const lStart = parseInt(document.getElementById("lengthStart")?.value,10);
-  if(Number.isFinite(lStart)) CFG.SIMPLE.length.handle = lStart;
-  CFG.SIMPLE.height.showHandle = document.getElementById("showHeightHandle")?.checked ?? CFG.SIMPLE.height.showHandle;
-  CFG.SIMPLE.length.showHandle = document.getElementById("showLengthHandle")?.checked ?? CFG.SIMPLE.length.showHandle;
-  CFG.ADV.grid = document.getElementById("grid")?.checked ?? CFG.ADV.grid;
-  CFG.ADV.splitLines = document.getElementById("splitLines")?.checked ?? CFG.ADV.splitLines;
+  const height = parseInt((_document$getElementB = document.getElementById("height")) === null || _document$getElementB === void 0 ? void 0 : _document$getElementB.value, 10);
+  if (Number.isFinite(height)) CFG.SIMPLE.height.cells = height;
+  const length = parseInt((_document$getElementB2 = document.getElementById("length")) === null || _document$getElementB2 === void 0 ? void 0 : _document$getElementB2.value, 10);
+  if (Number.isFinite(length)) CFG.SIMPLE.length.cells = length;
+  const hStart = parseInt((_document$getElementB3 = document.getElementById("heightStart")) === null || _document$getElementB3 === void 0 ? void 0 : _document$getElementB3.value, 10);
+  if (Number.isFinite(hStart)) CFG.SIMPLE.height.handle = hStart;
+  const lStart = parseInt((_document$getElementB4 = document.getElementById("lengthStart")) === null || _document$getElementB4 === void 0 ? void 0 : _document$getElementB4.value, 10);
+  if (Number.isFinite(lStart)) CFG.SIMPLE.length.handle = lStart;
+  CFG.SIMPLE.height.showHandle = (_document$getElementB5 = (_document$getElementB6 = document.getElementById("showHeightHandle")) === null || _document$getElementB6 === void 0 ? void 0 : _document$getElementB6.checked) !== null && _document$getElementB5 !== void 0 ? _document$getElementB5 : CFG.SIMPLE.height.showHandle;
+  CFG.SIMPLE.length.showHandle = (_document$getElementB7 = (_document$getElementB8 = document.getElementById("showLengthHandle")) === null || _document$getElementB8 === void 0 ? void 0 : _document$getElementB8.checked) !== null && _document$getElementB7 !== void 0 ? _document$getElementB7 : CFG.SIMPLE.length.showHandle;
+  CFG.ADV.grid = (_document$getElementB9 = (_document$getElementB0 = document.getElementById("grid")) === null || _document$getElementB0 === void 0 ? void 0 : _document$getElementB0.checked) !== null && _document$getElementB9 !== void 0 ? _document$getElementB9 : CFG.ADV.grid;
+  CFG.ADV.splitLines = (_document$getElementB1 = (_document$getElementB10 = document.getElementById("splitLines")) === null || _document$getElementB10 === void 0 ? void 0 : _document$getElementB10.checked) !== null && _document$getElementB1 !== void 0 ? _document$getElementB1 : CFG.ADV.splitLines;
 }
-
-function draw(){
+function draw() {
+  var _SV$height$cells, _SV$height, _SV$length$cells, _SV$length, _ADV$check$ten, _ADV$check, _ADV$handleIcons$size, _ADV$handleIcons, _ADV$margins$l, _ADV$margins, _ADV$margins$r, _ADV$margins2, _ADV$margins$t, _ADV$margins3, _ADV$margins$b, _ADV$margins4, _ADV$classes$outer, _ADV$classes, _ADV$classes$grid, _ADV$classes2, _ADV$classes$split, _ADV$classes3, _ADV$classes$handle, _ADV$classes4, _ADV$classes$labelCel, _ADV$classes5, _ADV$classes$labelEdg, _ADV$classes6, _ADV$classes$cells, _ADV$classes7, _SV$height2, _SV$length2, _ADV$drag, _ADV$drag2, _ADV$limits$minColsEa, _ADV$limits, _ADV$limits$minRowsEa, _ADV$limits2, _SV$length$handle, _SV$length3, _SV$height$handle, _SV$height3, _SV$height4, _SV$length4, _ADV$handleIcons$hori, _ADV$handleIcons2, _ADV$handleIcons$vert, _ADV$handleIcons3, _ADV$fit$maxVh, _ADV$fit, _ADV$labels$dot, _ADV$labels, _ADV$labels$equals, _ADV$labels2, _ADV$labels$edgeMode, _ADV$labels3, _ADV$labels$cellMode, _ADV$labels4;
   ensureCfgDefaults();
-  const ADV = CFG.ADV, SV = CFG.SIMPLE;
-
+  const ADV = CFG.ADV,
+    SV = CFG.SIMPLE;
   const UNIT = +ADV.unit || 40;
-  const ROWS = Math.max(2, Math.round(SV.height?.cells ?? 16));
-  const COLS = Math.max(2, Math.round(SV.length?.cells ?? 17));
-  const TEN  = Math.max(1, Math.round(ADV.check?.ten ?? 10));
+  const ROWS = Math.max(2, Math.round((_SV$height$cells = (_SV$height = SV.height) === null || _SV$height === void 0 ? void 0 : _SV$height.cells) !== null && _SV$height$cells !== void 0 ? _SV$height$cells : 16));
+  const COLS = Math.max(2, Math.round((_SV$length$cells = (_SV$length = SV.length) === null || _SV$length === void 0 ? void 0 : _SV$length.cells) !== null && _SV$length$cells !== void 0 ? _SV$length$cells : 17));
+  const TEN = Math.max(1, Math.round((_ADV$check$ten = (_ADV$check = ADV.check) === null || _ADV$check === void 0 ? void 0 : _ADV$check.ten) !== null && _ADV$check$ten !== void 0 ? _ADV$check$ten : 10));
 
   // spacing for kant-tekst utenfor
-  const EDGE_GAP = { x: 14, y: 32 };
-
-  // pilstørrelse + auto-margin
-  const HANDLE_SIZE = Math.max(12, ADV.handleIcons?.size ?? 84);
-  const MLconf = ADV.margins?.l ?? 80;
-  const MR = ADV.margins?.r ?? 40;
-  const MT = ADV.margins?.t ?? 40;
-  const MBconf = ADV.margins?.b ?? 120;
-
-  const ML = Math.max(MLconf, HANDLE_SIZE / 2 + 18);
-  const MB = Math.max(MBconf, HANDLE_SIZE / 2 + EDGE_GAP.y + 18);
-
-  const W = COLS * UNIT, H = ROWS * UNIT;
-  const VBW = ML + W + MR, VBH = MT + H + MB;
-
-  const classes = {
-    outer: ADV.classes?.outer ?? "outer",
-    grid: ADV.classes?.grid ?? "grid",
-    split: ADV.classes?.split ?? "split",
-    handle: ADV.classes?.handle ?? "handleImg",
-    labelCell: ADV.classes?.labelCell ?? "labelCell",
-    labelEdge: ADV.classes?.labelEdge ?? "labelEdge",
-    cells: ADV.classes?.cells ?? ["c1","c2","c3","c4"]
+  const EDGE_GAP = {
+    x: 14,
+    y: 32
   };
 
-  const showGrid       = ADV.grid !== false;
-  const clickToMove    = ADV.clickToMove !== false;
-  const showHeightAxis = SV.height?.show !== false;
-  const showLengthAxis = SV.length?.show !== false;
-
-  const dragVertical   = showHeightAxis && (ADV.drag?.vertical   !== false);
-  const dragHorizontal = showLengthAxis && (ADV.drag?.horizontal !== false);
-
+  // pilstørrelse + auto-margin
+  const HANDLE_SIZE = Math.max(12, (_ADV$handleIcons$size = (_ADV$handleIcons = ADV.handleIcons) === null || _ADV$handleIcons === void 0 ? void 0 : _ADV$handleIcons.size) !== null && _ADV$handleIcons$size !== void 0 ? _ADV$handleIcons$size : 84);
+  const MLconf = (_ADV$margins$l = (_ADV$margins = ADV.margins) === null || _ADV$margins === void 0 ? void 0 : _ADV$margins.l) !== null && _ADV$margins$l !== void 0 ? _ADV$margins$l : 80;
+  const MR = (_ADV$margins$r = (_ADV$margins2 = ADV.margins) === null || _ADV$margins2 === void 0 ? void 0 : _ADV$margins2.r) !== null && _ADV$margins$r !== void 0 ? _ADV$margins$r : 40;
+  const MT = (_ADV$margins$t = (_ADV$margins3 = ADV.margins) === null || _ADV$margins3 === void 0 ? void 0 : _ADV$margins3.t) !== null && _ADV$margins$t !== void 0 ? _ADV$margins$t : 40;
+  const MBconf = (_ADV$margins$b = (_ADV$margins4 = ADV.margins) === null || _ADV$margins4 === void 0 ? void 0 : _ADV$margins4.b) !== null && _ADV$margins$b !== void 0 ? _ADV$margins$b : 120;
+  const ML = Math.max(MLconf, HANDLE_SIZE / 2 + 18);
+  const MB = Math.max(MBconf, HANDLE_SIZE / 2 + EDGE_GAP.y + 18);
+  const W = COLS * UNIT,
+    H = ROWS * UNIT;
+  const VBW = ML + W + MR,
+    VBH = MT + H + MB;
+  const classes = {
+    outer: (_ADV$classes$outer = (_ADV$classes = ADV.classes) === null || _ADV$classes === void 0 ? void 0 : _ADV$classes.outer) !== null && _ADV$classes$outer !== void 0 ? _ADV$classes$outer : "outer",
+    grid: (_ADV$classes$grid = (_ADV$classes2 = ADV.classes) === null || _ADV$classes2 === void 0 ? void 0 : _ADV$classes2.grid) !== null && _ADV$classes$grid !== void 0 ? _ADV$classes$grid : "grid",
+    split: (_ADV$classes$split = (_ADV$classes3 = ADV.classes) === null || _ADV$classes3 === void 0 ? void 0 : _ADV$classes3.split) !== null && _ADV$classes$split !== void 0 ? _ADV$classes$split : "split",
+    handle: (_ADV$classes$handle = (_ADV$classes4 = ADV.classes) === null || _ADV$classes4 === void 0 ? void 0 : _ADV$classes4.handle) !== null && _ADV$classes$handle !== void 0 ? _ADV$classes$handle : "handleImg",
+    labelCell: (_ADV$classes$labelCel = (_ADV$classes5 = ADV.classes) === null || _ADV$classes5 === void 0 ? void 0 : _ADV$classes5.labelCell) !== null && _ADV$classes$labelCel !== void 0 ? _ADV$classes$labelCel : "labelCell",
+    labelEdge: (_ADV$classes$labelEdg = (_ADV$classes6 = ADV.classes) === null || _ADV$classes6 === void 0 ? void 0 : _ADV$classes6.labelEdge) !== null && _ADV$classes$labelEdg !== void 0 ? _ADV$classes$labelEdg : "labelEdge",
+    cells: (_ADV$classes$cells = (_ADV$classes7 = ADV.classes) === null || _ADV$classes7 === void 0 ? void 0 : _ADV$classes7.cells) !== null && _ADV$classes$cells !== void 0 ? _ADV$classes$cells : ["c1", "c2", "c3", "c4"]
+  };
+  const showGrid = ADV.grid !== false;
+  const clickToMove = ADV.clickToMove !== false;
+  const showHeightAxis = ((_SV$height2 = SV.height) === null || _SV$height2 === void 0 ? void 0 : _SV$height2.show) !== false;
+  const showLengthAxis = ((_SV$length2 = SV.length) === null || _SV$length2 === void 0 ? void 0 : _SV$length2.show) !== false;
+  const dragVertical = showHeightAxis && ((_ADV$drag = ADV.drag) === null || _ADV$drag === void 0 ? void 0 : _ADV$drag.vertical) !== false;
+  const dragHorizontal = showLengthAxis && ((_ADV$drag2 = ADV.drag) === null || _ADV$drag2 === void 0 ? void 0 : _ADV$drag2.horizontal) !== false;
   const splitLinesOn = ADV.splitLines !== false;
   const showHLine = splitLinesOn && showHeightAxis;
   const showVLine = splitLinesOn && showLengthAxis;
-
-  const minColsEachSide = Math.max(1, ADV.limits?.minColsEachSide ?? 1);
-  const minRowsEachSide = Math.max(1, ADV.limits?.minRowsEachSide ?? 1);
-
-  const initLeftCols   = (SV.length?.handle ?? Math.floor(COLS/2));
-  const initBottomRows = (SV.height?.handle ?? Math.floor(ROWS/2));
-
-  const showLeftHandle   = showHeightAxis && (SV.height?.showHandle !== false);
-  const showBottomHandle = showLengthAxis && (SV.length?.showHandle !== false);
+  const minColsEachSide = Math.max(1, (_ADV$limits$minColsEa = (_ADV$limits = ADV.limits) === null || _ADV$limits === void 0 ? void 0 : _ADV$limits.minColsEachSide) !== null && _ADV$limits$minColsEa !== void 0 ? _ADV$limits$minColsEa : 1);
+  const minRowsEachSide = Math.max(1, (_ADV$limits$minRowsEa = (_ADV$limits2 = ADV.limits) === null || _ADV$limits2 === void 0 ? void 0 : _ADV$limits2.minRowsEachSide) !== null && _ADV$limits$minRowsEa !== void 0 ? _ADV$limits$minRowsEa : 1);
+  const initLeftCols = (_SV$length$handle = (_SV$length3 = SV.length) === null || _SV$length3 === void 0 ? void 0 : _SV$length3.handle) !== null && _SV$length$handle !== void 0 ? _SV$length$handle : Math.floor(COLS / 2);
+  const initBottomRows = (_SV$height$handle = (_SV$height3 = SV.height) === null || _SV$height3 === void 0 ? void 0 : _SV$height3.handle) !== null && _SV$height$handle !== void 0 ? _SV$height$handle : Math.floor(ROWS / 2);
+  const showLeftHandle = showHeightAxis && ((_SV$height4 = SV.height) === null || _SV$height4 === void 0 ? void 0 : _SV$height4.showHandle) !== false;
+  const showBottomHandle = showLengthAxis && ((_SV$length4 = SV.length) === null || _SV$length4 === void 0 ? void 0 : _SV$length4.showHandle) !== false;
 
   // helpers
-  const NS  = "http://www.w3.org/2000/svg";
-  const el  = n => document.createElementNS(NS, n);
-  const set = (node, n, v) => { node.setAttribute(n, v); return node; };
-  const clamp = (v,a,b)=>Math.max(a,Math.min(b,v));
-  const clampInt = (v,a,b)=>Math.max(a,Math.min(b,Math.round(v)));
-  const snap  = v => Math.round(v/UNIT)*UNIT;
-
-  const minX = ML + minColsEachSide*UNIT;
-  const maxX = ML + W  - minColsEachSide*UNIT;
-  const minY = MT + minRowsEachSide*UNIT;
-  const maxY = MT + H  - minRowsEachSide*UNIT;
-
-  const H_ICON_URL  = ADV.handleIcons?.horiz ?? "";
-  const V_ICON_URL  = ADV.handleIcons?.vert  ?? "";
+  const NS = "http://www.w3.org/2000/svg";
+  const el = n => document.createElementNS(NS, n);
+  const set = (node, n, v) => {
+    node.setAttribute(n, v);
+    return node;
+  };
+  const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+  const clampInt = (v, a, b) => Math.max(a, Math.min(b, Math.round(v)));
+  const snap = v => Math.round(v / UNIT) * UNIT;
+  const minX = ML + minColsEachSide * UNIT;
+  const maxX = ML + W - minColsEachSide * UNIT;
+  const minY = MT + minRowsEachSide * UNIT;
+  const maxY = MT + H - minRowsEachSide * UNIT;
+  const H_ICON_URL = (_ADV$handleIcons$hori = (_ADV$handleIcons2 = ADV.handleIcons) === null || _ADV$handleIcons2 === void 0 ? void 0 : _ADV$handleIcons2.horiz) !== null && _ADV$handleIcons$hori !== void 0 ? _ADV$handleIcons$hori : "";
+  const V_ICON_URL = (_ADV$handleIcons$vert = (_ADV$handleIcons3 = ADV.handleIcons) === null || _ADV$handleIcons3 === void 0 ? void 0 : _ADV$handleIcons3.vert) !== null && _ADV$handleIcons$vert !== void 0 ? _ADV$handleIcons$vert : "";
 
   // state
-  let sx = clampInt(initLeftCols,   1, COLS-1) * UNIT;
-  let sy = clampInt(initBottomRows, 1, ROWS-1) * UNIT;
+  let sx = clampInt(initLeftCols, 1, COLS - 1) * UNIT;
+  let sy = clampInt(initBottomRows, 1, ROWS - 1) * UNIT;
   let lastSyncedLeft = null;
   let lastSyncedBottom = null;
-
-  function syncSimpleHandles(){
-    const leftCols = Math.round(sx/UNIT);
-    const bottomRows = Math.round(sy/UNIT);
-    if(leftCols === lastSyncedLeft && bottomRows === lastSyncedBottom) return;
+  function syncSimpleHandles() {
+    const leftCols = Math.round(sx / UNIT);
+    const bottomRows = Math.round(sy / UNIT);
+    if (leftCols === lastSyncedLeft && bottomRows === lastSyncedBottom) return;
     lastSyncedLeft = leftCols;
     lastSyncedBottom = bottomRows;
-    if(!CFG.SIMPLE.length) CFG.SIMPLE.length = {};
-    if(!CFG.SIMPLE.height) CFG.SIMPLE.height = {};
+    if (!CFG.SIMPLE.length) CFG.SIMPLE.length = {};
+    if (!CFG.SIMPLE.height) CFG.SIMPLE.height = {};
     CFG.SIMPLE.length.handle = leftCols;
     CFG.SIMPLE.height.handle = bottomRows;
     const lengthStart = document.getElementById('lengthStart');
-    if(lengthStart) lengthStart.value = String(leftCols);
+    if (lengthStart) lengthStart.value = String(leftCols);
     const heightStart = document.getElementById('heightStart');
-    if(heightStart) heightStart.value = String(bottomRows);
+    if (heightStart) heightStart.value = String(bottomRows);
   }
-
   injectRuntimeStyles();
 
   // DOM
@@ -205,48 +226,84 @@ function draw(){
   set(svg, "viewBox", `0 0 ${VBW} ${VBH}`);
   set(svg, "preserveAspectRatio", "xMidYMid meet");
   Object.assign(svg.style, {
-    maxHeight: (ADV.fit?.maxVh ?? 100) + "vh",
+    maxHeight: ((_ADV$fit$maxVh = (_ADV$fit = ADV.fit) === null || _ADV$fit === void 0 ? void 0 : _ADV$fit.maxVh) !== null && _ADV$fit$maxVh !== void 0 ? _ADV$fit$maxVh : 100) + "vh",
     maxWidth: "100%",
     display: "block",
     touchAction: "none"
   });
-
   const rectOuter = el("rect");
-  set(rectOuter,"x",ML); set(rectOuter,"y",MT);
-  set(rectOuter,"width",W); set(rectOuter,"height",H);
-  set(rectOuter,"class",classes.outer);
+  set(rectOuter, "x", ML);
+  set(rectOuter, "y", MT);
+  set(rectOuter, "width", W);
+  set(rectOuter, "height", H);
+  set(rectOuter, "class", classes.outer);
   svg.appendChild(rectOuter);
-
-  const defs = el("defs"); svg.appendChild(defs);
-  const clip = el("clipPath"); set(clip,"id","clipR");
+  const defs = el("defs");
+  svg.appendChild(defs);
+  const clip = el("clipPath");
+  set(clip, "id", "clipR");
   const clipRect = el("rect");
-  set(clipRect,"x",ML); set(clipRect,"y",MT); set(clipRect,"width",W); set(clipRect,"height",H);
-  clip.appendChild(clipRect); defs.appendChild(clip);
-
-  const rTL = el("rect"), rTR = el("rect"), rBL = el("rect"), rBR = el("rect");
-  set(rTL,"class",classes.cells[0]); set(rTR,"class",classes.cells[1]);
-  set(rBL,"class",classes.cells[2]); set(rBR,"class",classes.cells[3]);
-  svg.append(rTL,rTR,rBL,rBR);
-
-  const gridGroup = el("g"); set(gridGroup,"class",classes.grid); set(gridGroup,"clip-path","url(#clipR)");
+  set(clipRect, "x", ML);
+  set(clipRect, "y", MT);
+  set(clipRect, "width", W);
+  set(clipRect, "height", H);
+  clip.appendChild(clipRect);
+  defs.appendChild(clip);
+  const rTL = el("rect"),
+    rTR = el("rect"),
+    rBL = el("rect"),
+    rBR = el("rect");
+  set(rTL, "class", classes.cells[0]);
+  set(rTR, "class", classes.cells[1]);
+  set(rBL, "class", classes.cells[2]);
+  set(rBR, "class", classes.cells[3]);
+  svg.append(rTL, rTR, rBL, rBR);
+  const gridGroup = el("g");
+  set(gridGroup, "class", classes.grid);
+  set(gridGroup, "clip-path", "url(#clipR)");
   if (showGrid) {
     for (let x = ML + UNIT; x < ML + W; x += UNIT) {
-      const ln = el("line"); set(ln,"x1",x); set(ln,"y1",MT); set(ln,"x2",x); set(ln,"y2",MT+H); gridGroup.appendChild(ln);
+      const ln = el("line");
+      set(ln, "x1", x);
+      set(ln, "y1", MT);
+      set(ln, "x2", x);
+      set(ln, "y2", MT + H);
+      gridGroup.appendChild(ln);
     }
     for (let y = MT + UNIT; y < MT + H; y += UNIT) {
-      const ln = el("line"); set(ln,"x1",ML); set(ln,"y1",y); set(ln,"x2",ML+W); set(ln,"y2",y); gridGroup.appendChild(ln);
+      const ln = el("line");
+      set(ln, "x1", ML);
+      set(ln, "y1", y);
+      set(ln, "x2", ML + W);
+      set(ln, "y2", y);
+      gridGroup.appendChild(ln);
     }
   }
   svg.appendChild(gridGroup);
 
   // delingslinjer
-  let vLine=null,hLine=null;
-  if (showVLine) { vLine = el("line"); set(vLine,"class",classes.split); svg.append(vLine); }
-  if (showHLine) { hLine = el("line"); set(hLine,"class",classes.split); svg.append(hLine); }
+  let vLine = null,
+    hLine = null;
+  if (showVLine) {
+    vLine = el("line");
+    set(vLine, "class", classes.split);
+    svg.append(vLine);
+  }
+  if (showHLine) {
+    hLine = el("line");
+    set(hLine, "class", classes.split);
+    svg.append(hLine);
+  }
 
   // håndtak + hit-soner + tastaturoverlay
-  let handleLeft = null, handleDown = null, hitLeft = null, hitDown = null,
-      a11yLeft = null, a11yLeftRect = null, a11yDown = null, a11yDownRect = null;
+  let handleLeft = null,
+    handleDown = null,
+    hitLeft = null,
+    hitDown = null,
+    a11yLeft = null,
+    a11yLeftRect = null,
+    a11yDown = null,
+    a11yDownRect = null;
   if (showLeftHandle) {
     handleLeft = el("image");
     set(handleLeft, "class", classes.handle);
@@ -254,12 +311,10 @@ function draw(){
     set(handleLeft, "height", HANDLE_SIZE);
     set(handleLeft, "href", V_ICON_URL);
     svg.append(handleLeft);
-
     hitLeft = el("circle");
     set(hitLeft, "class", "handleHit");
-    set(hitLeft, "r", (HANDLE_SIZE*0.55));
+    set(hitLeft, "r", HANDLE_SIZE * 0.55);
     svg.append(hitLeft);
-
     a11yLeft = el("g");
     set(a11yLeft, "class", "handleOverlay");
     set(a11yLeft, "tabindex", "0");
@@ -282,12 +337,10 @@ function draw(){
     set(handleDown, "height", HANDLE_SIZE);
     set(handleDown, "href", H_ICON_URL);
     svg.append(handleDown);
-
     hitDown = el("circle");
     set(hitDown, "class", "handleHit");
-    set(hitDown, "r", (HANDLE_SIZE*0.55));
+    set(hitDown, "r", HANDLE_SIZE * 0.55);
     svg.append(hitDown);
-
     a11yDown = el("g");
     set(a11yDown, "class", "handleOverlay");
     set(a11yDown, "tabindex", "0");
@@ -305,176 +358,272 @@ function draw(){
   }
 
   // tekster
-  const tTL = el("text"), tTR = el("text"), tBL = el("text"), tBR = el("text");
-  [tTL,tTR,tBL,tBR].forEach(t=>{ set(t,"class",classes.labelCell); set(t,"text-anchor","middle"); });
-
-  const leftTop  = el("text"), leftBot  = el("text"), botLeft = el("text"), botRight = el("text");
-  set(leftTop ,'class',classes.labelEdge);  set(leftTop ,'text-anchor', "end");
-  set(leftBot ,'class',classes.labelEdge);  set(leftBot ,'text-anchor', "end");
-  set(botLeft ,'class',classes.labelEdge);  set(botLeft ,'text-anchor',"middle");
-  set(botRight,'class',classes.labelEdge);  set(botRight,'text-anchor',"middle");
-  svg.append(tTL,tTR,tBL,tBR,leftTop,leftBot,botLeft,botRight);
-
-  const dot    = ADV.labels?.dot ?? " · ";
-  const equals = ADV.labels?.equals ?? " = ";
-  const edgeOn = (ADV.labels?.edgeMode ?? "counts") === "counts";
-  const cellMode = ADV.labels?.cellMode ?? "factors";
-  function formatCellLabel(w,h){
-    if (cellMode === "none")   return "";
-    if (cellMode === "factors")return `${w}${dot}${h}`;
-    if (cellMode === "area")   return `${w*h}`;
-    return `${w}${dot}${h}${equals}${w*h}`;
+  const tTL = el("text"),
+    tTR = el("text"),
+    tBL = el("text"),
+    tBR = el("text");
+  [tTL, tTR, tBL, tBR].forEach(t => {
+    set(t, "class", classes.labelCell);
+    set(t, "text-anchor", "middle");
+  });
+  const leftTop = el("text"),
+    leftBot = el("text"),
+    botLeft = el("text"),
+    botRight = el("text");
+  set(leftTop, 'class', classes.labelEdge);
+  set(leftTop, 'text-anchor', "end");
+  set(leftBot, 'class', classes.labelEdge);
+  set(leftBot, 'text-anchor', "end");
+  set(botLeft, 'class', classes.labelEdge);
+  set(botLeft, 'text-anchor', "middle");
+  set(botRight, 'class', classes.labelEdge);
+  set(botRight, 'text-anchor', "middle");
+  svg.append(tTL, tTR, tBL, tBR, leftTop, leftBot, botLeft, botRight);
+  const dot = (_ADV$labels$dot = (_ADV$labels = ADV.labels) === null || _ADV$labels === void 0 ? void 0 : _ADV$labels.dot) !== null && _ADV$labels$dot !== void 0 ? _ADV$labels$dot : " · ";
+  const equals = (_ADV$labels$equals = (_ADV$labels2 = ADV.labels) === null || _ADV$labels2 === void 0 ? void 0 : _ADV$labels2.equals) !== null && _ADV$labels$equals !== void 0 ? _ADV$labels$equals : " = ";
+  const edgeOn = ((_ADV$labels$edgeMode = (_ADV$labels3 = ADV.labels) === null || _ADV$labels3 === void 0 ? void 0 : _ADV$labels3.edgeMode) !== null && _ADV$labels$edgeMode !== void 0 ? _ADV$labels$edgeMode : "counts") === "counts";
+  const cellMode = (_ADV$labels$cellMode = (_ADV$labels4 = ADV.labels) === null || _ADV$labels4 === void 0 ? void 0 : _ADV$labels4.cellMode) !== null && _ADV$labels$cellMode !== void 0 ? _ADV$labels$cellMode : "factors";
+  function formatCellLabel(w, h) {
+    if (cellMode === "none") return "";
+    if (cellMode === "factors") return `${w}${dot}${h}`;
+    if (cellMode === "area") return `${w * h}`;
+    return `${w}${dot}${h}${equals}${w * h}`;
   }
 
   // ------- Rask mapping: klient → viewBox -------
   let svgRect = svg.getBoundingClientRect();
-  function clientToSvg(e){
+  function clientToSvg(e) {
     const vb = svg.viewBox.baseVal;
-    const sx = vb.width  / svgRect.width;
+    const sx = vb.width / svgRect.width;
     const sy = vb.height / svgRect.height;
     return {
       x: vb.x + (e.clientX - svgRect.left) * sx,
-      y: vb.y + (e.clientY - svgRect.top ) * sy
+      y: vb.y + (e.clientY - svgRect.top) * sy
     };
   }
-  function refreshSvgRect(){ svgRect = svg.getBoundingClientRect(); }
+  function refreshSvgRect() {
+    svgRect = svg.getBoundingClientRect();
+  }
 
   // ------- rAF-basert redraw -------
   let rafId = 0;
-  function scheduleRedraw(){
+  function scheduleRedraw() {
     if (rafId) return;
-    rafId = requestAnimationFrame(() => { rafId = 0; redraw(); });
+    rafId = requestAnimationFrame(() => {
+      rafId = 0;
+      redraw();
+    });
   }
-
-  function redraw(){
-    const wL = Math.round(sx/UNIT), wR = COLS - wL;
-    const hB = Math.round(sy/UNIT), hT = ROWS - hB;
-
-    set(rTL,"x",ML); set(rTL,"y",MT); set(rTL,"width",sx); set(rTL,"height",H-sy);
-    set(rTR,"x",ML+sx); set(rTR,"y",MT); set(rTR,"width",W-sx); set(rTR,"height",H-sy);
-    set(rBL,"x",ML); set(rBL,"y",MT+(H-sy)); set(rBL,"width",sx); set(rBL,"height",sy);
-    set(rBR,"x",ML+sx); set(rBR,"y",MT+(H-sy)); set(rBR,"width",W-sx); set(rBR,"height",sy);
-
-    if (vLine) { set(vLine,"x1",ML+sx); set(vLine,"y1",MT); set(vLine,"x2",ML+sx); set(vLine,"y2",MT+H); }
-    if (hLine) { set(hLine,"x1",ML); set(hLine,"y1",MT+(H-sy)); set(hLine,"x2",ML+W); set(hLine,"y2",MT+(H-sy)); }
-
-    const hLeftCX = ML,      hLeftCY = MT + (H - sy);
-    const hDownCX = ML + sx, hDownCY = MT + H;
-
-    if (handleLeft) { set(handleLeft, "x", hLeftCX - HANDLE_SIZE/2); set(handleLeft, "y", hLeftCY - HANDLE_SIZE/2); }
-    if (handleDown) { set(handleDown, "x", hDownCX - HANDLE_SIZE/2); set(handleDown, "y", hDownCY - HANDLE_SIZE/2); }
-    if (hitLeft)    { set(hitLeft,    "cx", hLeftCX); set(hitLeft,    "cy", hLeftCY); }
-    if (hitDown)    { set(hitDown,    "cx", hDownCX); set(hitDown,    "cy", hDownCY); }
-
-    if (a11yLeftRect) { set(a11yLeftRect, "x", hLeftCX - HANDLE_SIZE/2); set(a11yLeftRect, "y", hLeftCY - HANDLE_SIZE/2); }
+  function redraw() {
+    const wL = Math.round(sx / UNIT),
+      wR = COLS - wL;
+    const hB = Math.round(sy / UNIT),
+      hT = ROWS - hB;
+    set(rTL, "x", ML);
+    set(rTL, "y", MT);
+    set(rTL, "width", sx);
+    set(rTL, "height", H - sy);
+    set(rTR, "x", ML + sx);
+    set(rTR, "y", MT);
+    set(rTR, "width", W - sx);
+    set(rTR, "height", H - sy);
+    set(rBL, "x", ML);
+    set(rBL, "y", MT + (H - sy));
+    set(rBL, "width", sx);
+    set(rBL, "height", sy);
+    set(rBR, "x", ML + sx);
+    set(rBR, "y", MT + (H - sy));
+    set(rBR, "width", W - sx);
+    set(rBR, "height", sy);
+    if (vLine) {
+      set(vLine, "x1", ML + sx);
+      set(vLine, "y1", MT);
+      set(vLine, "x2", ML + sx);
+      set(vLine, "y2", MT + H);
+    }
+    if (hLine) {
+      set(hLine, "x1", ML);
+      set(hLine, "y1", MT + (H - sy));
+      set(hLine, "x2", ML + W);
+      set(hLine, "y2", MT + (H - sy));
+    }
+    const hLeftCX = ML,
+      hLeftCY = MT + (H - sy);
+    const hDownCX = ML + sx,
+      hDownCY = MT + H;
+    if (handleLeft) {
+      set(handleLeft, "x", hLeftCX - HANDLE_SIZE / 2);
+      set(handleLeft, "y", hLeftCY - HANDLE_SIZE / 2);
+    }
+    if (handleDown) {
+      set(handleDown, "x", hDownCX - HANDLE_SIZE / 2);
+      set(handleDown, "y", hDownCY - HANDLE_SIZE / 2);
+    }
+    if (hitLeft) {
+      set(hitLeft, "cx", hLeftCX);
+      set(hitLeft, "cy", hLeftCY);
+    }
+    if (hitDown) {
+      set(hitDown, "cx", hDownCX);
+      set(hitDown, "cy", hDownCY);
+    }
+    if (a11yLeftRect) {
+      set(a11yLeftRect, "x", hLeftCX - HANDLE_SIZE / 2);
+      set(a11yLeftRect, "y", hLeftCY - HANDLE_SIZE / 2);
+    }
     if (a11yLeft) {
       set(a11yLeft, "aria-valuenow", hB);
       set(a11yLeft, "aria-valuetext", `${hB} nederst, ${hT} øverst`);
     }
-    if (a11yDownRect) { set(a11yDownRect, "x", hDownCX - HANDLE_SIZE/2); set(a11yDownRect, "y", hDownCY - HANDLE_SIZE/2); }
+    if (a11yDownRect) {
+      set(a11yDownRect, "x", hDownCX - HANDLE_SIZE / 2);
+      set(a11yDownRect, "y", hDownCY - HANDLE_SIZE / 2);
+    }
     if (a11yDown) {
       set(a11yDown, "aria-valuenow", wL);
       set(a11yDown, "aria-valuetext", `${wL} venstre, ${wR} høyre`);
     }
 
     // cell-etiketter
-    set(tTL,"x",ML + sx/2);               set(tTL,"y",MT + (H - sy)/2 + 8);      tTL.textContent = formatCellLabel(wL, hT);
-    set(tTR,"x",ML + sx + (W - sx)/2);    set(tTR,"y",MT + (H - sy)/2 + 8);      tTR.textContent = formatCellLabel(wR, hT);
-    set(tBL,"x",ML + sx/2);               set(tBL,"y",MT + (H - sy) + sy/2 + 8); tBL.textContent = formatCellLabel(wL, hB);
-    set(tBR,"x",ML + sx + (W - sx)/2);    set(tBR,"y",MT + (H - sy) + sy/2 + 8); tBR.textContent = formatCellLabel(wR, hB);
+    set(tTL, "x", ML + sx / 2);
+    set(tTL, "y", MT + (H - sy) / 2 + 8);
+    tTL.textContent = formatCellLabel(wL, hT);
+    set(tTR, "x", ML + sx + (W - sx) / 2);
+    set(tTR, "y", MT + (H - sy) / 2 + 8);
+    tTR.textContent = formatCellLabel(wR, hT);
+    set(tBL, "x", ML + sx / 2);
+    set(tBL, "y", MT + (H - sy) + sy / 2 + 8);
+    tBL.textContent = formatCellLabel(wL, hB);
+    set(tBR, "x", ML + sx + (W - sx) / 2);
+    set(tBR, "y", MT + (H - sy) + sy / 2 + 8);
+    tBR.textContent = formatCellLabel(wR, hB);
 
     // kant-etiketter (utenfor, med luft)
-    const leftXOutside   = ML - (HANDLE_SIZE/2) - EDGE_GAP.x;
-    const bottomYOutside = MT + H + (HANDLE_SIZE/2) + EDGE_GAP.y;
-
+    const leftXOutside = ML - HANDLE_SIZE / 2 - EDGE_GAP.x;
+    const bottomYOutside = MT + H + HANDLE_SIZE / 2 + EDGE_GAP.y;
     if (edgeOn && showHeightAxis) {
-      set(leftTop,"x",leftXOutside); set(leftTop,"y",MT + (H - sy)/2 + 10);  leftTop.textContent  = `${hT}`;
-      set(leftBot,"x",leftXOutside); set(leftBot,"y",MT + (H - sy) + sy/2 + 10); leftBot.textContent = `${hB}`;
-    } else { leftTop.textContent = leftBot.textContent = ""; }
-
+      set(leftTop, "x", leftXOutside);
+      set(leftTop, "y", MT + (H - sy) / 2 + 10);
+      leftTop.textContent = `${hT}`;
+      set(leftBot, "x", leftXOutside);
+      set(leftBot, "y", MT + (H - sy) + sy / 2 + 10);
+      leftBot.textContent = `${hB}`;
+    } else {
+      leftTop.textContent = leftBot.textContent = "";
+    }
     if (edgeOn && showLengthAxis) {
-      set(botLeft,"x",ML + sx/2);            set(botLeft,"y",bottomYOutside);
-      set(botRight,"x",ML + sx + (W - sx)/2); set(botRight,"y",bottomYOutside);
-      botLeft.textContent  = `${wL}`; botRight.textContent = `${wR}`;
-    } else { botLeft.textContent = botRight.textContent = ""; }
+      set(botLeft, "x", ML + sx / 2);
+      set(botLeft, "y", bottomYOutside);
+      set(botRight, "x", ML + sx + (W - sx) / 2);
+      set(botRight, "y", bottomYOutside);
+      botLeft.textContent = `${wL}`;
+      botRight.textContent = `${wR}`;
+    } else {
+      botLeft.textContent = botRight.textContent = "";
+    }
 
     // “Riktig” – doble linjer når begge sider har en tier
-    const okX = (wL === TEN || wR === TEN);
-    const okY = (hB === TEN || hT === TEN);
-    const on  = okX && okY;
+    const okX = wL === TEN || wR === TEN;
+    const okY = hB === TEN || hT === TEN;
+    const on = okX && okY;
     if (vLine) vLine.setAttribute("class", classes.split + (on ? " ok" : ""));
     if (hLine) hLine.setAttribute("class", classes.split + (on ? " ok" : ""));
 
     // hold håndtak/hit-soner øverst
-    if (handleLeft)  svg.append(handleLeft);
-    if (hitLeft)     svg.append(hitLeft);
-    if (a11yLeft)    svg.append(a11yLeft);
-    if (handleDown)  svg.append(handleDown);
-    if (hitDown)     svg.append(hitDown);
-    if (a11yDown)    svg.append(a11yDown);
-
+    if (handleLeft) svg.append(handleLeft);
+    if (hitLeft) svg.append(hitLeft);
+    if (a11yLeft) svg.append(a11yLeft);
+    if (handleDown) svg.append(handleDown);
+    if (hitDown) svg.append(hitDown);
+    if (a11yDown) svg.append(a11yDown);
     syncSimpleHandles();
   }
 
   // ---- Responsiv skalering ----
-  function fitToViewport(){
-    const SAFE = ADV.fit?.safePad || {top:8,right:8,bottom:64,left:8};
+  function fitToViewport() {
+    var _ADV$fit2;
+    const SAFE = ((_ADV$fit2 = ADV.fit) === null || _ADV$fit2 === void 0 ? void 0 : _ADV$fit2.safePad) || {
+      top: 8,
+      right: 8,
+      bottom: 64,
+      left: 8
+    };
     const availW = Math.max(100, svg.parentElement.clientWidth - (SAFE.left + SAFE.right));
-    const availH = Math.max(100, window.innerHeight - (SAFE.top  + SAFE.bottom));
+    const availH = Math.max(100, window.innerHeight - (SAFE.top + SAFE.bottom));
     const s = Math.min(availW / VBW, availH / VBH);
     const w = VBW * s;
     const h = VBH * s;
-    svg.setAttribute("width",  w);
+    svg.setAttribute("width", w);
     svg.setAttribute("height", h);
     svg.style.width = w + "px";
     svg.style.height = h + "px";
     refreshSvgRect();
   }
-
   redraw();
   fitToViewport();
-  window.addEventListener("resize", fitToViewport, { passive: true });
+  window.addEventListener("resize", fitToViewport, {
+    passive: true
+  });
 
   // ======== DRAGGING – pointer capture + touch-lock + rAF ========
-  let active = { axis: null, pointerId: null, captor: null };
+  let active = {
+    axis: null,
+    pointerId: null,
+    captor: null
+  };
   let justDragged = false;
-  const armJustDragged = ()=>{ justDragged = true; setTimeout(()=>{ justDragged = false; }, 220); };
-
-  function lockTouch(){
+  const armJustDragged = () => {
+    justDragged = true;
+    setTimeout(() => {
+      justDragged = false;
+    }, 220);
+  };
+  function lockTouch() {
     document.documentElement.style.touchAction = "none";
     document.body.style.touchAction = "none";
     document.documentElement.style.overscrollBehavior = "contain";
     document.body.style.overscrollBehavior = "contain";
   }
-  function unlockTouch(){
+  function unlockTouch() {
     document.documentElement.style.touchAction = "";
     document.body.style.touchAction = "";
     document.documentElement.style.overscrollBehavior = "";
     document.body.style.overscrollBehavior = "";
   }
-
-  function onMove(e){
+  function onMove(e) {
     if (e.pointerId !== active.pointerId) return;
     e.preventDefault();
     const p = clientToSvg(e);
     if (active.axis === "v") {
       const y = clamp(p.y, minY, maxY);
       const newSy = MT + H - y;
-      if (newSy !== sy) { sy = newSy; scheduleRedraw(); }
+      if (newSy !== sy) {
+        sy = newSy;
+        scheduleRedraw();
+      }
     } else if (active.axis === "h") {
       const x = clamp(p.x, minX, maxX);
       const newSx = x - ML;
-      if (newSx !== sx) { sx = newSx; scheduleRedraw(); }
+      if (newSx !== sx) {
+        sx = newSx;
+        scheduleRedraw();
+      }
     }
   }
-  function onUp(e){
+  function onUp(e) {
     if (e.pointerId !== active.pointerId) return;
     e.preventDefault();
     if (active.axis === "v") sy = snap(sy);
     if (active.axis === "h") sx = snap(sx);
-    if (active.captor && active.captor.releasePointerCapture) { try { active.captor.releasePointerCapture(e.pointerId); } catch(_){} }
+    if (active.captor && active.captor.releasePointerCapture) {
+      try {
+        active.captor.releasePointerCapture(e.pointerId);
+      } catch (_) {}
+    }
     if (active.captor) active.captor.classList.remove("dragging");
-    active.axis = null; active.pointerId = null; active.captor = null;
+    active.axis = null;
+    active.pointerId = null;
+    active.captor = null;
     window.removeEventListener("pointermove", onMove);
     window.removeEventListener("pointerup", onUp);
     window.removeEventListener("pointercancel", onUp);
@@ -482,172 +631,258 @@ function draw(){
     armJustDragged();
     scheduleRedraw();
   }
-
-  function startDrag(axis, e){
+  function startDrag(axis, e) {
     active.axis = axis;
     active.pointerId = e.pointerId;
     active.captor = e.currentTarget || e.target;
-    if (active.captor && active.captor.setPointerCapture) { try { active.captor.setPointerCapture(e.pointerId); } catch(_){} }
+    if (active.captor && active.captor.setPointerCapture) {
+      try {
+        active.captor.setPointerCapture(e.pointerId);
+      } catch (_) {}
+    }
     if (active.captor) active.captor.classList.add("dragging");
     lockTouch();
-    window.addEventListener("pointermove", onMove, { passive: false });
-    window.addEventListener("pointerup", onUp, { passive: false });
-    window.addEventListener("pointercancel", onUp, { passive: false });
+    window.addEventListener("pointermove", onMove, {
+      passive: false
+    });
+    window.addEventListener("pointerup", onUp, {
+      passive: false
+    });
+    window.addEventListener("pointercancel", onUp, {
+      passive: false
+    });
   }
-
   if (dragVertical && hitLeft) {
     hitLeft.style.touchAction = "none";
-    hitLeft.addEventListener("pointerdown", e => { e.preventDefault(); startDrag("v", e); }, { passive: false });
+    hitLeft.addEventListener("pointerdown", e => {
+      e.preventDefault();
+      startDrag("v", e);
+    }, {
+      passive: false
+    });
   }
   if (dragHorizontal && hitDown) {
     hitDown.style.touchAction = "none";
-    hitDown.addEventListener("pointerdown", e => { e.preventDefault(); startDrag("h", e); }, { passive: false });
+    hitDown.addEventListener("pointerdown", e => {
+      e.preventDefault();
+      startDrag("h", e);
+    }, {
+      passive: false
+    });
   }
-
   if (a11yLeft) {
     a11yLeft.addEventListener("keydown", e => {
       let handled = true;
       if (e.key === "ArrowUp") {
-        sy = clamp(sy + UNIT, minRowsEachSide*UNIT, (ROWS - minRowsEachSide)*UNIT);
+        sy = clamp(sy + UNIT, minRowsEachSide * UNIT, (ROWS - minRowsEachSide) * UNIT);
       } else if (e.key === "ArrowDown") {
-        sy = clamp(sy - UNIT, minRowsEachSide*UNIT, (ROWS - minRowsEachSide)*UNIT);
+        sy = clamp(sy - UNIT, minRowsEachSide * UNIT, (ROWS - minRowsEachSide) * UNIT);
       } else if (e.key === "Home") {
-        sy = minRowsEachSide*UNIT;
+        sy = minRowsEachSide * UNIT;
       } else if (e.key === "End") {
-        sy = (ROWS - minRowsEachSide)*UNIT;
+        sy = (ROWS - minRowsEachSide) * UNIT;
       } else {
         handled = false;
       }
-      if (handled) { e.preventDefault(); scheduleRedraw(); }
+      if (handled) {
+        e.preventDefault();
+        scheduleRedraw();
+      }
     });
   }
-
   if (a11yDown) {
     a11yDown.addEventListener("keydown", e => {
       let handled = true;
       if (e.key === "ArrowRight") {
-        sx = clamp(sx + UNIT, minColsEachSide*UNIT, (COLS - minColsEachSide)*UNIT);
+        sx = clamp(sx + UNIT, minColsEachSide * UNIT, (COLS - minColsEachSide) * UNIT);
       } else if (e.key === "ArrowLeft") {
-        sx = clamp(sx - UNIT, minColsEachSide*UNIT, (COLS - minColsEachSide)*UNIT);
+        sx = clamp(sx - UNIT, minColsEachSide * UNIT, (COLS - minColsEachSide) * UNIT);
       } else if (e.key === "Home") {
-        sx = minColsEachSide*UNIT;
+        sx = minColsEachSide * UNIT;
       } else if (e.key === "End") {
-        sx = (COLS - minColsEachSide)*UNIT;
+        sx = (COLS - minColsEachSide) * UNIT;
       } else {
         handled = false;
       }
-      if (handled) { e.preventDefault(); scheduleRedraw(); }
+      if (handled) {
+        e.preventDefault();
+        scheduleRedraw();
+      }
     });
   }
-
   if (clickToMove) {
     svg.addEventListener("click", e => {
       if (justDragged) return;
       const p = clientToSvg(e);
-      if (dragVertical   && showHeightAxis && Math.abs(p.x - ML) < 12 && p.y >= MT && p.y <= MT+H) { sy = snap(MT + H - clamp(p.y, minY, maxY)); scheduleRedraw(); }
-      if (dragHorizontal && showLengthAxis && Math.abs(p.y - (MT + H)) < 12 && p.x >= ML && p.x <= ML+W) { sx = snap(clamp(p.x, minX, maxX) - ML); scheduleRedraw(); }
+      if (dragVertical && showHeightAxis && Math.abs(p.x - ML) < 12 && p.y >= MT && p.y <= MT + H) {
+        sy = snap(MT + H - clamp(p.y, minY, maxY));
+        scheduleRedraw();
+      }
+      if (dragHorizontal && showLengthAxis && Math.abs(p.y - (MT + H)) < 12 && p.x >= ML && p.x <= ML + W) {
+        sx = snap(clamp(p.x, minX, maxX) - ML);
+        scheduleRedraw();
+      }
     });
   }
-
-  function buildExportOptions(){
-    const includeHandles = (showLeftHandle || showBottomHandle) || ADV.export?.includeHandlesIfHidden;
+  function buildExportOptions() {
+    var _ADV$export, _ADV$export2, _ADV$fit3;
+    const includeHandles = showLeftHandle || showBottomHandle || ((_ADV$export = ADV.export) === null || _ADV$export === void 0 ? void 0 : _ADV$export.includeHandlesIfHidden);
     return {
-      unit: UNIT, rows: ROWS, cols: COLS,
-      margins: { ML, MR, MT, MB },
-      width: W, height: H, vbw: VBW, vbh: VBH,
-      sx, sy, TEN,
-      limits: { minColsEachSide, minRowsEachSide },
+      unit: UNIT,
+      rows: ROWS,
+      cols: COLS,
+      margins: {
+        ML,
+        MR,
+        MT,
+        MB
+      },
+      width: W,
+      height: H,
+      vbw: VBW,
+      vbh: VBH,
+      sx,
+      sy,
+      TEN,
+      limits: {
+        minColsEachSide,
+        minRowsEachSide
+      },
       classes,
-      includeGrid: !!ADV.export?.includeGrid,
-      showHeightAxis, showLengthAxis,
+      includeGrid: !!((_ADV$export2 = ADV.export) !== null && _ADV$export2 !== void 0 && _ADV$export2.includeGrid),
+      showHeightAxis,
+      showLengthAxis,
       includeHandles,
       colorsCSS: getInlineStyleDefaults(),
       handleSize: HANDLE_SIZE,
-      icons: { horizUrl: ADV.handleIcons.horiz, vertUrl: ADV.handleIcons.vert },
+      icons: {
+        horizUrl: ADV.handleIcons.horiz,
+        vertUrl: ADV.handleIcons.vert
+      },
       edgeGap: EDGE_GAP,
-      safePad: ADV.fit?.safePad || {top:8,right:8,bottom:64,left:8}
+      safePad: ((_ADV$fit3 = ADV.fit) === null || _ADV$fit3 === void 0 ? void 0 : _ADV$fit3.safePad) || {
+        top: 8,
+        right: 8,
+        bottom: 64,
+        left: 8
+      }
     };
   }
-
   const btnSvgStatic = document.getElementById("btnSvgStatic");
-  if(btnSvgStatic) btnSvgStatic.onclick = () => {
+  if (btnSvgStatic) btnSvgStatic.onclick = () => {
+    var _ADV$export3;
     const svgStr = buildBaseSvgMarkup(buildExportOptions(), true);
-    downloadText(ADV.export?.filenameStatic || "arealmodell.svg", svgStr, "image/svg+xml");
+    downloadText(((_ADV$export3 = ADV.export) === null || _ADV$export3 === void 0 ? void 0 : _ADV$export3.filenameStatic) || "arealmodell.svg", svgStr, "image/svg+xml");
   };
-
   const btnPng = document.getElementById("btnPng");
-  if(btnPng) btnPng.onclick = () => {
+  if (btnPng) btnPng.onclick = () => {
+    var _ADV$export4;
     const svgStr = buildBaseSvgMarkup(buildExportOptions(), true);
-    downloadPNGFromString(svgStr, ADV.export?.filenamePng || "arealmodell.png");
+    downloadPNGFromString(svgStr, ((_ADV$export4 = ADV.export) === null || _ADV$export4 === void 0 ? void 0 : _ADV$export4.filenamePng) || "arealmodell.png");
   };
-
   const btnSvg = document.getElementById("btnSvg");
-  if(btnSvg) btnSvg.onclick = () => {
+  if (btnSvg) btnSvg.onclick = () => {
+    var _ADV$export5;
     const svgStr = buildInteractiveSvgString(buildExportOptions());
-    downloadText(ADV.export?.filename || "arealmodell_interaktiv.svg", svgStr, "image/svg+xml");
+    downloadText(((_ADV$export5 = ADV.export) === null || _ADV$export5 === void 0 ? void 0 : _ADV$export5.filename) || "arealmodell_interaktiv.svg", svgStr, "image/svg+xml");
   };
 
   // ===== Eksporter interaktiv HTML =====
   const btnHtml = document.getElementById("btnHtml");
-  if(btnHtml) btnHtml.onclick = () => {
-    const includeHandles = (showLeftHandle || showBottomHandle) || ADV.export?.includeHandlesIfHidden;
-
+  if (btnHtml) btnHtml.onclick = () => {
+    var _ADV$export6, _ADV$export7, _ADV$fit4, _ADV$export8;
+    const includeHandles = showLeftHandle || showBottomHandle || ((_ADV$export6 = ADV.export) === null || _ADV$export6 === void 0 ? void 0 : _ADV$export6.includeHandlesIfHidden);
     const htmlStr = buildInteractiveHtmlString({
-      unit: UNIT, rows: ROWS, cols: COLS,
-      margins: { ML, MR, MT, MB },
-      width: W, height: H, vbw: VBW, vbh: VBH,
-      sx, sy, TEN,
-      limits: { minColsEachSide, minRowsEachSide },
+      unit: UNIT,
+      rows: ROWS,
+      cols: COLS,
+      margins: {
+        ML,
+        MR,
+        MT,
+        MB
+      },
+      width: W,
+      height: H,
+      vbw: VBW,
+      vbh: VBH,
+      sx,
+      sy,
+      TEN,
+      limits: {
+        minColsEachSide,
+        minRowsEachSide
+      },
       classes,
-      includeGrid: !!ADV.export?.includeGrid,
-      showHeightAxis, showLengthAxis,
+      includeGrid: !!((_ADV$export7 = ADV.export) !== null && _ADV$export7 !== void 0 && _ADV$export7.includeGrid),
+      showHeightAxis,
+      showLengthAxis,
       includeHandles,
       colorsCSS: getInlineStyleDefaults(),
       handleSize: HANDLE_SIZE,
-      icons: { horizUrl: ADV.handleIcons.horiz, vertUrl: ADV.handleIcons.vert },
+      icons: {
+        horizUrl: ADV.handleIcons.horiz,
+        vertUrl: ADV.handleIcons.vert
+      },
       edgeGap: EDGE_GAP,
-      safePad: ADV.fit?.safePad || {top:8,right:8,bottom:64,left:8}
+      safePad: ((_ADV$fit4 = ADV.fit) === null || _ADV$fit4 === void 0 ? void 0 : _ADV$fit4.safePad) || {
+        top: 8,
+        right: 8,
+        bottom: 64,
+        left: 8
+      }
     });
-    const fname = ADV.export?.filenameHtml || "arealmodell_interaktiv.html";
+    const fname = ((_ADV$export8 = ADV.export) === null || _ADV$export8 === void 0 ? void 0 : _ADV$export8.filenameHtml) || "arealmodell_interaktiv.html";
     downloadText(fname, htmlStr, "text/html;charset=utf-8");
   };
 
   // ===== helpers =====
-  function downloadText(filename, text, mime){
-    const blob = new Blob([text], { type: mime });
+  function downloadText(filename, text, mime) {
+    const blob = new Blob([text], {
+      type: mime
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
-    a.href = url; a.download = filename;
-    document.body.appendChild(a); a.click(); a.remove();
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
     URL.revokeObjectURL(url);
   }
-
-  function downloadPNGFromString(svgStr, filename){
-    const blob = new Blob([svgStr], {type:'image/svg+xml;charset=utf-8'});
+  function downloadPNGFromString(svgStr, filename) {
+    const blob = new Blob([svgStr], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
     const url = URL.createObjectURL(blob);
     const img = new Image();
     img.onload = () => {
-      const w = img.width, h = img.height;
+      const w = img.width,
+        h = img.height;
       const canvas = document.createElement('canvas');
-      canvas.width = w; canvas.height = h;
+      canvas.width = w;
+      canvas.height = h;
       const ctx = canvas.getContext('2d');
       ctx.fillStyle = '#fff';
-      ctx.fillRect(0,0,w,h);
-      ctx.drawImage(img,0,0,w,h);
+      ctx.fillRect(0, 0, w, h);
+      ctx.drawImage(img, 0, 0, w, h);
       URL.revokeObjectURL(url);
-      canvas.toBlob(b=>{
+      canvas.toBlob(b => {
         const urlPng = URL.createObjectURL(b);
         const a = document.createElement('a');
-        a.href = urlPng; a.download = filename;
-        document.body.appendChild(a); a.click(); a.remove();
-        setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
+        a.href = urlPng;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(urlPng), 1000);
       }, 'image/png');
     };
     img.src = url;
   }
 
   // === FARGER/typografi ===
-  function getInlineStyleDefaults(){
+  function getInlineStyleDefaults() {
     const cols = ADV.colors || ["#e07c7c", "#f0c667", "#7fb2d6", "#8bb889"];
     return `
 .outer { fill: white; stroke: #333; stroke-width: 3; pointer-events: none; }
@@ -669,8 +904,7 @@ function draw(){
 .handleHit { fill: rgba(0,0,0,0.004); cursor: grab; pointer-events: all; }
 `;
   }
-
-  function injectRuntimeStyles(){
+  function injectRuntimeStyles() {
     if (document.getElementById("arealmodell-runtime-css")) return;
     const style = document.createElement("style");
     style.id = "arealmodell-runtime-css";
@@ -679,199 +913,122 @@ function draw(){
   }
 
   // -------- Base-SVG uten skript --------
-  function buildBaseSvgMarkup(o, includeXmlHeader){
-    const ML = o.margins.ML, MT = o.margins.MT;
-    const wL = Math.round(o.sx/o.unit), wR = o.cols - wL;
-    const hB = Math.round(o.sy/o.unit), hT = o.rows - hB;
-    const HS = o.handleSize ?? 84;
-    const gapX = o.edgeGap?.x ?? 14, gapY = o.edgeGap?.y ?? 32;
-
+  function buildBaseSvgMarkup(o, includeXmlHeader) {
+    var _o$handleSize, _o$edgeGap$x, _o$edgeGap, _o$edgeGap$y, _o$edgeGap2;
+    const ML = o.margins.ML,
+      MT = o.margins.MT;
+    const wL = Math.round(o.sx / o.unit),
+      wR = o.cols - wL;
+    const hB = Math.round(o.sy / o.unit),
+      hT = o.rows - hB;
+    const HS = (_o$handleSize = o.handleSize) !== null && _o$handleSize !== void 0 ? _o$handleSize : 84;
+    const gapX = (_o$edgeGap$x = (_o$edgeGap = o.edgeGap) === null || _o$edgeGap === void 0 ? void 0 : _o$edgeGap.x) !== null && _o$edgeGap$x !== void 0 ? _o$edgeGap$x : 14,
+      gapY = (_o$edgeGap$y = (_o$edgeGap2 = o.edgeGap) === null || _o$edgeGap2 === void 0 ? void 0 : _o$edgeGap2.y) !== null && _o$edgeGap$y !== void 0 ? _o$edgeGap$y : 32;
     let gridStr = "";
     if (o.includeGrid) {
       let lines = [];
-      for (let i=1;i<o.cols;i++){
-        const x = ML + o.unit*i;
-        lines.push('<line x1="'+x+'" y1="'+MT+'" x2="'+x+'" y2="'+(MT+o.height)+'" />');
+      for (let i = 1; i < o.cols; i++) {
+        const x = ML + o.unit * i;
+        lines.push('<line x1="' + x + '" y1="' + MT + '" x2="' + x + '" y2="' + (MT + o.height) + '" />');
       }
-      for (let j=1;j<o.rows;j++){
-        const y = MT + o.unit*j;
-        lines.push('<line x1="'+ML+'" y1="'+y+'" x2="'+(ML+o.width)+'" y2="'+y+'" />');
+      for (let j = 1; j < o.rows; j++) {
+        const y = MT + o.unit * j;
+        lines.push('<line x1="' + ML + '" y1="' + y + '" x2="' + (ML + o.width) + '" y2="' + y + '" />');
       }
-      gridStr = '<g class="'+o.classes.grid+'" clip-path="url(#clipR)">'+lines.join("")+'</g>';
+      gridStr = '<g class="' + o.classes.grid + '" clip-path="url(#clipR)">' + lines.join("") + '</g>';
     }
-
-    const vLineStr = o.showLengthAxis ? '<line id="vLine" class="'+o.classes.split+'" x1="'+(ML+o.sx)+'" y1="'+MT+'" x2="'+(ML+o.sx)+'" y2="'+(MT+o.height)+'"/>' : "";
-    const hLineStr = o.showHeightAxis ? '<line id="hLine" class="'+o.classes.split+'" x1="'+ML+'" y1="'+(MT+o.height-o.sy)+'" x2="'+(ML+o.width)+'" y2="'+(MT+o.height-o.sy)+'"/>' : "";
-
-    const hLeftImg  = (o.includeHandles && o.showHeightAxis)
-      ? '<image id="hLeft" class="'+o.classes.handle+'" href="'+(o.icons.vertUrl||'')+'" width="'+HS+'" height="'+HS+'" x="'+(ML-HS/2)+'" y="'+(MT+o.height-o.sy-HS/2)+'"/>' : "";
-    const hDownImg  = (o.includeHandles && o.showLengthAxis)
-      ? '<image id="hDown" class="'+o.classes.handle+'" href="'+(o.icons.horizUrl||'')+'" width="'+HS+'" height="'+HS+'" x="'+(ML+o.sx-HS/2)+'" y="'+(MT+o.height-HS/2)+'"/>' : "";
+    const vLineStr = o.showLengthAxis ? '<line id="vLine" class="' + o.classes.split + '" x1="' + (ML + o.sx) + '" y1="' + MT + '" x2="' + (ML + o.sx) + '" y2="' + (MT + o.height) + '"/>' : "";
+    const hLineStr = o.showHeightAxis ? '<line id="hLine" class="' + o.classes.split + '" x1="' + ML + '" y1="' + (MT + o.height - o.sy) + '" x2="' + (ML + o.width) + '" y2="' + (MT + o.height - o.sy) + '"/>' : "";
+    const hLeftImg = o.includeHandles && o.showHeightAxis ? '<image id="hLeft" class="' + o.classes.handle + '" href="' + (o.icons.vertUrl || '') + '" width="' + HS + '" height="' + HS + '" x="' + (ML - HS / 2) + '" y="' + (MT + o.height - o.sy - HS / 2) + '"/>' : "";
+    const hDownImg = o.includeHandles && o.showLengthAxis ? '<image id="hDown" class="' + o.classes.handle + '" href="' + (o.icons.horizUrl || '') + '" width="' + HS + '" height="' + HS + '" x="' + (ML + o.sx - HS / 2) + '" y="' + (MT + o.height - HS / 2) + '"/>' : "";
 
     // Start på riktig posisjon
-    const hLeftHit  = (o.includeHandles && o.showHeightAxis)
-      ? '<circle id="hLeftHit" class="handleHit" r="'+(HS*0.55)+'" cx="'+(ML)+'" cy="'+(MT+o.height-o.sy)+'" style="cursor:grab"/>' : "";
-    const hDownHit  = (o.includeHandles && o.showLengthAxis)
-      ? '<circle id="hDownHit" class="handleHit" r="'+(HS*0.55)+'" cx="'+(ML+o.sx)+'" cy="'+(MT+o.height)+'" style="cursor:grab"/>' : "";
-
-    const hotLeftStr   = o.showHeightAxis ? '<rect id="hotLeft" class="hot" x="'+(ML-10)+'" y="'+MT+'" width="10" height="'+o.height+'"/>' : "";
-    const hotBottomStr = o.showLengthAxis ? '<rect id="hotBottom" class="hot" x="'+ML+'" y="'+(MT+o.height)+'" width="'+o.width+'" height="10"/>' : "";
-
+    const hLeftHit = o.includeHandles && o.showHeightAxis ? '<circle id="hLeftHit" class="handleHit" r="' + HS * 0.55 + '" cx="' + ML + '" cy="' + (MT + o.height - o.sy) + '" style="cursor:grab"/>' : "";
+    const hDownHit = o.includeHandles && o.showLengthAxis ? '<circle id="hDownHit" class="handleHit" r="' + HS * 0.55 + '" cx="' + (ML + o.sx) + '" cy="' + (MT + o.height) + '" style="cursor:grab"/>' : "";
+    const hotLeftStr = o.showHeightAxis ? '<rect id="hotLeft" class="hot" x="' + (ML - 10) + '" y="' + MT + '" width="10" height="' + o.height + '"/>' : "";
+    const hotBottomStr = o.showLengthAxis ? '<rect id="hotBottom" class="hot" x="' + ML + '" y="' + (MT + o.height) + '" width="' + o.width + '" height="10"/>' : "";
     const parts = [];
     if (includeXmlHeader) parts.push('<?xml version="1.0" encoding="UTF-8"?>');
-    parts.push('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 '+o.vbw+' '+o.vbh+'" width="'+o.vbw+'" height="'+o.vbh+'" tabindex="0">');
+    parts.push('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + o.vbw + ' ' + o.vbh + '" width="' + o.vbw + '" height="' + o.vbh + '" tabindex="0">');
     parts.push('<title>Arealmodell – dragbare delinger</title>');
-    parts.push('<style>'+o.colorsCSS+'</style>');
-    parts.push('<defs><clipPath id="clipR"><rect x="'+ML+'" y="'+MT+'" width="'+o.width+'" height="'+o.height+'"/></clipPath></defs>');
-    parts.push('<rect class="'+o.classes.outer+'" x="'+ML+'" y="'+MT+'" width="'+o.width+'" height="'+o.height+'"/>');
-
-    parts.push('<rect id="rTL" class="cell '+o.classes.cells[0]+'" x="'+ML+'" y="'+MT+'" width="'+o.sx+'" height="'+(o.height-o.sy)+'"></rect>');
-    parts.push('<rect id="rTR" class="cell '+o.classes.cells[1]+'" x="'+(ML+o.sx)+'" y="'+MT+'" width="'+(o.width-o.sx)+'" height="'+(o.height-o.sy)+'"></rect>');
-    parts.push('<rect id="rBL" class="cell '+o.classes.cells[2]+'" x="'+ML+'" y="'+(MT+o.height-o.sy)+'" width="'+o.sx+'" height="'+o.sy+'"></rect>');
-    parts.push('<rect id="rBR" class="cell '+o.classes.cells[3]+'" x="'+(ML+o.sx)+'" y="'+(MT+o.height-o.sy)+'" width="'+(o.width-o.sx)+'" height="'+o.sy+'"></rect>');
-
+    parts.push('<style>' + o.colorsCSS + '</style>');
+    parts.push('<defs><clipPath id="clipR"><rect x="' + ML + '" y="' + MT + '" width="' + o.width + '" height="' + o.height + '"/></clipPath></defs>');
+    parts.push('<rect class="' + o.classes.outer + '" x="' + ML + '" y="' + MT + '" width="' + o.width + '" height="' + o.height + '"/>');
+    parts.push('<rect id="rTL" class="cell ' + o.classes.cells[0] + '" x="' + ML + '" y="' + MT + '" width="' + o.sx + '" height="' + (o.height - o.sy) + '"></rect>');
+    parts.push('<rect id="rTR" class="cell ' + o.classes.cells[1] + '" x="' + (ML + o.sx) + '" y="' + MT + '" width="' + (o.width - o.sx) + '" height="' + (o.height - o.sy) + '"></rect>');
+    parts.push('<rect id="rBL" class="cell ' + o.classes.cells[2] + '" x="' + ML + '" y="' + (MT + o.height - o.sy) + '" width="' + o.sx + '" height="' + o.sy + '"></rect>');
+    parts.push('<rect id="rBR" class="cell ' + o.classes.cells[3] + '" x="' + (ML + o.sx) + '" y="' + (MT + o.height - o.sy) + '" width="' + (o.width - o.sx) + '" height="' + o.sy + '"></rect>');
     parts.push(gridStr);
-
     parts.push(vLineStr, hLineStr, hotLeftStr, hotBottomStr, hLeftImg, hDownImg, hLeftHit, hDownHit);
 
     // cell-tekster
-    parts.push('<text id="tTL" class="labelCell" x="'+(ML+o.sx/2)+'" y="'+(MT+(o.height-o.sy)/2+8)+'" text-anchor="middle">'+(wL)+' · '+(hT)+'</text>');
-    parts.push('<text id="tTR" class="labelCell" x="'+(ML+o.sx+(o.width-o.sx)/2)+'" y="'+(MT+(o.height-o.sy)/2+8)+'" text-anchor="middle">'+(wR)+' · '+(hT)+'</text>');
-    parts.push('<text id="tBL" class="labelCell" x="'+(ML+o.sx/2)+'" y="'+(MT+(o.height-o.sy)+o.sy/2+8)+'" text-anchor="middle">'+(wL)+' · '+(hB)+'</text>');
-    parts.push('<text id="tBR" class="labelCell" x="'+(ML+o.sx+(o.width-o.sx)/2)+'" y="'+(MT+(o.height-o.sy)+o.sy/2+8)+'" text-anchor="middle">'+(wR)+' · '+(hB)+'</text>');
+    parts.push('<text id="tTL" class="labelCell" x="' + (ML + o.sx / 2) + '" y="' + (MT + (o.height - o.sy) / 2 + 8) + '" text-anchor="middle">' + wL + ' · ' + hT + '</text>');
+    parts.push('<text id="tTR" class="labelCell" x="' + (ML + o.sx + (o.width - o.sx) / 2) + '" y="' + (MT + (o.height - o.sy) / 2 + 8) + '" text-anchor="middle">' + wR + ' · ' + hT + '</text>');
+    parts.push('<text id="tBL" class="labelCell" x="' + (ML + o.sx / 2) + '" y="' + (MT + (o.height - o.sy) + o.sy / 2 + 8) + '" text-anchor="middle">' + wL + ' · ' + hB + '</text>');
+    parts.push('<text id="tBR" class="labelCell" x="' + (ML + o.sx + (o.width - o.sx) / 2) + '" y="' + (MT + (o.height - o.sy) + o.sy / 2 + 8) + '" text-anchor="middle">' + wR + ' · ' + hB + '</text>');
 
     // kant-tekst Utenfor, med luft:
-    const xL = ML - (HS/2) - (gapX);
-    const yB = MT + o.height + (HS/2) + (gapY);
+    const xL = ML - HS / 2 - gapX;
+    const yB = MT + o.height + HS / 2 + gapY;
     if (o.showHeightAxis) {
-      parts.push('<text id="leftTop" class="labelEdge" x="'+xL+'" y="'+(MT+(o.height-o.sy)/2+10)+'" text-anchor="end">'+(hT)+'</text>');
-      parts.push('<text id="leftBot" class="labelEdge" x="'+xL+'" y="'+(MT+(o.height-o.sy)+o.sy/2+10)+'" text-anchor="end">'+(hB)+'</text>');
+      parts.push('<text id="leftTop" class="labelEdge" x="' + xL + '" y="' + (MT + (o.height - o.sy) / 2 + 10) + '" text-anchor="end">' + hT + '</text>');
+      parts.push('<text id="leftBot" class="labelEdge" x="' + xL + '" y="' + (MT + (o.height - o.sy) + o.sy / 2 + 10) + '" text-anchor="end">' + hB + '</text>');
     }
     if (o.showLengthAxis) {
-      parts.push('<text id="botLeft"  class="labelEdge" x="'+(ML+o.sx/2)+'" y="'+yB+'" text-anchor="middle">'+(wL)+'</text>');
-      parts.push('<text id="botRight" class="labelEdge" x="'+(ML+o.sx+(o.width-o.sx)/2)+'" y="'+yB+'" text-anchor="middle">'+(wR)+'</text>');
+      parts.push('<text id="botLeft"  class="labelEdge" x="' + (ML + o.sx / 2) + '" y="' + yB + '" text-anchor="middle">' + wL + '</text>');
+      parts.push('<text id="botRight" class="labelEdge" x="' + (ML + o.sx + (o.width - o.sx) / 2) + '" y="' + yB + '" text-anchor="middle">' + wR + '</text>');
     }
-
     parts.push("</svg>");
     return parts.join("\n");
   }
 
   // runtime-skript (eksportert SVG/HTML)
-  function buildRuntimeScriptText(o, rootExpr){
-    const ML = o.margins.ML, MT = o.margins.MT;
-    return [
-      "(function(){",
-      "var UNIT="+o.unit+", ROWS="+o.rows+", COLS="+o.cols+", TEN="+o.TEN+";",
-      "var ML="+ML+", MT="+MT+", W="+o.width+", H="+o.height+";",
-      "var minColsEachSide="+o.limits.minColsEachSide+", minRowsEachSide="+o.limits.minRowsEachSide+";",
-      "var SPLIT_C=\""+o.classes.split.replace(/\"/g,"&quot;")+"\";",
-      "var HS="+(o.handleSize ?? 84)+", GAPX="+(o.edgeGap?.x ?? 14)+", GAPY="+(o.edgeGap?.y ?? 32)+";",
-      "var SAFE="+JSON.stringify(o.safePad || {top:8,right:8,bottom:64,left:8})+";",
-      "var root="+rootExpr+"; root.style.touchAction='none';",
-      "var rTL=document.getElementById('rTL'), rTR=document.getElementById('rTR'), rBL=document.getElementById('rBL'), rBR=document.getElementById('rBR');",
-      "var vLine=document.getElementById('vLine'), hLine=document.getElementById('hLine');",
-      "var tTL=document.getElementById('tTL'), tTR=document.getElementById('tTR'), tBL=document.getElementById('tBL'), tBR=document.getElementById('tBR');",
-      "var leftTop=document.getElementById('leftTop'), leftBot=document.getElementById('leftBot'), botLeft=document.getElementById('botLeft'), botRight=document.getElementById('botRight');",
-      "var hLeft=document.getElementById('hLeft'), hDown=document.getElementById('hDown');",
-      "var hitLeft=document.getElementById('hLeftHit'), hitDown=document.getElementById('hDownHit');",
-      "var hotLeft=document.getElementById('hotLeft'), hotBottom=document.getElementById('hotBottom');",
-      "var vb=root.viewBox.baseVal; var sx="+o.sx+", sy="+o.sy+";",
-      "function set(el,a,v){ if(el) el.setAttribute(a,v); }",
-      "function clamp(v,a,b){ return Math.max(a, Math.min(b, v)); }",
-      "function snap(v){ return Math.round(v/UNIT)*UNIT; }",
-      "var rect=root.getBoundingClientRect(); function refreshRect(){ rect=root.getBoundingClientRect(); }",
-      "function clientToSvg(e){ var sx=vb.width/rect.width, sy=vb.height/rect.height; return { x: vb.x+(e.clientX-rect.left)*sx, y: vb.y+(e.clientY-rect.top)*sy }; }",
-      "var raf=0; function schedule(){ if(raf) return; raf=requestAnimationFrame(function(){ raf=0; redraw(); }); }",
-      "function redraw(){ var wL=Math.round(sx/UNIT), wR=COLS-wL; var hB=Math.round(sy/UNIT), hT=ROWS-hB;",
-      " set(rTL,'x',ML); set(rTL,'y',MT); set(rTL,'width',sx); set(rTL,'height',H-sy);",
-      " set(rTR,'x',ML+sx); set(rTR,'y',MT); set(rTR,'width',W-sx); set(rTR,'height',H-sy);",
-      " set(rBL,'x',ML); set(rBL,'y',MT+(H-sy)); set(rBL,'width',sx); set(rBL,'height',sy);",
-      " set(rBR,'x',ML+sx); set(rBR,'y',MT+(H-sy)); set(rBR,'width',W-sx); set(rBR,'height',sy);",
-      " if(vLine){ set(vLine,'x1',ML+sx); set(vLine,'y1',MT); set(vLine,'x2',ML+sx); set(vLine,'y2',MT+H); }",
-      " if(hLine){ set(hLine,'x1',ML); set(hLine,'y1',MT+(H-sy)); set(hLine,'x2',ML+W); set(hLine,'y2',MT+(H-sy)); }",
-      " var hLeftCX=ML, hLeftCY=MT+(H-sy), hDownCX=ML+sx, hDownCY=MT+H;",
-      " if(hLeft){ set(hLeft,'x',hLeftCX-HS/2); set(hLeft,'y',hLeftCY-HS/2); }",
-      " if(hDown){ set(hDown,'x',hDownCX-HS/2); set(hDown,'y',hDownCY-HS/2); }",
-      " if(hitLeft){ set(hitLeft,'cx',hLeftCX); set(hitLeft,'cy',hLeftCY); }",
-      " if(hitDown){ set(hitDown,'cx',hDownCX); set(hitDown,'cy',hDownCY); }",
-      " var leftXOutside = ML-(HS/2)-GAPX, bottomYOutside = MT+H+(HS/2)+GAPY;",
-      " if(tTL){ set(tTL,'x',ML+sx/2); set(tTL,'y',MT+(H-sy)/2+8); tTL.textContent=wL+' · '+hT; }",
-      " if(tTR){ set(tTR,'x',ML+sx+(W-sx)/2); set(tTR,'y',MT+(H-sy)/2+8); tTR.textContent=wR+' · '+hT; }",
-      " if(tBL){ set(tBL,'x',ML+sx/2); set(tBL,'y',MT+(H-sy)+sy/2+8); tBL.textContent=wL+' · '+hB; }",
-      " if(tBR){ set(tBR,'x',ML+sx+(W-sx)/2); set(tBR,'y',MT+(H-sy)+sy/2+8); tBR.textContent=wR+' · '+hB; }",
-      " if(leftTop){ leftTop.textContent=String(hT); set(leftTop,'x',leftXOutside); set(leftTop,'y',MT+(H-sy)/2+10); }",
-      " if(leftBot){ leftBot.textContent=String(hB); set(leftBot,'x',leftXOutside); set(leftBot,'y',MT+(H-sy)+sy/2+10); }",
-      " if(botLeft){ botLeft.textContent=String(wL); set(botLeft,'x',ML+sx/2); set(botLeft,'y',bottomYOutside); }",
-      " if(botRight){ botRight.textContent=String(wR); set(botRight,'x',ML+sx+(W-sx)/2); set(botRight,'y',bottomYOutside); }",
-      " var on=((wL===TEN||wR===TEN)&&(hB===TEN||hT===TEN));",
-      " if(vLine){ vLine.setAttribute('class',SPLIT_C+(on?' ok':'')); }",
-      " if(hLine){ hLine.setAttribute('class',SPLIT_C+(on?' ok':'')); }",
-      " if(hLeft) root.append(hLeft); if(hitLeft) root.append(hitLeft); if(hDown) root.append(hDown); if(hitDown) root.append(hitDown);",
-      "}",
-      "function fit(){ var availW=Math.max(100, window.innerWidth-(SAFE.left+SAFE.right)); var availH=Math.max(100, window.innerHeight-(SAFE.top+SAFE.bottom)); var s=Math.min(availW/vb.width, availH/vb.height); root.setAttribute('width', vb.width*s); root.setAttribute('height', vb.height*s); refreshRect(); }",
-      "fit(); redraw(); window.addEventListener('resize', fit, {passive:true});",
-      "var active={axis:null,id:null,captor:null}; var justDragged=false; function arm(){ justDragged=true; setTimeout(function(){ justDragged=false; },220); }",
-      "function lock(){ document.documentElement.style.touchAction='none'; document.body.style.touchAction='none'; document.documentElement.style.overscrollBehavior='contain'; document.body.style.overscrollBehavior='contain'; }",
-      "function unlock(){ document.documentElement.style.touchAction=''; document.body.style.touchAction=''; document.documentElement.style.overscrollBehavior=''; document.body.style.overscrollBehavior=''; }",
-      "function onMove(e){ if(e.pointerId!==active.id) return; e.preventDefault(); var p=clientToSvg(e); if(active.axis==='v'){ var y=Math.max(MT+minRowsEachSide*UNIT, Math.min(MT+H-minRowsEachSide*UNIT, p.y)); var n=(MT+H)-y; if(n!==sy){ sy=n; schedule(); } } else if(active.axis==='h'){ var x=Math.max(ML+minColsEachSide*UNIT, Math.min(ML+W-minColsEachSide*UNIT, p.x)); var n=x-ML; if(n!==sx){ sx=n; schedule(); } }}",
-      "function onUp(e){ if(e.pointerId!==active.id) return; e.preventDefault(); if(active.axis==='v') sy=snap(sy); if(active.axis==='h') sx=snap(sx); if(active.captor&&active.captor.releasePointerCapture){try{active.captor.releasePointerCapture(e.pointerId);}catch(_){}} if(active.captor){active.captor.setAttribute('class',(active.captor.getAttribute('class')||'').replace(/\\bdragging\\b/,'').trim());} active.axis=null; active.id=null; active.captor=null; window.removeEventListener('pointermove', onMove); window.removeEventListener('pointerup', onUp); window.removeEventListener('pointercancel', onUp); unlock(); arm(); schedule(); }",
-      "function start(axis,e){ active.axis=axis; active.id=e.pointerId; active.captor=e.currentTarget||e.target; if(active.captor&&active.captor.setPointerCapture){try{active.captor.setPointerCapture(e.pointerId);}catch(_){}} var cls=(active.captor.getAttribute('class')||''); active.captor.setAttribute('class', (cls+' dragging').trim()); lock(); window.addEventListener('pointermove', onMove, {passive:false}); window.addEventListener('pointerup', onUp, {passive:false}); window.addEventListener('pointercancel', onUp, {passive:false}); }",
-      "if(hitLeft){ hitLeft.style.touchAction='none'; hitLeft.addEventListener('pointerdown', function(e){ e.preventDefault(); start('v',e); }, {passive:false}); }",
-      "if(hitDown){ hitDown.style.touchAction='none'; hitDown.addEventListener('pointerdown', function(e){ e.preventDefault(); start('h',e); }, {passive:false}); }",
-      (ADV.clickToMove!==false
-        ? "root.addEventListener('click',function(e){ if(justDragged) return; var p=clientToSvg(e); if(Math.abs(p.x-ML)<12 && p.y>=MT && p.y<=MT+H){ sy=Math.round(((MT+H)-Math.max(MT+minRowsEachSide*UNIT,Math.min(MT+H-minRowsEachSide*UNIT,p.y)))/UNIT)*UNIT; schedule(); } else if(Math.abs(p.y-(MT+H))<12 && p.x>=ML && p.x<=ML+W){ sx=Math.round((Math.max(ML+minColsEachSide*UNIT,Math.min(ML+W-minColsEachSide*UNIT,p.x))-ML)/UNIT)*UNIT; schedule(); } });"
-        : ""),
-      "})();"
-    ].join("\n");
+  function buildRuntimeScriptText(o, rootExpr) {
+    var _o$handleSize2, _o$edgeGap$x2, _o$edgeGap3, _o$edgeGap$y2, _o$edgeGap4;
+    const ML = o.margins.ML,
+      MT = o.margins.MT;
+    return ["(function(){", "var UNIT=" + o.unit + ", ROWS=" + o.rows + ", COLS=" + o.cols + ", TEN=" + o.TEN + ";", "var ML=" + ML + ", MT=" + MT + ", W=" + o.width + ", H=" + o.height + ";", "var minColsEachSide=" + o.limits.minColsEachSide + ", minRowsEachSide=" + o.limits.minRowsEachSide + ";", "var SPLIT_C=\"" + o.classes.split.replace(/\"/g, "&quot;") + "\";", "var HS=" + ((_o$handleSize2 = o.handleSize) !== null && _o$handleSize2 !== void 0 ? _o$handleSize2 : 84) + ", GAPX=" + ((_o$edgeGap$x2 = (_o$edgeGap3 = o.edgeGap) === null || _o$edgeGap3 === void 0 ? void 0 : _o$edgeGap3.x) !== null && _o$edgeGap$x2 !== void 0 ? _o$edgeGap$x2 : 14) + ", GAPY=" + ((_o$edgeGap$y2 = (_o$edgeGap4 = o.edgeGap) === null || _o$edgeGap4 === void 0 ? void 0 : _o$edgeGap4.y) !== null && _o$edgeGap$y2 !== void 0 ? _o$edgeGap$y2 : 32) + ";", "var SAFE=" + JSON.stringify(o.safePad || {
+      top: 8,
+      right: 8,
+      bottom: 64,
+      left: 8
+    }) + ";", "var root=" + rootExpr + "; root.style.touchAction='none';", "var rTL=document.getElementById('rTL'), rTR=document.getElementById('rTR'), rBL=document.getElementById('rBL'), rBR=document.getElementById('rBR');", "var vLine=document.getElementById('vLine'), hLine=document.getElementById('hLine');", "var tTL=document.getElementById('tTL'), tTR=document.getElementById('tTR'), tBL=document.getElementById('tBL'), tBR=document.getElementById('tBR');", "var leftTop=document.getElementById('leftTop'), leftBot=document.getElementById('leftBot'), botLeft=document.getElementById('botLeft'), botRight=document.getElementById('botRight');", "var hLeft=document.getElementById('hLeft'), hDown=document.getElementById('hDown');", "var hitLeft=document.getElementById('hLeftHit'), hitDown=document.getElementById('hDownHit');", "var hotLeft=document.getElementById('hotLeft'), hotBottom=document.getElementById('hotBottom');", "var vb=root.viewBox.baseVal; var sx=" + o.sx + ", sy=" + o.sy + ";", "function set(el,a,v){ if(el) el.setAttribute(a,v); }", "function clamp(v,a,b){ return Math.max(a, Math.min(b, v)); }", "function snap(v){ return Math.round(v/UNIT)*UNIT; }", "var rect=root.getBoundingClientRect(); function refreshRect(){ rect=root.getBoundingClientRect(); }", "function clientToSvg(e){ var sx=vb.width/rect.width, sy=vb.height/rect.height; return { x: vb.x+(e.clientX-rect.left)*sx, y: vb.y+(e.clientY-rect.top)*sy }; }", "var raf=0; function schedule(){ if(raf) return; raf=requestAnimationFrame(function(){ raf=0; redraw(); }); }", "function redraw(){ var wL=Math.round(sx/UNIT), wR=COLS-wL; var hB=Math.round(sy/UNIT), hT=ROWS-hB;", " set(rTL,'x',ML); set(rTL,'y',MT); set(rTL,'width',sx); set(rTL,'height',H-sy);", " set(rTR,'x',ML+sx); set(rTR,'y',MT); set(rTR,'width',W-sx); set(rTR,'height',H-sy);", " set(rBL,'x',ML); set(rBL,'y',MT+(H-sy)); set(rBL,'width',sx); set(rBL,'height',sy);", " set(rBR,'x',ML+sx); set(rBR,'y',MT+(H-sy)); set(rBR,'width',W-sx); set(rBR,'height',sy);", " if(vLine){ set(vLine,'x1',ML+sx); set(vLine,'y1',MT); set(vLine,'x2',ML+sx); set(vLine,'y2',MT+H); }", " if(hLine){ set(hLine,'x1',ML); set(hLine,'y1',MT+(H-sy)); set(hLine,'x2',ML+W); set(hLine,'y2',MT+(H-sy)); }", " var hLeftCX=ML, hLeftCY=MT+(H-sy), hDownCX=ML+sx, hDownCY=MT+H;", " if(hLeft){ set(hLeft,'x',hLeftCX-HS/2); set(hLeft,'y',hLeftCY-HS/2); }", " if(hDown){ set(hDown,'x',hDownCX-HS/2); set(hDown,'y',hDownCY-HS/2); }", " if(hitLeft){ set(hitLeft,'cx',hLeftCX); set(hitLeft,'cy',hLeftCY); }", " if(hitDown){ set(hitDown,'cx',hDownCX); set(hitDown,'cy',hDownCY); }", " var leftXOutside = ML-(HS/2)-GAPX, bottomYOutside = MT+H+(HS/2)+GAPY;", " if(tTL){ set(tTL,'x',ML+sx/2); set(tTL,'y',MT+(H-sy)/2+8); tTL.textContent=wL+' · '+hT; }", " if(tTR){ set(tTR,'x',ML+sx+(W-sx)/2); set(tTR,'y',MT+(H-sy)/2+8); tTR.textContent=wR+' · '+hT; }", " if(tBL){ set(tBL,'x',ML+sx/2); set(tBL,'y',MT+(H-sy)+sy/2+8); tBL.textContent=wL+' · '+hB; }", " if(tBR){ set(tBR,'x',ML+sx+(W-sx)/2); set(tBR,'y',MT+(H-sy)+sy/2+8); tBR.textContent=wR+' · '+hB; }", " if(leftTop){ leftTop.textContent=String(hT); set(leftTop,'x',leftXOutside); set(leftTop,'y',MT+(H-sy)/2+10); }", " if(leftBot){ leftBot.textContent=String(hB); set(leftBot,'x',leftXOutside); set(leftBot,'y',MT+(H-sy)+sy/2+10); }", " if(botLeft){ botLeft.textContent=String(wL); set(botLeft,'x',ML+sx/2); set(botLeft,'y',bottomYOutside); }", " if(botRight){ botRight.textContent=String(wR); set(botRight,'x',ML+sx+(W-sx)/2); set(botRight,'y',bottomYOutside); }", " var on=((wL===TEN||wR===TEN)&&(hB===TEN||hT===TEN));", " if(vLine){ vLine.setAttribute('class',SPLIT_C+(on?' ok':'')); }", " if(hLine){ hLine.setAttribute('class',SPLIT_C+(on?' ok':'')); }", " if(hLeft) root.append(hLeft); if(hitLeft) root.append(hitLeft); if(hDown) root.append(hDown); if(hitDown) root.append(hitDown);", "}", "function fit(){ var availW=Math.max(100, window.innerWidth-(SAFE.left+SAFE.right)); var availH=Math.max(100, window.innerHeight-(SAFE.top+SAFE.bottom)); var s=Math.min(availW/vb.width, availH/vb.height); root.setAttribute('width', vb.width*s); root.setAttribute('height', vb.height*s); refreshRect(); }", "fit(); redraw(); window.addEventListener('resize', fit, {passive:true});", "var active={axis:null,id:null,captor:null}; var justDragged=false; function arm(){ justDragged=true; setTimeout(function(){ justDragged=false; },220); }", "function lock(){ document.documentElement.style.touchAction='none'; document.body.style.touchAction='none'; document.documentElement.style.overscrollBehavior='contain'; document.body.style.overscrollBehavior='contain'; }", "function unlock(){ document.documentElement.style.touchAction=''; document.body.style.touchAction=''; document.documentElement.style.overscrollBehavior=''; document.body.style.overscrollBehavior=''; }", "function onMove(e){ if(e.pointerId!==active.id) return; e.preventDefault(); var p=clientToSvg(e); if(active.axis==='v'){ var y=Math.max(MT+minRowsEachSide*UNIT, Math.min(MT+H-minRowsEachSide*UNIT, p.y)); var n=(MT+H)-y; if(n!==sy){ sy=n; schedule(); } } else if(active.axis==='h'){ var x=Math.max(ML+minColsEachSide*UNIT, Math.min(ML+W-minColsEachSide*UNIT, p.x)); var n=x-ML; if(n!==sx){ sx=n; schedule(); } }}", "function onUp(e){ if(e.pointerId!==active.id) return; e.preventDefault(); if(active.axis==='v') sy=snap(sy); if(active.axis==='h') sx=snap(sx); if(active.captor&&active.captor.releasePointerCapture){try{active.captor.releasePointerCapture(e.pointerId);}catch(_){}} if(active.captor){active.captor.setAttribute('class',(active.captor.getAttribute('class')||'').replace(/\\bdragging\\b/,'').trim());} active.axis=null; active.id=null; active.captor=null; window.removeEventListener('pointermove', onMove); window.removeEventListener('pointerup', onUp); window.removeEventListener('pointercancel', onUp); unlock(); arm(); schedule(); }", "function start(axis,e){ active.axis=axis; active.id=e.pointerId; active.captor=e.currentTarget||e.target; if(active.captor&&active.captor.setPointerCapture){try{active.captor.setPointerCapture(e.pointerId);}catch(_){}} var cls=(active.captor.getAttribute('class')||''); active.captor.setAttribute('class', (cls+' dragging').trim()); lock(); window.addEventListener('pointermove', onMove, {passive:false}); window.addEventListener('pointerup', onUp, {passive:false}); window.addEventListener('pointercancel', onUp, {passive:false}); }", "if(hitLeft){ hitLeft.style.touchAction='none'; hitLeft.addEventListener('pointerdown', function(e){ e.preventDefault(); start('v',e); }, {passive:false}); }", "if(hitDown){ hitDown.style.touchAction='none'; hitDown.addEventListener('pointerdown', function(e){ e.preventDefault(); start('h',e); }, {passive:false}); }", ADV.clickToMove !== false ? "root.addEventListener('click',function(e){ if(justDragged) return; var p=clientToSvg(e); if(Math.abs(p.x-ML)<12 && p.y>=MT && p.y<=MT+H){ sy=Math.round(((MT+H)-Math.max(MT+minRowsEachSide*UNIT,Math.min(MT+H-minRowsEachSide*UNIT,p.y)))/UNIT)*UNIT; schedule(); } else if(Math.abs(p.y-(MT+H))<12 && p.x>=ML && p.x<=ML+W){ sx=Math.round((Math.max(ML+minColsEachSide*UNIT,Math.min(ML+W-minColsEachSide*UNIT,p.x))-ML)/UNIT)*UNIT; schedule(); } });" : "", "})();"].join("\n");
   }
-
-  function buildInteractiveSvgString(o){
+  function buildInteractiveSvgString(o) {
     const svgNoScript = buildBaseSvgMarkup(o, true);
-    const scriptText  = buildRuntimeScriptText(o, "document.documentElement");
-    return svgNoScript.replace("</svg>",
-      "<script><![CDATA[\n" + scriptText + "\n]]>" + "</" + "script>\n</svg>");
+    const scriptText = buildRuntimeScriptText(o, "document.documentElement");
+    return svgNoScript.replace("</svg>", "<script><![CDATA[\n" + scriptText + "\n]]>" + "</" + "script>\n</svg>");
   }
 
   // Selvstendig HTML med interaktiv SVG
-  function buildInteractiveHtmlString(o){
+  function buildInteractiveHtmlString(o) {
     let svgMarkup = buildBaseSvgMarkup(o, false).replace('<svg ', '<svg id="rootSvg" ');
-    const scriptText  = buildRuntimeScriptText(o, "document.getElementById('rootSvg')");
-    const safeScript  = "<script>" + scriptText.replace(/<\/script>/gi, "<\\/script>") + "</" + "script>";
-    const resetCss =
-      "html,body{margin:0;padding:0;height:100%;background:#fff;}" +
-      "body{display:flex;align-items:center;justify-content:center;}";
-
-    return [
-      "<!DOCTYPE html>",
-      "<html lang='no'><head><meta charset='utf-8'/>",
-      "<meta name='viewport' content='width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no'/>",
-      "<title>Arealmodell – interaktiv</title>",
-      "<style>", resetCss, "</style>",
-      "</head><body>",
-      svgMarkup,
-      safeScript,
-      "</body></html>"
-    ].join("");
+    const scriptText = buildRuntimeScriptText(o, "document.getElementById('rootSvg')");
+    const safeScript = "<script>" + scriptText.replace(/<\/script>/gi, "<\\/script>") + "</" + "script>";
+    const resetCss = "html,body{margin:0;padding:0;height:100%;background:#fff;}" + "body{display:flex;align-items:center;justify-content:center;}";
+    return ["<!DOCTYPE html>", "<html lang='no'><head><meta charset='utf-8'/>", "<meta name='viewport' content='width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no'/>", "<title>Arealmodell – interaktiv</title>", "<style>", resetCss, "</style>", "</head><body>", svgMarkup, safeScript, "</body></html>"].join("");
   }
 }
-
-function initFromHtml(){
+function initFromHtml() {
   readConfigFromHtml();
   render();
 }
-
-function setSimpleConfig(o={}){
+function setSimpleConfig(o = {}) {
   ensureCfgDefaults();
-  if(o.height != null) CFG.SIMPLE.height.cells = Math.round(o.height);
-  if(o.length != null) CFG.SIMPLE.length.cells = Math.round(o.length);
-  if(o.heightStart != null) CFG.SIMPLE.height.handle = Math.round(o.heightStart);
-  else if(o.heightHandle != null) CFG.SIMPLE.height.handle = Math.round(o.heightHandle);
-  if(o.lengthStart != null) CFG.SIMPLE.length.handle = Math.round(o.lengthStart);
-  else if(o.lengthHandle != null) CFG.SIMPLE.length.handle = Math.round(o.lengthHandle);
-  if(o.showHeightHandle != null) CFG.SIMPLE.height.showHandle = !!o.showHeightHandle;
-  if(o.showLengthHandle != null) CFG.SIMPLE.length.showHandle = !!o.showLengthHandle;
-  const setVal = (id,v)=>{ const el=document.getElementById(id); if(el && v!=null) el.value=v; };
-  const setChk = (id,v)=>{ const el=document.getElementById(id); if(el) el.checked=!!v; };
+  if (o.height != null) CFG.SIMPLE.height.cells = Math.round(o.height);
+  if (o.length != null) CFG.SIMPLE.length.cells = Math.round(o.length);
+  if (o.heightStart != null) CFG.SIMPLE.height.handle = Math.round(o.heightStart);else if (o.heightHandle != null) CFG.SIMPLE.height.handle = Math.round(o.heightHandle);
+  if (o.lengthStart != null) CFG.SIMPLE.length.handle = Math.round(o.lengthStart);else if (o.lengthHandle != null) CFG.SIMPLE.length.handle = Math.round(o.lengthHandle);
+  if (o.showHeightHandle != null) CFG.SIMPLE.height.showHandle = !!o.showHeightHandle;
+  if (o.showLengthHandle != null) CFG.SIMPLE.length.showHandle = !!o.showLengthHandle;
+  const setVal = (id, v) => {
+    const el = document.getElementById(id);
+    if (el && v != null) el.value = v;
+  };
+  const setChk = (id, v) => {
+    const el = document.getElementById(id);
+    if (el) el.checked = !!v;
+  };
   setVal("length", CFG.SIMPLE.length.cells);
   setVal("lengthStart", CFG.SIMPLE.length.handle);
   setChk("showLengthHandle", CFG.SIMPLE.length.showHandle !== false);
@@ -880,50 +1037,47 @@ function setSimpleConfig(o={}){
   setChk("showHeightHandle", CFG.SIMPLE.height.showHandle !== false);
   render();
 }
-
 window.setArealmodellBConfig = setSimpleConfig;
-
-function applyConfigToInputs(){
+function applyConfigToInputs() {
+  var _simple$length, _simple$length2, _simple$length3, _simple$height, _simple$height2, _simple$height3;
   ensureCfgDefaults();
   const simple = CFG.SIMPLE || {};
   const adv = CFG.ADV || {};
-  const setVal = (id,value)=>{
-    const el=document.getElementById(id);
-    if(!el || value==null) return;
-    const str=String(value);
-    if(el.value!==str) el.value=str;
+  const setVal = (id, value) => {
+    const el = document.getElementById(id);
+    if (!el || value == null) return;
+    const str = String(value);
+    if (el.value !== str) el.value = str;
   };
-  const setChk = (id,value)=>{
-    const el=document.getElementById(id);
-    if(!el) return;
-    const bool=!!value;
-    if(el.checked!==bool) el.checked=bool;
+  const setChk = (id, value) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const bool = !!value;
+    if (el.checked !== bool) el.checked = bool;
   };
-
-  setVal('length', simple.length?.cells);
-  setVal('lengthStart', simple.length?.handle);
-  setChk('showLengthHandle', simple.length?.showHandle !== false);
-  setVal('height', simple.height?.cells);
-  setVal('heightStart', simple.height?.handle);
-  setChk('showHeightHandle', simple.height?.showHandle !== false);
+  setVal('length', (_simple$length = simple.length) === null || _simple$length === void 0 ? void 0 : _simple$length.cells);
+  setVal('lengthStart', (_simple$length2 = simple.length) === null || _simple$length2 === void 0 ? void 0 : _simple$length2.handle);
+  setChk('showLengthHandle', ((_simple$length3 = simple.length) === null || _simple$length3 === void 0 ? void 0 : _simple$length3.showHandle) !== false);
+  setVal('height', (_simple$height = simple.height) === null || _simple$height === void 0 ? void 0 : _simple$height.cells);
+  setVal('heightStart', (_simple$height2 = simple.height) === null || _simple$height2 === void 0 ? void 0 : _simple$height2.handle);
+  setChk('showHeightHandle', ((_simple$height3 = simple.height) === null || _simple$height3 === void 0 ? void 0 : _simple$height3.showHandle) !== false);
   setChk('grid', !!adv.grid);
   setChk('splitLines', adv.splitLines !== false);
 }
-
-function applyExamplesConfig(){
+function applyExamplesConfig() {
   ensureCfgDefaults();
-  if(document.readyState === 'loading'){
-    document.addEventListener('DOMContentLoaded', applyExamplesConfig, {once:true});
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyExamplesConfig, {
+      once: true
+    });
     return;
   }
   applyConfigToInputs();
   draw();
 }
-
-function render(){
+function render() {
   applyExamplesConfig();
 }
-
 window.addEventListener('load', () => {
   initFromHtml();
   document.querySelectorAll('.settings input').forEach(el => {
@@ -931,8 +1085,7 @@ window.addEventListener('load', () => {
     el.addEventListener('input', initFromHtml);
   });
 });
-
-if(typeof window !== 'undefined'){
+if (typeof window !== 'undefined') {
   window.applyConfig = applyExamplesConfig;
   window.applyState = applyExamplesConfig;
   window.render = render;

--- a/brøkfigurer.js
+++ b/brøkfigurer.js
@@ -1,70 +1,76 @@
-(function(){
-  function svgToString(svgEl){
+(function (_colorCountInp$value) {
+  function svgToString(svgEl) {
     const clone = svgEl.cloneNode(true);
     const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
     const style = document.createElement('style');
     style.textContent = css;
     clone.insertBefore(style, clone.firstChild);
-    clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
-    clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
   }
-
-  function downloadSVG(svgEl, filename){
+  function downloadSVG(svgEl, filename) {
     const data = svgToString(svgEl);
-    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const blob = new Blob([data], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
     a.download = filename.endsWith('.svg') ? filename : filename + '.svg';
-    document.body.appendChild(a); a.click(); a.remove();
-    setTimeout(()=>URL.revokeObjectURL(url),1000);
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
-
-  function downloadPNG(svgEl, filename, scale=2, bg='#fff'){
-    const vb = svgEl.viewBox?.baseVal;
-    const w = vb?.width || svgEl.clientWidth || 420;
-    const h = vb?.height|| svgEl.clientHeight || 420;
+  function downloadPNG(svgEl, filename, scale = 2, bg = '#fff') {
+    var _svgEl$viewBox;
+    const vb = (_svgEl$viewBox = svgEl.viewBox) === null || _svgEl$viewBox === void 0 ? void 0 : _svgEl$viewBox.baseVal;
+    const w = (vb === null || vb === void 0 ? void 0 : vb.width) || svgEl.clientWidth || 420;
+    const h = (vb === null || vb === void 0 ? void 0 : vb.height) || svgEl.clientHeight || 420;
     const data = svgToString(svgEl);
-    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
-    const url  = URL.createObjectURL(blob);
+    const blob = new Blob([data], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
+    const url = URL.createObjectURL(blob);
     const img = new Image();
-    img.onload = ()=>{
+    img.onload = () => {
       const canvas = document.createElement('canvas');
-      canvas.width  = Math.round(w * scale);
+      canvas.width = Math.round(w * scale);
       canvas.height = Math.round(h * scale);
       const ctx = canvas.getContext('2d');
       ctx.fillStyle = bg;
-      ctx.fillRect(0,0,canvas.width,canvas.height);
-      ctx.drawImage(img,0,0,canvas.width,canvas.height);
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
       URL.revokeObjectURL(url);
-      canvas.toBlob(blob=>{
+      canvas.toBlob(blob => {
         const urlPng = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = urlPng;
         a.download = filename.endsWith('.png') ? filename : filename + '.png';
-        document.body.appendChild(a); a.click(); a.remove();
-        setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
-      },'image/png');
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(urlPng), 1000);
+      }, 'image/png');
     };
     img.src = url;
   }
-
   const SVG_NS = 'http://www.w3.org/2000/svg';
   const figures = [];
   const BOARD_MARGIN = 0.05;
   const BOARD_SIZE = 1 + BOARD_MARGIN * 2;
   const BOARD_BOUNDING_BOX = [-BOARD_MARGIN, 1 + BOARD_MARGIN, 1 + BOARD_MARGIN, -BOARD_MARGIN];
-  const CLIP_PADDING_PERCENT = (BOARD_MARGIN / BOARD_SIZE) * 100;
+  const CLIP_PADDING_PERCENT = BOARD_MARGIN / BOARD_SIZE * 100;
   const CLIP_PAD_EXTRA_PERCENT = 2;
   const CLIP_PAD_PERCENT = CLIP_PADDING_PERCENT + CLIP_PAD_EXTRA_PERCENT;
   const CIRCLE_RADIUS = 0.45;
   const OUTLINE_STROKE_WIDTH = 6;
   const colorCountInp = document.getElementById('colorCount');
   const colorInputs = [];
-  for(let i=1;;i++){
+  for (let i = 1;; i++) {
     const inp = document.getElementById('color_' + i);
-    if(!inp) break;
+    if (!inp) break;
     colorInputs.push(inp);
   }
   const addBtn = document.getElementById('addFigure');
@@ -77,680 +83,901 @@
     const clamped = Math.max(min, base);
     return max != null ? Math.min(clamped, max) : clamped;
   };
-  const STATE = (window.STATE && typeof window.STATE === 'object') ? window.STATE : {};
+  const STATE = window.STATE && typeof window.STATE === 'object' ? window.STATE : {};
   window.STATE = STATE;
   const modifiedColorIndexes = new Set();
-  if(Array.isArray(STATE.colors)){
-    STATE.colors.forEach((color, idx)=>{
-      if(typeof color === 'string' && color) modifiedColorIndexes.add(idx);
+  if (Array.isArray(STATE.colors)) {
+    STATE.colors.forEach((color, idx) => {
+      if (typeof color === 'string' && color) modifiedColorIndexes.add(idx);
     });
   }
   let autoPaletteEnabled = modifiedColorIndexes.size === 0;
   let lastAppliedPaletteSize = null;
-  if(!STATE.figures || typeof STATE.figures !== 'object') STATE.figures = {};
+  if (!STATE.figures || typeof STATE.figures !== 'object') STATE.figures = {};
   const maxColors = colorInputs.length || 1;
-  const defaultColorCount = clampInt(colorCountInp?.value ?? 1, 1, maxColors);
+  const defaultColorCount = clampInt((_colorCountInp$value = colorCountInp === null || colorCountInp === void 0 ? void 0 : colorCountInp.value) !== null && _colorCountInp$value !== void 0 ? _colorCountInp$value : 1, 1, maxColors);
   const stateColorCount = STATE.colorCount != null ? clampInt(STATE.colorCount, 1, maxColors) : null;
   let colorCount = stateColorCount || defaultColorCount;
   STATE.colorCount = colorCount;
-  function ensureFigureState(id){
+  function ensureFigureState(id) {
     const existing = STATE.figures[id];
-    const fig = (existing && typeof existing === 'object') ? existing : {};
+    const fig = existing && typeof existing === 'object' ? existing : {};
     const shapeEl = document.getElementById(`shape${id}`);
     const partsEl = document.getElementById(`parts${id}`);
     const divisionEl = document.getElementById(`division${id}`);
     const wrongEl = document.getElementById(`allowWrong${id}`);
-    if(shapeEl && fig.shape == null) fig.shape = shapeEl.value;
-    if(partsEl && fig.parts == null){
-      const parsed = parseInt(partsEl.value,10);
+    if (shapeEl && fig.shape == null) fig.shape = shapeEl.value;
+    if (partsEl && fig.parts == null) {
+      const parsed = parseInt(partsEl.value, 10);
       fig.parts = Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
     }
-    if(divisionEl && fig.division == null) fig.division = divisionEl.value;
-    if(wrongEl && typeof fig.allowWrong !== 'boolean') fig.allowWrong = !!wrongEl.checked;
+    if (divisionEl && fig.division == null) fig.division = divisionEl.value;
+    if (wrongEl && typeof fig.allowWrong !== 'boolean') fig.allowWrong = !!wrongEl.checked;
     STATE.figures[id] = fig;
     return fig;
   }
   ensureFigureState(1);
   ensureFigureState(2);
-  if(typeof STATE.figure2Visible !== 'boolean'){
+  if (typeof STATE.figure2Visible !== 'boolean') {
     const panel2 = document.getElementById('panel2');
     STATE.figure2Visible = panel2 ? panel2.style.display !== 'none' : false;
   }
   const DEFAULT_COLOR_SETS = {
-    1:['#6C1BA2'],
-    2:['#BF4474','#534477'],
-    3:['#B25FE3','#6C1BA2','#BF4474'],
-    4:['#B25FE3','#6C1BA2','#534477','#BF4474'],
-    5:['#B25FE3','#6C1BA2','#534477','#873E79','#BF4474'],
-    6:['#B25FE3','#6C1BA2','#534477','#873E79','#BF4474','#E31C3D']
+    1: ['#6C1BA2'],
+    2: ['#BF4474', '#534477'],
+    3: ['#B25FE3', '#6C1BA2', '#BF4474'],
+    4: ['#B25FE3', '#6C1BA2', '#534477', '#BF4474'],
+    5: ['#B25FE3', '#6C1BA2', '#534477', '#873E79', '#BF4474'],
+    6: ['#B25FE3', '#6C1BA2', '#534477', '#873E79', '#BF4474', '#E31C3D']
   };
-  function ensureColorDefaults(count){
+  function ensureColorDefaults(count) {
     const palette = DEFAULT_COLOR_SETS[count] || DEFAULT_COLOR_SETS[maxColors] || ['#6C1BA2'];
     const fillPalette = DEFAULT_COLOR_SETS[maxColors] || palette;
-    if(autoPaletteEnabled){
-      if(lastAppliedPaletteSize !== count || !Array.isArray(STATE.colors)){
+    if (autoPaletteEnabled) {
+      if (lastAppliedPaletteSize !== count || !Array.isArray(STATE.colors)) {
         STATE.colors = palette.slice();
       }
-    }else if(!Array.isArray(STATE.colors)){
+    } else if (!Array.isArray(STATE.colors)) {
       STATE.colors = [];
     }
-    if(!Array.isArray(STATE.colors)) STATE.colors = [];
+    if (!Array.isArray(STATE.colors)) STATE.colors = [];
     const required = Math.max(count, maxColors);
-    for(let i=0;i<required;i++){
+    for (let i = 0; i < required; i++) {
       const withinCount = i < count;
       const source = withinCount ? palette : fillPalette;
       let defaultColor = '#6C1BA2';
-      if(Array.isArray(source) && source.length > 0){
-        defaultColor = source[Math.min(i, source.length - 1)] ?? '#6C1BA2';
-      }else if(Array.isArray(palette) && palette.length > 0){
-        defaultColor = palette[Math.min(withinCount ? i : palette.length - 1, palette.length - 1)] ?? '#6C1BA2';
+      if (Array.isArray(source) && source.length > 0) {
+        var _source$Math$min;
+        defaultColor = (_source$Math$min = source[Math.min(i, source.length - 1)]) !== null && _source$Math$min !== void 0 ? _source$Math$min : '#6C1BA2';
+      } else if (Array.isArray(palette) && palette.length > 0) {
+        var _palette$Math$min;
+        defaultColor = (_palette$Math$min = palette[Math.min(withinCount ? i : palette.length - 1, palette.length - 1)]) !== null && _palette$Math$min !== void 0 ? _palette$Math$min : '#6C1BA2';
       }
       const hasColor = typeof STATE.colors[i] === 'string' && STATE.colors[i];
       const shouldUseDefault = autoPaletteEnabled || !modifiedColorIndexes.has(i);
-      if(shouldUseDefault || !hasColor){
+      if (shouldUseDefault || !hasColor) {
         STATE.colors[i] = defaultColor || '#6C1BA2';
       }
-      if(typeof STATE.colors[i] !== 'string' || !STATE.colors[i]){
+      if (typeof STATE.colors[i] !== 'string' || !STATE.colors[i]) {
         STATE.colors[i] = '#6C1BA2';
       }
     }
-    if(STATE.colors.length > required) STATE.colors.length = required;
+    if (STATE.colors.length > required) STATE.colors.length = required;
     lastAppliedPaletteSize = count;
   }
-  function getColors(){
+  function getColors() {
     ensureColorDefaults(colorCount);
     return STATE.colors.slice(0, colorCount);
   }
-  function updateColorVisibility(){
-    colorInputs.forEach((inp,idx)=>{
+  function updateColorVisibility() {
+    colorInputs.forEach((inp, idx) => {
       inp.style.display = idx < colorCount ? '' : 'none';
     });
   }
-  colorCountInp?.addEventListener('input', ()=>{
+  colorCountInp === null || colorCountInp === void 0 || colorCountInp.addEventListener('input', () => {
+    var _window$render, _window;
     const next = clampInt(colorCountInp.value, 1, maxColors);
-    if(STATE.colorCount !== next){
+    if (STATE.colorCount !== next) {
       STATE.colorCount = next;
     }
     colorCount = STATE.colorCount;
     ensureColorDefaults(colorCount);
-    window.render?.();
+    (_window$render = (_window = window).render) === null || _window$render === void 0 || _window$render.call(_window);
   });
-  colorInputs.forEach((inp, idx)=>inp.addEventListener('input', ()=>{
+  colorInputs.forEach((inp, idx) => inp.addEventListener('input', () => {
+    var _window$render2, _window2;
     modifiedColorIndexes.add(idx);
     autoPaletteEnabled = modifiedColorIndexes.size === 0;
     ensureColorDefaults(Math.max(idx + 1, colorCount));
-    if(!Array.isArray(STATE.colors)) STATE.colors = [];
+    if (!Array.isArray(STATE.colors)) STATE.colors = [];
     STATE.colors[idx] = inp.value;
-    window.render?.();
+    (_window$render2 = (_window2 = window).render) === null || _window$render2 === void 0 || _window$render2.call(_window2);
   }));
-
-  function applyStateToControls(){
+  function applyStateToControls() {
     colorCount = clampInt(STATE.colorCount, 1, maxColors);
     STATE.colorCount = colorCount;
-    if(colorCountInp) colorCountInp.value = String(colorCount);
+    if (colorCountInp) colorCountInp.value = String(colorCount);
     ensureColorDefaults(colorCount);
-    colorInputs.forEach((inp, idx)=>{
+    colorInputs.forEach((inp, idx) => {
       const color = STATE.colors[idx];
-      if(typeof color === 'string') inp.value = color;
+      if (typeof color === 'string') inp.value = color;
     });
-    for(let id=1; id<=2; id++){
+    for (let id = 1; id <= 2; id++) {
       const figState = ensureFigureState(id);
       const shapeSel = document.getElementById(`shape${id}`);
-      if(shapeSel && figState.shape){
+      if (shapeSel && figState.shape) {
         const options = Array.from(shapeSel.options || []);
-        if(options.some(opt=>opt.value === figState.shape)) shapeSel.value = figState.shape;
-        else figState.shape = shapeSel.value;
+        if (options.some(opt => opt.value === figState.shape)) shapeSel.value = figState.shape;else figState.shape = shapeSel.value;
       }
       const partsInp = document.getElementById(`parts${id}`);
       const partsVal = document.getElementById(`partsVal${id}`);
-      if(partsInp){
+      if (partsInp) {
         const parts = clampInt(figState.parts, 1);
         figState.parts = parts;
         partsInp.value = String(parts);
-        if(partsVal) partsVal.textContent = String(parts);
-      }else if(partsVal && figState.parts != null){
+        if (partsVal) partsVal.textContent = String(parts);
+      } else if (partsVal && figState.parts != null) {
         partsVal.textContent = String(figState.parts);
       }
       const divSel = document.getElementById(`division${id}`);
-      if(divSel && figState.division){
+      if (divSel && figState.division) {
         const options = Array.from(divSel.options || []);
-        if(options.some(opt=>opt.value === figState.division)) divSel.value = figState.division;
+        if (options.some(opt => opt.value === figState.division)) divSel.value = figState.division;
       }
       const wrongInp = document.getElementById(`allowWrong${id}`);
-      if(wrongInp && typeof figState.allowWrong === 'boolean') wrongInp.checked = figState.allowWrong;
+      if (wrongInp && typeof figState.allowWrong === 'boolean') wrongInp.checked = figState.allowWrong;
     }
   }
-
-  function applyFigureVisibility(){
+  function applyFigureVisibility() {
     const showSecond = !!STATE.figure2Visible;
-    if(addBtn) addBtn.style.display = showSecond ? 'none' : '';
-    if(fieldset2) fieldset2.style.display = showSecond ? '' : 'none';
-    if(removeBtn2) removeBtn2.style.display = showSecond ? '' : 'none';
-    if(removeBtn1) removeBtn1.style.display = showSecond ? '' : 'none';
+    if (addBtn) addBtn.style.display = showSecond ? 'none' : '';
+    if (fieldset2) fieldset2.style.display = showSecond ? '' : 'none';
+    if (removeBtn2) removeBtn2.style.display = showSecond ? '' : 'none';
+    if (removeBtn1) removeBtn1.style.display = showSecond ? '' : 'none';
     const second = figures[2];
-    if(second){
-      if(second.panel) second.panel.style.display = showSecond ? '' : 'none';
-      if(second.toolbar) second.toolbar.style.display = showSecond ? '' : 'none';
+    if (second) {
+      if (second.panel) second.panel.style.display = showSecond ? '' : 'none';
+      if (second.toolbar) second.toolbar.style.display = showSecond ? '' : 'none';
     }
   }
-
-  function renderAll(){
+  function renderAll() {
     applyStateToControls();
     applyFigureVisibility();
     updateColorVisibility();
-    for(const fig of figures){
-      if(fig && typeof fig.draw === 'function') fig.draw();
+    for (const fig of figures) {
+      if (fig && typeof fig.draw === 'function') fig.draw();
     }
   }
   window.render = renderAll;
-
-  function setupFigure(id){
+  function setupFigure(id) {
     const shapeSel = document.getElementById(`shape${id}`);
     const partsInp = document.getElementById(`parts${id}`);
-    const divSel   = document.getElementById(`division${id}`);
+    const divSel = document.getElementById(`division${id}`);
     const wrongInp = document.getElementById(`allowWrong${id}`);
     const minusBtn = document.getElementById(`partsMinus${id}`);
-    const plusBtn  = document.getElementById(`partsPlus${id}`);
+    const plusBtn = document.getElementById(`partsPlus${id}`);
     const partsVal = document.getElementById(`partsVal${id}`);
-    const btnSvg   = document.getElementById(`btnSvg${id}`);
-    const btnPng   = document.getElementById(`btnPng${id}`);
-    const panel    = document.getElementById(`panel${id}`);
-    const toolbar  = btnSvg?.parentElement;
+    const btnSvg = document.getElementById(`btnSvg${id}`);
+    const btnPng = document.getElementById(`btnPng${id}`);
+    const panel = document.getElementById(`panel${id}`);
+    const toolbar = btnSvg === null || btnSvg === void 0 ? void 0 : btnSvg.parentElement;
     let board;
     let filled = new Map();
-
-    function normalizeFilledEntries(value){
+    function normalizeFilledEntries(value) {
       let iterable;
-      if(value instanceof Map){
+      if (value instanceof Map) {
         iterable = value.entries();
-      }else if(Array.isArray(value)){
+      } else if (Array.isArray(value)) {
         iterable = value;
-      }else if(value && typeof value[Symbol.iterator] === 'function'){
+      } else if (value && typeof value[Symbol.iterator] === 'function') {
         iterable = value;
-      }else if(value && typeof value === 'object'){
+      } else if (value && typeof value === 'object') {
         iterable = Object.entries(value);
-      }else{
+      } else {
         iterable = [];
       }
       const normalized = new Map();
-      for(const entry of iterable){
-        if(entry == null) continue;
+      for (const entry of iterable) {
+        if (entry == null) continue;
         let pair;
-        if(Array.isArray(entry)) pair = entry;
-        else{
-          try{ pair = Array.from(entry); }
-          catch(_){ continue; }
+        if (Array.isArray(entry)) pair = entry;else {
+          try {
+            pair = Array.from(entry);
+          } catch (_) {
+            continue;
+          }
         }
-        if(!Array.isArray(pair) || pair.length < 2) continue;
+        if (!Array.isArray(pair) || pair.length < 2) continue;
         const partIndex = Number.parseInt(pair[0], 10);
         const colorIndex = Number.parseInt(pair[1], 10);
-        if(!Number.isFinite(partIndex) || partIndex < 0) continue;
-        if(!Number.isFinite(colorIndex) || colorIndex <= 0) continue;
+        if (!Number.isFinite(partIndex) || partIndex < 0) continue;
+        if (!Number.isFinite(colorIndex) || colorIndex <= 0) continue;
         normalized.set(partIndex, colorIndex);
       }
       return Array.from(normalized.entries()).sort((a, b) => a[0] - b[0]);
     }
-
-    function syncFilledState(entriesOverride, skipMapUpdate){
+    function syncFilledState(entriesOverride, skipMapUpdate) {
       const figState = ensureFigureState(id);
       const entries = Array.isArray(entriesOverride) ? entriesOverride.slice() : Array.from(filled.entries());
       entries.sort((a, b) => a[0] - b[0]);
-      if(!skipMapUpdate){
+      if (!skipMapUpdate) {
         filled = new Map(entries);
       }
       figState.filled = entries;
     }
-
-    function initBoard(){
-      if(board) JXG.JSXGraph.freeBoard(board);
+    function initBoard() {
+      if (board) JXG.JSXGraph.freeBoard(board);
       board = JXG.JSXGraph.initBoard(`box${id}`, {
-        boundingbox: BOARD_BOUNDING_BOX, axis:false, showCopyright:false,
-        showNavigation:false, keepaspectratio:true
+        boundingbox: BOARD_BOUNDING_BOX,
+        axis: false,
+        showCopyright: false,
+        showNavigation: false,
+        keepaspectratio: true
       });
     }
-
-    function disableHitDetection(element){
-      if(element && typeof element.hasPoint === 'function'){
+    function disableHitDetection(element) {
+      if (element && typeof element.hasPoint === 'function') {
         element.hasPoint = () => false;
       }
     }
-
-    function togglePart(i, element){
+    function togglePart(i, element) {
       const colors = getColors();
       const current = filled.get(i) || 0;
       const next = (current + 1) % (colors.length + 1);
-      if(next===0){
+      if (next === 0) {
         filled.delete(i);
-        element.setAttribute({fillColor:'#fff', fillOpacity:1});
-      }else{
-        filled.set(i,next);
-        element.setAttribute({fillColor:colors[next-1], fillOpacity:1});
+        element.setAttribute({
+          fillColor: '#fff',
+          fillOpacity: 1
+        });
+      } else {
+        filled.set(i, next);
+        element.setAttribute({
+          fillColor: colors[next - 1],
+          fillOpacity: 1
+        });
       }
       board.update();
       syncFilledState();
     }
-
-    function gridDims(n){
+    function gridDims(n) {
       let cols = Math.floor(Math.sqrt(n));
-      while(n % cols !== 0) cols--;
+      while (n % cols !== 0) cols--;
       const rows = n / cols;
-      return {rows, cols};
+      return {
+        rows,
+        cols
+      };
     }
-
-    function hasProperFactor(n){
-      if(n < 4) return false;
-      for(let i=2;i*i<=n;i++){
-        if(n % i === 0) return true;
+    function hasProperFactor(n) {
+      if (n < 4) return false;
+      for (let i = 2; i * i <= n; i++) {
+        if (n % i === 0) return true;
       }
       return false;
     }
-
-    function draw(){
-      if(panel.style.display==='none') return;
+    function draw() {
+      var _ref, _partsInp$value, _wrongInp$checked, _wrongInp$checked2;
+      if (panel.style.display === 'none') return;
       const figState = ensureFigureState(id);
       setFilled(figState.filled);
       initBoard();
-      let n = clampInt(partsInp?.value ?? figState.parts ?? 1, 1);
-      const shape = shapeSel?.value || figState.shape || 'rectangle';
-      let division = divSel?.value || figState.division || 'horizontal';
-      const allowWrong = wrongInp?.checked ?? !!figState.allowWrong;
-      if((shape==='rectangle' || shape==='square') && division==='diagonal') n = 4;
-      const gridOpt = divSel?.querySelector('option[value="grid"]');
-      const vertOpt = divSel?.querySelector('option[value="vertical"]');
-      const triOpt  = divSel?.querySelector('option[value="triangular"]');
-      if(gridOpt){
-        gridOpt.hidden = !hasProperFactor(n) || (shape==='circle' && !allowWrong) || (shape==='triangle');
-        if(gridOpt.hidden && division==='grid') divSel.value = 'horizontal';
+      let n = clampInt((_ref = (_partsInp$value = partsInp === null || partsInp === void 0 ? void 0 : partsInp.value) !== null && _partsInp$value !== void 0 ? _partsInp$value : figState.parts) !== null && _ref !== void 0 ? _ref : 1, 1);
+      const shape = (shapeSel === null || shapeSel === void 0 ? void 0 : shapeSel.value) || figState.shape || 'rectangle';
+      let division = (divSel === null || divSel === void 0 ? void 0 : divSel.value) || figState.division || 'horizontal';
+      const allowWrong = (_wrongInp$checked = wrongInp === null || wrongInp === void 0 ? void 0 : wrongInp.checked) !== null && _wrongInp$checked !== void 0 ? _wrongInp$checked : !!figState.allowWrong;
+      if ((shape === 'rectangle' || shape === 'square') && division === 'diagonal') n = 4;
+      const gridOpt = divSel === null || divSel === void 0 ? void 0 : divSel.querySelector('option[value="grid"]');
+      const vertOpt = divSel === null || divSel === void 0 ? void 0 : divSel.querySelector('option[value="vertical"]');
+      const triOpt = divSel === null || divSel === void 0 ? void 0 : divSel.querySelector('option[value="triangular"]');
+      if (gridOpt) {
+        gridOpt.hidden = !hasProperFactor(n) || shape === 'circle' && !allowWrong || shape === 'triangle';
+        if (gridOpt.hidden && division === 'grid') divSel.value = 'horizontal';
       }
-      if(vertOpt){
-        vertOpt.hidden = (shape==='circle' && !allowWrong);
-        if(vertOpt.hidden && division==='vertical') divSel.value = 'horizontal';
+      if (vertOpt) {
+        vertOpt.hidden = shape === 'circle' && !allowWrong;
+        if (vertOpt.hidden && division === 'vertical') divSel.value = 'horizontal';
       }
-      if(triOpt){
-        triOpt.hidden = (shape!=='triangle');
-        if(triOpt.hidden && division==='triangular') divSel.value = 'horizontal';
+      if (triOpt) {
+        triOpt.hidden = shape !== 'triangle';
+        if (triOpt.hidden && division === 'triangular') divSel.value = 'horizontal';
       }
-      division = divSel?.value || division;
-      if(shape==='triangle' && division==='triangular'){
+      division = (divSel === null || divSel === void 0 ? void 0 : divSel.value) || division;
+      if (shape === 'triangle' && division === 'triangular') {
         const m = Math.max(1, Math.round(Math.sqrt(n)));
-        n = m*m;
+        n = m * m;
       }
-      if(partsInp) partsInp.value = String(n);
-      if(partsVal) partsVal.textContent = String(n);
+      if (partsInp) partsInp.value = String(n);
+      if (partsVal) partsVal.textContent = String(n);
       figState.parts = n;
-      figState.shape = shapeSel?.value || shape;
+      figState.shape = (shapeSel === null || shapeSel === void 0 ? void 0 : shapeSel.value) || shape;
       figState.division = division;
-      figState.allowWrong = !!(wrongInp?.checked ?? allowWrong);
+      figState.allowWrong = !!((_wrongInp$checked2 = wrongInp === null || wrongInp === void 0 ? void 0 : wrongInp.checked) !== null && _wrongInp$checked2 !== void 0 ? _wrongInp$checked2 : allowWrong);
       const colors = getColors();
       const colorFor = idx => {
         const c = filled.get(idx);
-        return c ? colors[c-1] || '#fff' : '#fff';
+        return c ? colors[c - 1] || '#fff' : '#fff';
       };
-      if(shape==='circle') drawCircle(n, division, allowWrong, colorFor);
-      else if(shape==='rectangle' || shape==='square') drawRect(n, division, colorFor);
-      else drawTriangle(n, division, allowWrong, colorFor);
+      if (shape === 'circle') drawCircle(n, division, allowWrong, colorFor);else if (shape === 'rectangle' || shape === 'square') drawRect(n, division, colorFor);else drawTriangle(n, division, allowWrong, colorFor);
       applyClip(shape, division);
     }
-
-    function drawCircle(n, division, allowWrong, colorFor){
+    function drawCircle(n, division, allowWrong, colorFor) {
       const r = CIRCLE_RADIUS;
-      const cx = 0.5, cy = 0.5;
-      const pointOpts = {visible:false, fixed:true, name:'', label:{visible:false}};
-      if(allowWrong && (division==='vertical' || division==='horizontal' || division==='grid')){
-        let rows=1, cols=n;
-        if(division==='horizontal'){ rows=n; cols=1; }
-        else if(division==='grid'){ const d=gridDims(n); rows=d.rows; cols=d.cols; }
-        for(let rIdx=0;rIdx<rows;rIdx++){
-          for(let cIdx=0;cIdx<cols;cIdx++){
-            const idx=rIdx*cols+cIdx;
-            const x1=cIdx/cols, x2=(cIdx+1)/cols;
-            const y1=rIdx/rows, y2=(rIdx+1)/rows;
-            const poly=board.create('polygon', [[x1,y1],[x2,y1],[x2,y2],[x1,y2]], {
-              borders:{strokeColor:'#fff', strokeWidth:6},
-              vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+      const cx = 0.5,
+        cy = 0.5;
+      const pointOpts = {
+        visible: false,
+        fixed: true,
+        name: '',
+        label: {
+          visible: false
+        }
+      };
+      if (allowWrong && (division === 'vertical' || division === 'horizontal' || division === 'grid')) {
+        let rows = 1,
+          cols = n;
+        if (division === 'horizontal') {
+          rows = n;
+          cols = 1;
+        } else if (division === 'grid') {
+          const d = gridDims(n);
+          rows = d.rows;
+          cols = d.cols;
+        }
+        for (let rIdx = 0; rIdx < rows; rIdx++) {
+          for (let cIdx = 0; cIdx < cols; cIdx++) {
+            const idx = rIdx * cols + cIdx;
+            const x1 = cIdx / cols,
+              x2 = (cIdx + 1) / cols;
+            const y1 = rIdx / rows,
+              y2 = (rIdx + 1) / rows;
+            const poly = board.create('polygon', [[x1, y1], [x2, y1], [x2, y2], [x1, y2]], {
+              borders: {
+                strokeColor: '#fff',
+                strokeWidth: 6
+              },
+              vertices: {
+                visible: false,
+                name: '',
+                fixed: true,
+                label: {
+                  visible: false
+                }
+              },
               fillColor: colorFor(idx),
-              fillOpacity:1,
-              highlight:false,
-              hasInnerPoints:true,
-              fixed:true
+              fillOpacity: 1,
+              highlight: false,
+              hasInnerPoints: true,
+              fixed: true
             });
             poly.on('down', () => togglePart(idx, poly));
           }
         }
-        for(let i=1;i<cols;i++){
-          const x=i/cols;
-          const seg = board.create('segment', [[x,0],[x,1]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
+        for (let i = 1; i < cols; i++) {
+          const x = i / cols;
+          const seg = board.create('segment', [[x, 0], [x, 1]], {
+            strokeColor: '#000',
+            strokeWidth: 2,
+            dash: 2,
+            highlight: false,
+            fixed: true,
+            cssStyle: 'pointer-events:none;'
+          });
           disableHitDetection(seg);
         }
-        for(let j=1;j<rows;j++){
-          const y=j/rows;
-          const seg = board.create('segment', [[0,y],[1,y]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
+        for (let j = 1; j < rows; j++) {
+          const y = j / rows;
+          const seg = board.create('segment', [[0, y], [1, y]], {
+            strokeColor: '#000',
+            strokeWidth: 2,
+            dash: 2,
+            highlight: false,
+            fixed: true,
+            cssStyle: 'pointer-events:none;'
+          });
           disableHitDetection(seg);
         }
-        board.create('circle', [[cx,cy], r], {
-          strokeColor:'#333', strokeWidth:OUTLINE_STROKE_WIDTH, fillColor:'none', highlight:false,
-          fixed:true, hasInnerPoints:false,
-          cssStyle:'pointer-events:none;'
+        board.create('circle', [[cx, cy], r], {
+          strokeColor: '#333',
+          strokeWidth: OUTLINE_STROKE_WIDTH,
+          fillColor: 'none',
+          highlight: false,
+          fixed: true,
+          hasInnerPoints: false,
+          cssStyle: 'pointer-events:none;'
         });
-      }else{
-        const center = board.create('point', [cx,cy], pointOpts);
+      } else {
+        const center = board.create('point', [cx, cy], pointOpts);
         const boundaryPts = [];
-        for(let i=0;i<n;i++){
-          const a1 = 2*Math.PI*i/n;
-          const a2 = 2*Math.PI*(i+1)/n;
-          const p1 = board.create('point', [cx + r*Math.cos(a1), cy + r*Math.sin(a1)], pointOpts);
-          const p2 = board.create('point', [cx + r*Math.cos(a2), cy + r*Math.sin(a2)], pointOpts);
+        for (let i = 0; i < n; i++) {
+          const a1 = 2 * Math.PI * i / n;
+          const a2 = 2 * Math.PI * (i + 1) / n;
+          const p1 = board.create('point', [cx + r * Math.cos(a1), cy + r * Math.sin(a1)], pointOpts);
+          const p2 = board.create('point', [cx + r * Math.cos(a2), cy + r * Math.sin(a2)], pointOpts);
           boundaryPts.push(p1);
-            const sector = board.create('sector', [center, p1, p2], {
-              withLines:true,
-              strokeColor:'#fff',
-              strokeWidth:6,
-              fillColor: colorFor(i),
-              fillOpacity:1,
-              highlight:false,
-              hasInnerPoints:true,
-              fixed:true
+          const sector = board.create('sector', [center, p1, p2], {
+            withLines: true,
+            strokeColor: '#fff',
+            strokeWidth: 6,
+            fillColor: colorFor(i),
+            fillOpacity: 1,
+            highlight: false,
+            hasInnerPoints: true,
+            fixed: true
           });
           sector.on('down', () => togglePart(i, sector));
         }
-        for(const p of boundaryPts){
+        for (const p of boundaryPts) {
           const seg = board.create('segment', [center, p], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+            strokeColor: '#000',
+            strokeWidth: 2,
+            dash: 2,
+            highlight: false,
+            fixed: true,
+            cssStyle: 'pointer-events:none;'
           });
           disableHitDetection(seg);
         }
         board.create('circle', [center, r], {
-          strokeColor:'#333', strokeWidth:OUTLINE_STROKE_WIDTH, fillColor:'none', highlight:false,
-          fixed:true, hasInnerPoints:false,
-          cssStyle:'pointer-events:none;'
+          strokeColor: '#333',
+          strokeWidth: OUTLINE_STROKE_WIDTH,
+          fillColor: 'none',
+          highlight: false,
+          fixed: true,
+          hasInnerPoints: false,
+          cssStyle: 'pointer-events:none;'
         });
       }
     }
-
-    function drawRect(n, division, colorFor){
-      if(division==='diagonal'){
-        const c = [0.5,0.5];
-        const corners = [[0,0],[1,0],[1,1],[0,1]];
-        for(let i=0;i<4;i++){
-          const pts = [corners[i], corners[(i+1)%4], c];
+    function drawRect(n, division, colorFor) {
+      if (division === 'diagonal') {
+        const c = [0.5, 0.5];
+        const corners = [[0, 0], [1, 0], [1, 1], [0, 1]];
+        for (let i = 0; i < 4; i++) {
+          const pts = [corners[i], corners[(i + 1) % 4], c];
           const poly = board.create('polygon', pts, {
-            borders:{strokeColor:'#fff', strokeWidth:6},
-            vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+            borders: {
+              strokeColor: '#fff',
+              strokeWidth: 6
+            },
+            vertices: {
+              visible: false,
+              name: '',
+              fixed: true,
+              label: {
+                visible: false
+              }
+            },
             fillColor: colorFor(i),
-            fillOpacity:1,
-            highlight:false,
-            hasInnerPoints:true,
-            fixed:true
+            fillOpacity: 1,
+            highlight: false,
+            hasInnerPoints: true,
+            fixed: true
           });
           poly.on('down', () => togglePart(i, poly));
           const seg = board.create('segment', [c, corners[i]], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+            strokeColor: '#000',
+            strokeWidth: 2,
+            dash: 2,
+            highlight: false,
+            fixed: true,
+            cssStyle: 'pointer-events:none;'
           });
           disableHitDetection(seg);
         }
-      }else if(division==='grid'){
-        const {rows, cols} = gridDims(n);
-        for(let rIdx=0;rIdx<rows;rIdx++){
-          for(let cIdx=0;cIdx<cols;cIdx++){
-            const idx=rIdx*cols+cIdx;
-            const x1=cIdx/cols, x2=(cIdx+1)/cols;
-            const y1=rIdx/rows, y2=(rIdx+1)/rows;
-            const pts=[[x1,y1],[x2,y1],[x2,y2],[x1,y2]];
-            const poly=board.create('polygon', pts, {
-              borders:{strokeColor:'#fff', strokeWidth:6},
-              vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+      } else if (division === 'grid') {
+        const {
+          rows,
+          cols
+        } = gridDims(n);
+        for (let rIdx = 0; rIdx < rows; rIdx++) {
+          for (let cIdx = 0; cIdx < cols; cIdx++) {
+            const idx = rIdx * cols + cIdx;
+            const x1 = cIdx / cols,
+              x2 = (cIdx + 1) / cols;
+            const y1 = rIdx / rows,
+              y2 = (rIdx + 1) / rows;
+            const pts = [[x1, y1], [x2, y1], [x2, y2], [x1, y2]];
+            const poly = board.create('polygon', pts, {
+              borders: {
+                strokeColor: '#fff',
+                strokeWidth: 6
+              },
+              vertices: {
+                visible: false,
+                name: '',
+                fixed: true,
+                label: {
+                  visible: false
+                }
+              },
               fillColor: colorFor(idx),
-              fillOpacity:1,
-              highlight:false,
-              hasInnerPoints:true,
-              fixed:true
+              fillOpacity: 1,
+              highlight: false,
+              hasInnerPoints: true,
+              fixed: true
             });
             poly.on('down', () => togglePart(idx, poly));
           }
         }
-        for(let i=1;i<cols;i++){
-          const x=i/cols;
-          const seg = board.create('segment', [[x,0],[x,1]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
+        for (let i = 1; i < cols; i++) {
+          const x = i / cols;
+          const seg = board.create('segment', [[x, 0], [x, 1]], {
+            strokeColor: '#000',
+            strokeWidth: 2,
+            dash: 2,
+            highlight: false,
+            fixed: true,
+            cssStyle: 'pointer-events:none;'
+          });
           disableHitDetection(seg);
         }
-        for(let j=1;j<rows;j++){
-          const y=j/rows;
-          const seg = board.create('segment', [[0,y],[1,y]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
+        for (let j = 1; j < rows; j++) {
+          const y = j / rows;
+          const seg = board.create('segment', [[0, y], [1, y]], {
+            strokeColor: '#000',
+            strokeWidth: 2,
+            dash: 2,
+            highlight: false,
+            fixed: true,
+            cssStyle: 'pointer-events:none;'
+          });
           disableHitDetection(seg);
         }
-      }else{
-        for(let i=0;i<n;i++){
+      } else {
+        for (let i = 0; i < n; i++) {
           let pts;
-          if(division==='vertical'){
-            const x1 = i/n, x2 = (i+1)/n;
-            pts = [[x1,0],[x2,0],[x2,1],[x1,1]];
-          }else{ // horizontal
-            const y1 = i/n, y2 = (i+1)/n;
-            pts = [[0,y1],[1,y1],[1,y2],[0,y2]];
+          if (division === 'vertical') {
+            const x1 = i / n,
+              x2 = (i + 1) / n;
+            pts = [[x1, 0], [x2, 0], [x2, 1], [x1, 1]];
+          } else {
+            // horizontal
+            const y1 = i / n,
+              y2 = (i + 1) / n;
+            pts = [[0, y1], [1, y1], [1, y2], [0, y2]];
           }
           const poly = board.create('polygon', pts, {
-            borders:{strokeColor:'#fff', strokeWidth:6},
-            vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+            borders: {
+              strokeColor: '#fff',
+              strokeWidth: 6
+            },
+            vertices: {
+              visible: false,
+              name: '',
+              fixed: true,
+              label: {
+                visible: false
+              }
+            },
             fillColor: colorFor(i),
-            fillOpacity:1,
-            highlight:false,
-            hasInnerPoints:true,
-            fixed:true
+            fillOpacity: 1,
+            highlight: false,
+            hasInnerPoints: true,
+            fixed: true
           });
           poly.on('down', () => togglePart(i, poly));
         }
-        for(let i=1;i<n;i++){
-          if(division==='vertical'){
-            const x=i/n;
-            const seg = board.create('segment', [[x,0],[x,1]], {
-              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+        for (let i = 1; i < n; i++) {
+          if (division === 'vertical') {
+            const x = i / n;
+            const seg = board.create('segment', [[x, 0], [x, 1]], {
+              strokeColor: '#000',
+              strokeWidth: 2,
+              dash: 2,
+              highlight: false,
+              fixed: true,
+              cssStyle: 'pointer-events:none;'
             });
             disableHitDetection(seg);
-          }else{
-            const y=i/n;
-            const seg = board.create('segment', [[0,y],[1,y]], {
-              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+          } else {
+            const y = i / n;
+            const seg = board.create('segment', [[0, y], [1, y]], {
+              strokeColor: '#000',
+              strokeWidth: 2,
+              dash: 2,
+              highlight: false,
+              fixed: true,
+              cssStyle: 'pointer-events:none;'
             });
             disableHitDetection(seg);
           }
         }
       }
-      board.create('polygon', [[0,0],[1,0],[1,1],[0,1]], {
-        borders:{strokeColor:'#333', strokeWidth:6},
-        vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
-        fillColor:'none',
-        highlight:false,
-        fixed:true,
-        hasInnerPoints:false,
-        cssStyle:'pointer-events:none;'
+      board.create('polygon', [[0, 0], [1, 0], [1, 1], [0, 1]], {
+        borders: {
+          strokeColor: '#333',
+          strokeWidth: 6
+        },
+        vertices: {
+          visible: false,
+          name: '',
+          fixed: true,
+          label: {
+            visible: false
+          }
+        },
+        fillColor: 'none',
+        highlight: false,
+        fixed: true,
+        hasInnerPoints: false,
+        cssStyle: 'pointer-events:none;'
       });
     }
-
-    function drawTriangle(n, division, allowWrong, colorFor){
+    function drawTriangle(n, division, allowWrong, colorFor) {
       const h = Math.sqrt(3) / 2;
       const toEq = ([x, y]) => [x + 0.5 * y, y * h];
       const toEqTri = ([x, y]) => [x, (1 - y) * h];
-
-      if(division==='triangular'){
+      if (division === 'triangular') {
         const m = Math.round(Math.sqrt(n));
-        const rows=[];
-        for(let r=0;r<=m;r++){
-          const y=r/m;
-          const xStart=0.5 - r/(2*m);
-          const row=[];
-          for(let c=0;c<=r;c++){
-            row.push(toEqTri([xStart + c/m, y]));
+        const rows = [];
+        for (let r = 0; r <= m; r++) {
+          const y = r / m;
+          const xStart = 0.5 - r / (2 * m);
+          const row = [];
+          for (let c = 0; c <= r; c++) {
+            row.push(toEqTri([xStart + c / m, y]));
           }
           rows.push(row);
         }
-        let idx=0;
-        for(let r=1;r<=m;r++){
-          for(let c=0;c<r;c++){
-            const pts=[rows[r][c], rows[r][c+1], rows[r-1][c]];
-            const poly=board.create('polygon', pts, {
-              borders:{strokeColor:'#fff', strokeWidth:6},
-              vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+        let idx = 0;
+        for (let r = 1; r <= m; r++) {
+          for (let c = 0; c < r; c++) {
+            const pts = [rows[r][c], rows[r][c + 1], rows[r - 1][c]];
+            const poly = board.create('polygon', pts, {
+              borders: {
+                strokeColor: '#fff',
+                strokeWidth: 6
+              },
+              vertices: {
+                visible: false,
+                name: '',
+                fixed: true,
+                label: {
+                  visible: false
+                }
+              },
               fillColor: colorFor(idx),
-              fillOpacity:1,
-              highlight:false,
-              hasInnerPoints:true,
-              fixed:true
+              fillOpacity: 1,
+              highlight: false,
+              hasInnerPoints: true,
+              fixed: true
             });
             poly.on('down', () => togglePart(idx, poly));
             idx++;
           }
         }
-        for(let r=0;r<m;r++){
-          for(let c=0;c<rows[r].length-1;c++){
-            const pts=[rows[r][c], rows[r][c+1], rows[r+1][c+1]];
-            const poly=board.create('polygon', pts, {
-              borders:{strokeColor:'#fff', strokeWidth:6},
-              vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+        for (let r = 0; r < m; r++) {
+          for (let c = 0; c < rows[r].length - 1; c++) {
+            const pts = [rows[r][c], rows[r][c + 1], rows[r + 1][c + 1]];
+            const poly = board.create('polygon', pts, {
+              borders: {
+                strokeColor: '#fff',
+                strokeWidth: 6
+              },
+              vertices: {
+                visible: false,
+                name: '',
+                fixed: true,
+                label: {
+                  visible: false
+                }
+              },
               fillColor: colorFor(idx),
-              fillOpacity:1,
-              highlight:false,
-              hasInnerPoints:true,
-              fixed:true
+              fillOpacity: 1,
+              highlight: false,
+              hasInnerPoints: true,
+              fixed: true
             });
             poly.on('down', () => togglePart(idx, poly));
             idx++;
           }
         }
-        for(let r=1;r<m;r++){
+        for (let r = 1; r < m; r++) {
           const seg1 = board.create('segment', [rows[r][0], rows[r][r]], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+            strokeColor: '#000',
+            strokeWidth: 2,
+            dash: 2,
+            highlight: false,
+            fixed: true,
+            cssStyle: 'pointer-events:none;'
           });
           disableHitDetection(seg1);
           const seg2 = board.create('segment', [rows[r][0], rows[m][r]], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+            strokeColor: '#000',
+            strokeWidth: 2,
+            dash: 2,
+            highlight: false,
+            fixed: true,
+            cssStyle: 'pointer-events:none;'
           });
           disableHitDetection(seg2);
-          const seg3 = board.create('segment', [rows[r][r], rows[m][m-r]], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+          const seg3 = board.create('segment', [rows[r][r], rows[m][m - r]], {
+            strokeColor: '#000',
+            strokeWidth: 2,
+            dash: 2,
+            highlight: false,
+            fixed: true,
+            cssStyle: 'pointer-events:none;'
           });
           disableHitDetection(seg3);
         }
-        board.create('polygon', [toEqTri([0,1]), toEqTri([1,1]), toEqTri([0.5,0])], {
-          borders:{strokeColor:'#333', strokeWidth:6},
-          vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
-          fillColor:'none',
-          highlight:false,
-          fixed:true,
-          hasInnerPoints:false,
-          cssStyle:'pointer-events:none;'
+        board.create('polygon', [toEqTri([0, 1]), toEqTri([1, 1]), toEqTri([0.5, 0])], {
+          borders: {
+            strokeColor: '#333',
+            strokeWidth: 6
+          },
+          vertices: {
+            visible: false,
+            name: '',
+            fixed: true,
+            label: {
+              visible: false
+            }
+          },
+          fillColor: 'none',
+          highlight: false,
+          fixed: true,
+          hasInnerPoints: false,
+          cssStyle: 'pointer-events:none;'
         });
         return;
       }
-      for(let i=0;i<n;i++){
+      for (let i = 0; i < n; i++) {
         let pts;
-        if(division==='vertical'){
-          const x1=i/n, x2=(i+1)/n;
-          if(allowWrong){
-            pts=[[x1,0],[x2,0],[x2,1-x2],[x1,1-x1]];
-          }else{
-            pts=[[x1,0],[x2,0],[0,1]];
+        if (division === 'vertical') {
+          const x1 = i / n,
+            x2 = (i + 1) / n;
+          if (allowWrong) {
+            pts = [[x1, 0], [x2, 0], [x2, 1 - x2], [x1, 1 - x1]];
+          } else {
+            pts = [[x1, 0], [x2, 0], [0, 1]];
           }
-        }else if(division==='horizontal'){
-          const y1=i/n, y2=(i+1)/n;
-          if(allowWrong){
-            pts=[[0,y1],[1-y1,y1],[1-y2,y2],[0,y2]];
-          }else{
-            pts=[[0,y1],[0,y2],[1,0]];
+        } else if (division === 'horizontal') {
+          const y1 = i / n,
+            y2 = (i + 1) / n;
+          if (allowWrong) {
+            pts = [[0, y1], [1 - y1, y1], [1 - y2, y2], [0, y2]];
+          } else {
+            pts = [[0, y1], [0, y2], [1, 0]];
           }
-        }else{ // diagonal
-          const t1=i/n, t2=(i+1)/n;
-          pts=[[1-t1,t1],[1-t2,t2],[0,0]];
+        } else {
+          // diagonal
+          const t1 = i / n,
+            t2 = (i + 1) / n;
+          pts = [[1 - t1, t1], [1 - t2, t2], [0, 0]];
         }
         pts = pts.map(toEq);
         const poly = board.create('polygon', pts, {
-          borders:{strokeColor:'#fff', strokeWidth:6},
-          vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+          borders: {
+            strokeColor: '#fff',
+            strokeWidth: 6
+          },
+          vertices: {
+            visible: false,
+            name: '',
+            fixed: true,
+            label: {
+              visible: false
+            }
+          },
           fillColor: colorFor(i),
-          fillOpacity:1,
-          highlight:false,
-          hasInnerPoints:true,
-          fixed:true
+          fillOpacity: 1,
+          highlight: false,
+          hasInnerPoints: true,
+          fixed: true
         });
         poly.on('down', () => togglePart(i, poly));
       }
-      if(division==='vertical'){
-        for(let i=1;i<n;i++){
-          const x=i/n;
-          if(allowWrong){
-            const seg = board.create('segment', [toEq([x,0]), toEq([x,1-x])], {
-              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+      if (division === 'vertical') {
+        for (let i = 1; i < n; i++) {
+          const x = i / n;
+          if (allowWrong) {
+            const seg = board.create('segment', [toEq([x, 0]), toEq([x, 1 - x])], {
+              strokeColor: '#000',
+              strokeWidth: 2,
+              dash: 2,
+              highlight: false,
+              fixed: true,
+              cssStyle: 'pointer-events:none;'
             });
             disableHitDetection(seg);
-          }else{
-            const seg = board.create('segment', [toEq([x,0]), toEq([0,1])], {
-              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
-            });
-            disableHitDetection(seg);
-          }
-        }
-      }else if(division==='horizontal'){
-        for(let i=1;i<n;i++){
-          const y=i/n;
-          if(allowWrong){
-            const seg = board.create('segment', [toEq([0,y]), toEq([1-y,y])], {
-              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
-            });
-            disableHitDetection(seg);
-          }else{
-            const seg = board.create('segment', [toEq([0,y]), toEq([1,0])], {
-              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+          } else {
+            const seg = board.create('segment', [toEq([x, 0]), toEq([0, 1])], {
+              strokeColor: '#000',
+              strokeWidth: 2,
+              dash: 2,
+              highlight: false,
+              fixed: true,
+              cssStyle: 'pointer-events:none;'
             });
             disableHitDetection(seg);
           }
         }
-      }else{ // diagonal
-        for(let i=1;i<n;i++){
-          const t=i/n;
-          const seg = board.create('segment', [toEq([1-t,t]), toEq([0,0])], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+      } else if (division === 'horizontal') {
+        for (let i = 1; i < n; i++) {
+          const y = i / n;
+          if (allowWrong) {
+            const seg = board.create('segment', [toEq([0, y]), toEq([1 - y, y])], {
+              strokeColor: '#000',
+              strokeWidth: 2,
+              dash: 2,
+              highlight: false,
+              fixed: true,
+              cssStyle: 'pointer-events:none;'
+            });
+            disableHitDetection(seg);
+          } else {
+            const seg = board.create('segment', [toEq([0, y]), toEq([1, 0])], {
+              strokeColor: '#000',
+              strokeWidth: 2,
+              dash: 2,
+              highlight: false,
+              fixed: true,
+              cssStyle: 'pointer-events:none;'
+            });
+            disableHitDetection(seg);
+          }
+        }
+      } else {
+        // diagonal
+        for (let i = 1; i < n; i++) {
+          const t = i / n;
+          const seg = board.create('segment', [toEq([1 - t, t]), toEq([0, 0])], {
+            strokeColor: '#000',
+            strokeWidth: 2,
+            dash: 2,
+            highlight: false,
+            fixed: true,
+            cssStyle: 'pointer-events:none;'
           });
           disableHitDetection(seg);
         }
       }
-      board.create('polygon', [toEq([0,0]), toEq([1,0]), toEq([0,1])], {
-        borders:{strokeColor:'#333', strokeWidth:6},
-        vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
-        fillColor:'none',
-        highlight:false,
-        fixed:true,
-        hasInnerPoints:false,
-        cssStyle:'pointer-events:none;'
+      board.create('polygon', [toEq([0, 0]), toEq([1, 0]), toEq([0, 1])], {
+        borders: {
+          strokeColor: '#333',
+          strokeWidth: 6
+        },
+        vertices: {
+          visible: false,
+          name: '',
+          fixed: true,
+          label: {
+            visible: false
+          }
+        },
+        fillColor: 'none',
+        highlight: false,
+        fixed: true,
+        hasInnerPoints: false,
+        cssStyle: 'pointer-events:none;'
       });
     }
-
-    function applyClip(shape, division){
-      const svg = board?.renderer?.svgRoot;
-      if(!svg) return;
+    function applyClip(shape, division) {
+      var _board;
+      const svg = (_board = board) === null || _board === void 0 || (_board = _board.renderer) === null || _board === void 0 ? void 0 : _board.svgRoot;
+      if (!svg) return;
       const pad = CLIP_PAD_PERCENT;
       const padStr = pad.toFixed(2);
       const maxStr = (100 + pad).toFixed(2);
       const clipId = `brokClip${id}`;
       let clipValue = '';
       let clipUpdater = null;
-      if(shape==='triangle'){
+      if (shape === 'triangle') {
         clipValue = `polygon(50% -${padStr}%, -${padStr}% ${maxStr}%, ${maxStr}% ${maxStr}%)`;
-      }else if(shape==='rectangle' || shape==='square'){
+      } else if (shape === 'rectangle' || shape === 'square') {
         clipValue = `polygon(-${padStr}% ${maxStr}%, ${maxStr}% ${maxStr}%, ${maxStr}% -${padStr}%, -${padStr}% -${padStr}%)`;
-      }else if(shape==='circle'){
+      } else if (shape === 'circle') {
+        var _svg$viewBox, _svg$viewBox2;
         const circleBase = CIRCLE_RADIUS / BOARD_SIZE;
-        const size = Math.max(
-          svg.clientWidth || 0,
-          svg.clientHeight || 0,
-          svg.viewBox?.baseVal?.width || 0,
-          svg.viewBox?.baseVal?.height || 0,
-          360
-        );
+        const size = Math.max(svg.clientWidth || 0, svg.clientHeight || 0, ((_svg$viewBox = svg.viewBox) === null || _svg$viewBox === void 0 || (_svg$viewBox = _svg$viewBox.baseVal) === null || _svg$viewBox === void 0 ? void 0 : _svg$viewBox.width) || 0, ((_svg$viewBox2 = svg.viewBox) === null || _svg$viewBox2 === void 0 || (_svg$viewBox2 = _svg$viewBox2.baseVal) === null || _svg$viewBox2 === void 0 ? void 0 : _svg$viewBox2.height) || 0, 360);
         const strokePadding = OUTLINE_STROKE_WIDTH / (2 * size);
         const circleClip = Math.min(0.5, circleBase + strokePadding);
         clipValue = `circle(${(circleClip * 100).toFixed(3)}% at 50% 50%)`;
         clipUpdater = clipPath => {
           clipPath.setAttribute('clipPathUnits', 'objectBoundingBox');
-          while(clipPath.firstChild) clipPath.removeChild(clipPath.firstChild);
+          while (clipPath.firstChild) clipPath.removeChild(clipPath.firstChild);
           const circle = document.createElementNS(SVG_NS, 'circle');
           circle.setAttribute('cx', '0.5');
           circle.setAttribute('cy', '0.5');
@@ -762,137 +989,153 @@
       svg.style.webkitClipPath = clipValue;
       const defsLookup = () => {
         let defs = svg.querySelector('defs');
-        if(!defs && clipUpdater){
+        if (!defs && clipUpdater) {
           defs = document.createElementNS(SVG_NS, 'defs');
           svg.insertBefore(defs, svg.firstChild);
         }
         return defs;
       };
-      if(clipUpdater){
+      if (clipUpdater) {
         const defs = defsLookup();
-        if(!defs) return;
+        if (!defs) return;
         let clipPath = defs.querySelector(`#${clipId}`);
-        if(!clipPath){
+        if (!clipPath) {
           clipPath = document.createElementNS(SVG_NS, 'clipPath');
           clipPath.setAttribute('id', clipId);
           defs.appendChild(clipPath);
         }
         clipUpdater(clipPath);
         svg.setAttribute('clip-path', `url(#${clipId})`);
-      }else{
+      } else {
         svg.removeAttribute('clip-path');
         const defs = defsLookup();
-        const clipPath = defs?.querySelector(`#${clipId}`);
-        if(clipPath) clipPath.remove();
+        const clipPath = defs === null || defs === void 0 ? void 0 : defs.querySelector(`#${clipId}`);
+        if (clipPath) clipPath.remove();
       }
     }
-
-    shapeSel?.addEventListener('change', ()=>{
+    shapeSel === null || shapeSel === void 0 || shapeSel.addEventListener('change', () => {
       const figState = ensureFigureState(id);
       figState.shape = shapeSel.value;
       window.render();
     });
-    partsInp?.addEventListener('input', ()=>{
+    partsInp === null || partsInp === void 0 || partsInp.addEventListener('input', () => {
       const figState = ensureFigureState(id);
       figState.parts = clampInt(partsInp.value, 1);
       window.render();
     });
-    divSel?.addEventListener('change', ()=>{
+    divSel === null || divSel === void 0 || divSel.addEventListener('change', () => {
       const figState = ensureFigureState(id);
       figState.division = divSel.value;
       window.render();
     });
-    wrongInp?.addEventListener('change', ()=>{
+    wrongInp === null || wrongInp === void 0 || wrongInp.addEventListener('change', () => {
       const figState = ensureFigureState(id);
       figState.allowWrong = !!wrongInp.checked;
       window.render();
     });
-    minusBtn?.addEventListener('click', () => {
+    minusBtn === null || minusBtn === void 0 || minusBtn.addEventListener('click', () => {
       let n = parseInt(partsInp.value, 10);
       n = isNaN(n) ? 1 : Math.max(1, n - 1);
       partsInp.value = String(n);
       partsInp.dispatchEvent(new Event('input'));
     });
-    plusBtn?.addEventListener('click', () => {
+    plusBtn === null || plusBtn === void 0 || plusBtn.addEventListener('click', () => {
       let n = parseInt(partsInp.value, 10);
       n = isNaN(n) ? 1 : n + 1;
       partsInp.value = String(n);
       partsInp.dispatchEvent(new Event('input'));
     });
-    btnSvg?.addEventListener('click', () => {
-      const svg = board?.renderer?.svgRoot;
-      if(svg) downloadSVG(svg, `brok${id}.svg`);
+    btnSvg === null || btnSvg === void 0 || btnSvg.addEventListener('click', () => {
+      var _board2;
+      const svg = (_board2 = board) === null || _board2 === void 0 || (_board2 = _board2.renderer) === null || _board2 === void 0 ? void 0 : _board2.svgRoot;
+      if (svg) downloadSVG(svg, `brok${id}.svg`);
     });
-    btnPng?.addEventListener('click', () => {
-      const svg = board?.renderer?.svgRoot;
-      if(svg) downloadPNG(svg, `brok${id}.png`, 2);
+    btnPng === null || btnPng === void 0 || btnPng.addEventListener('click', () => {
+      var _board3;
+      const svg = (_board3 = board) === null || _board3 === void 0 || (_board3 = _board3.renderer) === null || _board3 === void 0 ? void 0 : _board3.svgRoot;
+      if (svg) downloadPNG(svg, `brok${id}.png`, 2);
     });
-    function getFilled(){
+    function getFilled() {
       return new Map(filled);
     }
-
-    function setFilled(next){
+    function setFilled(next) {
       const normalized = normalizeFilledEntries(next);
       filled = new Map(normalized);
       syncFilledState(normalized, true);
     }
-
-    return {draw, panel, toolbar, getFilled, setFilled};
+    return {
+      draw,
+      panel,
+      toolbar,
+      getFilled,
+      setFilled
+    };
   }
-
   figures[1] = setupFigure(1);
   figures[2] = setupFigure(2);
-  addBtn?.addEventListener('click', ()=>{
+  addBtn === null || addBtn === void 0 || addBtn.addEventListener('click', () => {
     STATE.figure2Visible = true;
     window.render();
   });
-  removeBtn1?.addEventListener('click', ()=>{
-    if(!STATE.figure2Visible) return;
-    const fig1State = {...ensureFigureState(1)};
-    const fig2State = {...ensureFigureState(2)};
+  removeBtn1 === null || removeBtn1 === void 0 || removeBtn1.addEventListener('click', () => {
+    var _figures$1$getFilled, _figures$, _figures$$getFilled, _figures$2$getFilled, _figures$2, _figures$2$getFilled2, _figures$3, _figures$3$setFilled, _figures$4, _figures$4$setFilled;
+    if (!STATE.figure2Visible) return;
+    const fig1State = {
+      ...ensureFigureState(1)
+    };
+    const fig2State = {
+      ...ensureFigureState(2)
+    };
     STATE.figures[1] = fig2State;
     STATE.figures[2] = fig1State;
-    const fig1Filled = figures[1]?.getFilled?.() ?? new Map();
-    const fig2Filled = figures[2]?.getFilled?.() ?? new Map();
-    figures[1]?.setFilled?.(fig2Filled);
-    figures[2]?.setFilled?.(fig1Filled);
+    const fig1Filled = (_figures$1$getFilled = (_figures$ = figures[1]) === null || _figures$ === void 0 || (_figures$$getFilled = _figures$.getFilled) === null || _figures$$getFilled === void 0 ? void 0 : _figures$$getFilled.call(_figures$)) !== null && _figures$1$getFilled !== void 0 ? _figures$1$getFilled : new Map();
+    const fig2Filled = (_figures$2$getFilled = (_figures$2 = figures[2]) === null || _figures$2 === void 0 || (_figures$2$getFilled2 = _figures$2.getFilled) === null || _figures$2$getFilled2 === void 0 ? void 0 : _figures$2$getFilled2.call(_figures$2)) !== null && _figures$2$getFilled !== void 0 ? _figures$2$getFilled : new Map();
+    (_figures$3 = figures[1]) === null || _figures$3 === void 0 || (_figures$3$setFilled = _figures$3.setFilled) === null || _figures$3$setFilled === void 0 || _figures$3$setFilled.call(_figures$3, fig2Filled);
+    (_figures$4 = figures[2]) === null || _figures$4 === void 0 || (_figures$4$setFilled = _figures$4.setFilled) === null || _figures$4$setFilled === void 0 || _figures$4$setFilled.call(_figures$4, fig1Filled);
     STATE.figure2Visible = false;
     window.render();
   });
-  removeBtn2?.addEventListener('click', ()=>{
+  removeBtn2 === null || removeBtn2 === void 0 || removeBtn2.addEventListener('click', () => {
     STATE.figure2Visible = false;
     window.render();
   });
-
-  window.addEventListener('examples:collect', (event)=>{
-    const detail = event?.detail;
-    if(!detail || detail.svgOverride != null) return;
+  window.addEventListener('examples:collect', event => {
+    var _window$render3, _window3, _window$render4, _window4;
+    const detail = event === null || event === void 0 ? void 0 : event.detail;
+    if (!detail || detail.svgOverride != null) return;
     const restore = [];
-    for(const fig of figures){
-      if(!fig || typeof fig.getFilled !== 'function' || typeof fig.setFilled !== 'function') continue;
+    for (const fig of figures) {
+      if (!fig || typeof fig.getFilled !== 'function' || typeof fig.setFilled !== 'function') continue;
       let filled = fig.getFilled();
-      if(filled instanceof Map){
-        if(filled.size === 0) continue;
-      }else if(filled && typeof filled[Symbol.iterator] === 'function'){
+      if (filled instanceof Map) {
+        if (filled.size === 0) continue;
+      } else if (filled && typeof filled[Symbol.iterator] === 'function') {
         filled = new Map(filled);
-        if(filled.size === 0) continue;
-      }else{
+        if (filled.size === 0) continue;
+      } else {
         continue;
       }
-      restore.push({fig, filled});
+      restore.push({
+        fig,
+        filled
+      });
     }
-    if(restore.length === 0) return;
-    for(const {fig} of restore){
+    if (restore.length === 0) return;
+    for (const {
+      fig
+    } of restore) {
       fig.setFilled(new Map());
     }
-    window.render?.();
+    (_window$render3 = (_window3 = window).render) === null || _window$render3 === void 0 || _window$render3.call(_window3);
     const svg = document.querySelector('svg');
-    if(svg) detail.svgOverride = svg.outerHTML;
-    for(const {fig, filled} of restore){
+    if (svg) detail.svgOverride = svg.outerHTML;
+    for (const {
+      fig,
+      filled
+    } of restore) {
       fig.setFilled(filled);
     }
-    window.render?.();
+    (_window$render4 = (_window4 = window).render) === null || _window$render4 === void 0 || _window$render4.call(_window4);
   });
   window.render();
 })();
-

--- a/brøkpizza.js
+++ b/brøkpizza.js
@@ -1,154 +1,214 @@
 /* =======================
    KONFIG FRA HTML
    ======================= */
-const SIMPLE = { pizzas: [], ops: [] };
-if(typeof window !== 'undefined') window.SIMPLE = SIMPLE;
+const SIMPLE = {
+  pizzas: [],
+  ops: []
+};
+if (typeof window !== 'undefined') window.SIMPLE = SIMPLE;
 const PANEL_HTML = [];
-
-function readConfigFromHtml(){
+function readConfigFromHtml() {
   const pizzas = [];
-  for(let i=1;i<=3;i++){
-    const t      = parseInt(document.getElementById(`p${i}T`)?.value,10);
-    const n      = parseInt(document.getElementById(`p${i}N`)?.value,10);
-    const lockN  = document.getElementById(`p${i}LockN`)?.checked ?? false;
-    const lockT  = document.getElementById(`p${i}LockT`)?.checked ?? false;
-    const text   = document.getElementById(`p${i}Text`)?.value ?? "none";
-    const minN   = parseInt(document.getElementById(`p${i}MinN`)?.value,10);
-    const maxN   = parseInt(document.getElementById(`p${i}MaxN`)?.value,10);
-    const hideNVal = document.getElementById(`p${i}HideNVal`)?.checked ?? false;
+  for (let i = 1; i <= 3; i++) {
+    var _document$getElementB, _document$getElementB2, _document$getElementB3, _document$getElementB4, _document$getElementB5, _document$getElementB6, _document$getElementB7, _document$getElementB8, _document$getElementB9, _document$getElementB0, _document$getElementB1, _document$getElementB10;
+    const t = parseInt((_document$getElementB = document.getElementById(`p${i}T`)) === null || _document$getElementB === void 0 ? void 0 : _document$getElementB.value, 10);
+    const n = parseInt((_document$getElementB2 = document.getElementById(`p${i}N`)) === null || _document$getElementB2 === void 0 ? void 0 : _document$getElementB2.value, 10);
+    const lockN = (_document$getElementB3 = (_document$getElementB4 = document.getElementById(`p${i}LockN`)) === null || _document$getElementB4 === void 0 ? void 0 : _document$getElementB4.checked) !== null && _document$getElementB3 !== void 0 ? _document$getElementB3 : false;
+    const lockT = (_document$getElementB5 = (_document$getElementB6 = document.getElementById(`p${i}LockT`)) === null || _document$getElementB6 === void 0 ? void 0 : _document$getElementB6.checked) !== null && _document$getElementB5 !== void 0 ? _document$getElementB5 : false;
+    const text = (_document$getElementB7 = (_document$getElementB8 = document.getElementById(`p${i}Text`)) === null || _document$getElementB8 === void 0 ? void 0 : _document$getElementB8.value) !== null && _document$getElementB7 !== void 0 ? _document$getElementB7 : "none";
+    const minN = parseInt((_document$getElementB9 = document.getElementById(`p${i}MinN`)) === null || _document$getElementB9 === void 0 ? void 0 : _document$getElementB9.value, 10);
+    const maxN = parseInt((_document$getElementB0 = document.getElementById(`p${i}MaxN`)) === null || _document$getElementB0 === void 0 ? void 0 : _document$getElementB0.value, 10);
+    const hideNVal = (_document$getElementB1 = (_document$getElementB10 = document.getElementById(`p${i}HideNVal`)) === null || _document$getElementB10 === void 0 ? void 0 : _document$getElementB10.checked) !== null && _document$getElementB1 !== void 0 ? _document$getElementB1 : false;
     pizzas.push({
-      t: isFinite(t)?t:0,
-      n: isFinite(n)?n:1,
-      lockN, lockT, text,
+      t: isFinite(t) ? t : 0,
+      n: isFinite(n) ? n : 1,
+      lockN,
+      lockT,
+      text,
       hideNVal,
-      minN: isFinite(minN)?minN:1,
-      maksN: isFinite(maxN)?maxN:24
+      minN: isFinite(minN) ? minN : 1,
+      maksN: isFinite(maxN) ? maxN : 24
     });
   }
   const ops = [];
-  for(let i=1;i<=2;i++){
-    const op = document.getElementById(`op${i}`)?.value || "";
+  for (let i = 1; i <= 2; i++) {
+    var _document$getElementB11;
+    const op = ((_document$getElementB11 = document.getElementById(`op${i}`)) === null || _document$getElementB11 === void 0 ? void 0 : _document$getElementB11.value) || "";
     ops.push(op);
   }
-  return { pizzas, ops };
+  return {
+    pizzas,
+    ops
+  };
 }
 
 /* =======================
    Grunnoppsett
    ======================= */
 const PIZZA_DEFAULTS = {
-  minN: 1, maxN: 24, R: 180, stepN: 1, stepK: 1,
-  metaMode: "none", lockDenominator: false, lockNumerator: false,
+  minN: 1,
+  maxN: 24,
+  R: 180,
+  stepN: 1,
+  stepK: 1,
+  metaMode: "none",
+  lockDenominator: false,
+  lockNumerator: false,
   showDenominatorValue: true
 };
-const PIZZA_DOM = [
-  { svgId:"pizza1", fracId:"frac1", minusId:"nMinus1", plusId:"nPlus1", valId:"nVal1", index:0 },
-  { svgId:"pizza2", fracId:"frac2", minusId:"nMinus2", plusId:"nPlus2", valId:"nVal2", index:1 },
-  { svgId:"pizza3", fracId:"frac3", minusId:"nMinus3", plusId:"nPlus3", valId:"nVal3", index:2 }
-];
-
-const TAU=Math.PI*2;
-const norm=a=>((a%TAU)+TAU)%TAU;
-const mk=(n,a={})=>{const e=document.createElementNS("http://www.w3.org/2000/svg",n); for(const[k,v] of Object.entries(a)) e.setAttribute(k,v); return e;};
-const arcPath=(r,a0,a1)=>{const raw=a1-a0,span=((raw%TAU)+TAU)%TAU,isFull=Math.abs(span)<1e-6&&Math.abs(raw)>1e-6;
-  if(isFull) return `M ${r} 0 A ${r} ${r} 0 1 1 ${-r} 0 A ${r} ${r} 0 1 1 ${r} 0 Z`;
-  const sweep=1,large=span>Math.PI?1:0,x0=r*Math.cos(a0),y0=r*Math.sin(a0),x1=r*Math.cos(a1),y1=r*Math.sin(a1);
-  return `M 0 0 L ${x0} ${y0} A ${r} ${r} 0 ${large} ${sweep} ${x1} ${y1} Z`;};
-const gcd=(a,b)=>{a=Math.abs(a);b=Math.abs(b);while(b){const t=b;b=a%b;a=t;}return a||1;};
-const fmt=x=>{const s=(Math.round(x*100)/100).toFixed(2); return s.replace(/\.?0+$/,"");};
+const PIZZA_DOM = [{
+  svgId: "pizza1",
+  fracId: "frac1",
+  minusId: "nMinus1",
+  plusId: "nPlus1",
+  valId: "nVal1",
+  index: 0
+}, {
+  svgId: "pizza2",
+  fracId: "frac2",
+  minusId: "nMinus2",
+  plusId: "nPlus2",
+  valId: "nVal2",
+  index: 1
+}, {
+  svgId: "pizza3",
+  fracId: "frac3",
+  minusId: "nMinus3",
+  plusId: "nPlus3",
+  valId: "nVal3",
+  index: 2
+}];
+const TAU = Math.PI * 2;
+const norm = a => (a % TAU + TAU) % TAU;
+const mk = (n, a = {}) => {
+  const e = document.createElementNS("http://www.w3.org/2000/svg", n);
+  for (const [k, v] of Object.entries(a)) e.setAttribute(k, v);
+  return e;
+};
+const arcPath = (r, a0, a1) => {
+  const raw = a1 - a0,
+    span = (raw % TAU + TAU) % TAU,
+    isFull = Math.abs(span) < 1e-6 && Math.abs(raw) > 1e-6;
+  if (isFull) return `M ${r} 0 A ${r} ${r} 0 1 1 ${-r} 0 A ${r} ${r} 0 1 1 ${r} 0 Z`;
+  const sweep = 1,
+    large = span > Math.PI ? 1 : 0,
+    x0 = r * Math.cos(a0),
+    y0 = r * Math.sin(a0),
+    x1 = r * Math.cos(a1),
+    y1 = r * Math.sin(a1);
+  return `M 0 0 L ${x0} ${y0} A ${r} ${r} 0 ${large} ${sweep} ${x1} ${y1} Z`;
+};
+const gcd = (a, b) => {
+  a = Math.abs(a);
+  b = Math.abs(b);
+  while (b) {
+    const t = b;
+    b = a % b;
+    a = t;
+  }
+  return a || 1;
+};
+const fmt = x => {
+  const s = (Math.round(x * 100) / 100).toFixed(2);
+  return s.replace(/\.?0+$/, "");
+};
 
 /* ==== Senter-justering: sirklene på LINJE ==== */
-let _centerRaf=0;
+let _centerRaf = 0;
 function alignPanelsByCenter() {
-  const panels=[...document.querySelectorAll(".pizzaPanel")].filter(p=>p.offsetParent!==null);
-  if(!panels.length) return;
-  const items=panels.map(p=>{
-    const header=p.querySelector(".panelHeader");
-    const svg=p.querySelector("svg.pizza");
-    if(!header||!svg) return null;
-    header.style.height="auto";
-    const baseHeader=header.getBoundingClientRect().height;
-    const svgH=svg.getBoundingClientRect().height;
-    return {header, baseHeader, svgH};
+  const panels = [...document.querySelectorAll(".pizzaPanel")].filter(p => p.offsetParent !== null);
+  if (!panels.length) return;
+  const items = panels.map(p => {
+    const header = p.querySelector(".panelHeader");
+    const svg = p.querySelector("svg.pizza");
+    if (!header || !svg) return null;
+    header.style.height = "auto";
+    const baseHeader = header.getBoundingClientRect().height;
+    const svgH = svg.getBoundingClientRect().height;
+    return {
+      header,
+      baseHeader,
+      svgH
+    };
   }).filter(Boolean);
-  if(!items.length) return;
-  const maxCenter=Math.max(...items.map(it=>it.baseHeader + it.svgH/2));
-  items.forEach(it=>{
-    const targetHeader=Math.max(0, maxCenter - it.svgH/2);
-    const finalHeader=Math.max(targetHeader, it.baseHeader);
+  if (!items.length) return;
+  const maxCenter = Math.max(...items.map(it => it.baseHeader + it.svgH / 2));
+  items.forEach(it => {
+    const targetHeader = Math.max(0, maxCenter - it.svgH / 2);
+    const finalHeader = Math.max(targetHeader, it.baseHeader);
     it.header.style.height = finalHeader + "px";
   });
 }
-function scheduleCenterAlign(){ cancelAnimationFrame(_centerRaf); _centerRaf=requestAnimationFrame(alignPanelsByCenter); }
+function scheduleCenterAlign() {
+  cancelAnimationFrame(_centerRaf);
+  _centerRaf = requestAnimationFrame(alignPanelsByCenter);
+}
 window.addEventListener("resize", scheduleCenterAlign);
-
-function fitPizzasToLine(){
-  const container=document.querySelector(".grid2");
-  if(!container) return;
-  const panels=[...container.querySelectorAll(".pizzaPanel")].filter(p=>p.style.display!=="none");
-  if(!panels.length) return;
-  const ops=[...container.querySelectorAll(".opDisplay")].filter(op=>op.style.display!=="none");
-  const addBtn=document.getElementById("addPizza");
-  const extras=[...ops];
-  if(addBtn && addBtn.style.display!=="none") extras.push(addBtn);
-  const parent=container.parentElement;
-  let availWidth=container.clientWidth;
-  if(parent){
-    const parentStyles=getComputedStyle(parent);
-    const padL=parseFloat(parentStyles.paddingLeft||"0")||0;
-    const padR=parseFloat(parentStyles.paddingRight||"0")||0;
-    const parentInner=(parent.clientWidth||0)-padL-padR;
-    if(Number.isFinite(parentInner) && parentInner>0 && (!availWidth || parentInner<availWidth)){
-      availWidth=parentInner;
+function fitPizzasToLine() {
+  const container = document.querySelector(".grid2");
+  if (!container) return;
+  const panels = [...container.querySelectorAll(".pizzaPanel")].filter(p => p.style.display !== "none");
+  if (!panels.length) return;
+  const ops = [...container.querySelectorAll(".opDisplay")].filter(op => op.style.display !== "none");
+  const addBtn = document.getElementById("addPizza");
+  const extras = [...ops];
+  if (addBtn && addBtn.style.display !== "none") extras.push(addBtn);
+  const parent = container.parentElement;
+  let availWidth = container.clientWidth;
+  if (parent) {
+    const parentStyles = getComputedStyle(parent);
+    const padL = parseFloat(parentStyles.paddingLeft || "0") || 0;
+    const padR = parseFloat(parentStyles.paddingRight || "0") || 0;
+    const parentInner = (parent.clientWidth || 0) - padL - padR;
+    if (Number.isFinite(parentInner) && parentInner > 0 && (!availWidth || parentInner < availWidth)) {
+      availWidth = parentInner;
     }
   }
-  if((!availWidth || !Number.isFinite(availWidth) || availWidth<=0)){
-    availWidth=container.getBoundingClientRect().width;
+  if (!availWidth || !Number.isFinite(availWidth) || availWidth <= 0) {
+    availWidth = container.getBoundingClientRect().width;
   }
-  if(!availWidth || !Number.isFinite(availWidth)) return;
-  const extrasWidth=extras.reduce((sum,el)=>sum+el.getBoundingClientRect().width,0);
-  const cs=getComputedStyle(container);
-  const gap=parseFloat(cs.columnGap||cs.gap||"0");
-  const totalItems=panels.length+extras.length;
-  const totalGap=gap*Math.max(0,totalItems-1);
-  let computed=(availWidth-extrasWidth-totalGap)/panels.length;
-  if(!Number.isFinite(computed)) computed=container.clientWidth;
-  const MIN=160;
-  const MAX=420;
-  computed=Math.min(MAX,Math.max(MIN,computed));
-  container.style.setProperty("--panel-min",`${computed}px`);
-  panels.forEach(panel=>{
-    const svg=panel.querySelector("svg.pizza");
-    if(svg) svg.style.width="100%";
+  if (!availWidth || !Number.isFinite(availWidth)) return;
+  const extrasWidth = extras.reduce((sum, el) => sum + el.getBoundingClientRect().width, 0);
+  const cs = getComputedStyle(container);
+  const gap = parseFloat(cs.columnGap || cs.gap || "0");
+  const totalItems = panels.length + extras.length;
+  const totalGap = gap * Math.max(0, totalItems - 1);
+  let computed = (availWidth - extrasWidth - totalGap) / panels.length;
+  if (!Number.isFinite(computed)) computed = container.clientWidth;
+  const MIN = 160;
+  const MAX = 420;
+  computed = Math.min(MAX, Math.max(MIN, computed));
+  container.style.setProperty("--panel-min", `${computed}px`);
+  panels.forEach(panel => {
+    const svg = panel.querySelector("svg.pizza");
+    if (svg) svg.style.width = "100%";
   });
 }
 window.addEventListener("resize", fitPizzasToLine);
-
-function hidePizzaPanel(index){
-  const panel=document.getElementById(`panel${index}`);
-  if(panel) panel.style.display="none";
-  const fieldset=document.getElementById(`fieldset${index}`);
-  if(fieldset) fieldset.style.display="none";
+function hidePizzaPanel(index) {
+  const panel = document.getElementById(`panel${index}`);
+  if (panel) panel.style.display = "none";
+  const fieldset = document.getElementById(`fieldset${index}`);
+  if (fieldset) fieldset.style.display = "none";
 }
-
-function setupRemovePizzaButtons(){
-  const addBtn=document.getElementById('addPizza');
-  const remove2=document.getElementById('removePizza2');
-  if(remove2 && !remove2.dataset.bound){
-    remove2.dataset.bound='true';
-    remove2.addEventListener('click',()=>{
+function setupRemovePizzaButtons() {
+  const addBtn = document.getElementById('addPizza');
+  const remove2 = document.getElementById('removePizza2');
+  if (remove2 && !remove2.dataset.bound) {
+    remove2.dataset.bound = 'true';
+    remove2.addEventListener('click', () => {
       hidePizzaPanel(3);
       hidePizzaPanel(2);
-      if(addBtn) addBtn.style.display='';
+      if (addBtn) addBtn.style.display = '';
       initFromHtml();
     });
   }
-  const remove3=document.getElementById('removePizza3');
-  if(remove3 && !remove3.dataset.bound){
-    remove3.dataset.bound='true';
-    remove3.addEventListener('click',()=>{
+  const remove3 = document.getElementById('removePizza3');
+  if (remove3 && !remove3.dataset.bound) {
+    remove3.dataset.bound = 'true';
+    remove3.addEventListener('click', () => {
       hidePizzaPanel(3);
-      if(addBtn) addBtn.style.display='';
+      if (addBtn) addBtn.style.display = '';
       initFromHtml();
     });
   }
@@ -158,228 +218,332 @@ function setupRemovePizzaButtons(){
    Pizza-klasse
    ======================= */
 const REG = new Map(); // svgEl -> Pizza-instans (til eksport)
-class Pizza{
-  constructor(opts){
-    const cfg={...PIZZA_DEFAULTS,...opts};
-    this.cfg=cfg;
+class Pizza {
+  constructor(opts) {
+    var _cfg$minN, _cfg$maxN, _cfg$n, _cfg$k, _cfg$R, _cfg$textMode, _this$fracBox, _this$fracBox2, _this$nMinus, _this$nMinus2, _this$nPlus;
+    const cfg = {
+      ...PIZZA_DEFAULTS,
+      ...opts
+    };
+    this.cfg = cfg;
     this.index = typeof cfg.index === "number" ? cfg.index : null;
+    this.minN = Math.max(1, (_cfg$minN = cfg.minN) !== null && _cfg$minN !== void 0 ? _cfg$minN : 1);
+    this.maxN = Math.max(this.minN, (_cfg$maxN = cfg.maxN) !== null && _cfg$maxN !== void 0 ? _cfg$maxN : 24);
+    this.n = Math.min(Math.max((_cfg$n = cfg.n) !== null && _cfg$n !== void 0 ? _cfg$n : 6, this.minN), this.maxN);
+    this.k = Math.min((_cfg$k = cfg.k) !== null && _cfg$k !== void 0 ? _cfg$k : 0, this.n);
+    this.R = (_cfg$R = cfg.R) !== null && _cfg$R !== void 0 ? _cfg$R : 180;
+    this.theta = this.k / this.n * TAU;
+    this.textMode = (_cfg$textMode = cfg.textMode) !== null && _cfg$textMode !== void 0 ? _cfg$textMode : "none"; // "none" | "frac" | "percent" | "decimal"
 
-    this.minN=Math.max(1, cfg.minN ?? 1);
-    this.maxN=Math.max(this.minN, cfg.maxN ?? 24);
-
-    this.n=Math.min(Math.max(cfg.n ?? 6, this.minN), this.maxN);
-    this.k=Math.min(cfg.k ?? 0, this.n);
-    this.R=cfg.R ?? 180;
-    this.theta=(this.k/this.n)*TAU;
-    this.textMode = cfg.textMode ?? "none"; // "none" | "frac" | "percent" | "decimal"
-
-    this.svg=document.getElementById(cfg.svgId);
-    this.nMinus=document.getElementById(cfg.minusId);
-    this.nPlus=document.getElementById(cfg.plusId);
-    this.nVal=document.getElementById(cfg.valId);
+    this.svg = document.getElementById(cfg.svgId);
+    this.nMinus = document.getElementById(cfg.minusId);
+    this.nPlus = document.getElementById(cfg.plusId);
+    this.nVal = document.getElementById(cfg.valId);
     this.showDenominatorValue = cfg.showDenominatorValue !== false;
-    this.fracBox=document.getElementById(cfg.fracId);
-    this.fracNum=this.fracBox?.querySelector(".num") || null;
-    this.fracDen=this.fracBox?.querySelector(".den") || null;
-    if(!this.svg) throw new Error(`Mangler SVG med id="${cfg.svgId}"`);
-    if(this.nVal && !this.showDenominatorValue) this.nVal.style.display = "none";
+    this.fracBox = document.getElementById(cfg.fracId);
+    this.fracNum = ((_this$fracBox = this.fracBox) === null || _this$fracBox === void 0 ? void 0 : _this$fracBox.querySelector(".num")) || null;
+    this.fracDen = ((_this$fracBox2 = this.fracBox) === null || _this$fracBox2 === void 0 ? void 0 : _this$fracBox2.querySelector(".den")) || null;
+    if (!this.svg) throw new Error(`Mangler SVG med id="${cfg.svgId}"`);
+    if (this.nVal && !this.showDenominatorValue) this.nVal.style.display = "none";
 
     // Header-slot (over SVG)
-    this.header=document.createElement("div");
-    this.header.className="panelHeader";
-    this.svg.parentNode.insertBefore(this.header,this.svg);
-    if(this.fracBox){
+    this.header = document.createElement("div");
+    this.header.className = "panelHeader";
+    this.svg.parentNode.insertBefore(this.header, this.svg);
+    if (this.fracBox) {
       this.header.appendChild(this.fracBox);
-      this.fracBox.style.display = (this.textMode==="frac") ? "" : "none";
+      this.fracBox.style.display = this.textMode === "frac" ? "" : "none";
     }
-    if(this.textMode==="percent" || this.textMode==="decimal"){
-      this.metaLine=document.createElement("div");
+    if (this.textMode === "percent" || this.textMode === "decimal") {
+      this.metaLine = document.createElement("div");
       this.metaLine.style.fontSize = "28px";
       this.metaLine.style.lineHeight = "1";
-      this.metaLine.style.opacity  = "0.9";
-      this.metaLine.style.margin   = "0 0 6px 0";
+      this.metaLine.style.opacity = "0.9";
+      this.metaLine.style.margin = "0 0 6px 0";
       this.header.appendChild(this.metaLine);
     }
 
     // Lag i SVG
-    this.gFill=mk("g"); this.gLinesBlack=mk("g"); this.gRim=mk("g"); this.defs=mk("defs"); this.gLinesWhite=mk("g"); this.gA11y=mk("g"); this.gHandle=mk("g");
-    this.gFill.setAttribute("data-role","fill");
-    this.gLinesBlack.setAttribute("data-role","linesB");
-    this.gLinesWhite.setAttribute("data-role","linesW");
-
-    this.svg.append(this.gFill,this.gLinesBlack,this.gRim,this.defs,this.gLinesWhite,this.gA11y,this.gHandle);
-    this.gRim.appendChild(mk("circle",{cx:0,cy:0,r:this.R,class:"rim"}));
-
-    this.clipFilledId=`${cfg.svgId}-clipFilled`;
-    this.clipEmptyId =`${cfg.svgId}-clipEmpty`;
-    this.clipFilled  =mk("clipPath",{id:this.clipFilledId});
-    this.clipEmpty   =mk("clipPath",{id:this.clipEmptyId});
-    this.defs.append(this.clipFilled,this.clipEmpty);
-    this.gLinesWhite.setAttribute("clip-path",`url(#${this.clipFilledId})`);
-    this.gLinesBlack.setAttribute("clip-path",`url(#${this.clipEmptyId})`);
+    this.gFill = mk("g");
+    this.gLinesBlack = mk("g");
+    this.gRim = mk("g");
+    this.defs = mk("defs");
+    this.gLinesWhite = mk("g");
+    this.gA11y = mk("g");
+    this.gHandle = mk("g");
+    this.gFill.setAttribute("data-role", "fill");
+    this.gLinesBlack.setAttribute("data-role", "linesB");
+    this.gLinesWhite.setAttribute("data-role", "linesW");
+    this.svg.append(this.gFill, this.gLinesBlack, this.gRim, this.defs, this.gLinesWhite, this.gA11y, this.gHandle);
+    this.gRim.appendChild(mk("circle", {
+      cx: 0,
+      cy: 0,
+      r: this.R,
+      class: "rim"
+    }));
+    this.clipFilledId = `${cfg.svgId}-clipFilled`;
+    this.clipEmptyId = `${cfg.svgId}-clipEmpty`;
+    this.clipFilled = mk("clipPath", {
+      id: this.clipFilledId
+    });
+    this.clipEmpty = mk("clipPath", {
+      id: this.clipEmptyId
+    });
+    this.defs.append(this.clipFilled, this.clipEmpty);
+    this.gLinesWhite.setAttribute("clip-path", `url(#${this.clipFilledId})`);
+    this.gLinesBlack.setAttribute("clip-path", `url(#${this.clipEmptyId})`);
 
     // Handle + a11y
-    this.handle=mk("circle",{r:10,class:"handle",tabindex:-1});
+    this.handle = mk("circle", {
+      r: 10,
+      class: "handle",
+      tabindex: -1
+    });
     this.gHandle.appendChild(this.handle);
-    this.slider=mk("circle",{cx:0,cy:0,r:this.R,fill:"transparent",class:"a11y",tabindex:0,role:"slider","aria-orientation":"horizontal"});
-    this.slider.style.pointerEvents="none";
+    this.slider = mk("circle", {
+      cx: 0,
+      cy: 0,
+      r: this.R,
+      fill: "transparent",
+      class: "a11y",
+      tabindex: 0,
+      role: "slider",
+      "aria-orientation": "horizontal"
+    });
+    this.slider.style.pointerEvents = "none";
     this.gA11y.appendChild(this.slider);
 
     // <title>/<desc> for eksport og live-oppdatering
     this.titleEl = this.svg.querySelector('title');
-    this.descEl  = this.svg.querySelector('desc');
+    this.descEl = this.svg.querySelector('desc');
 
     // Låse-logikk
     this.fullyLocked = !!(cfg.lockDenominator && cfg.lockNumerator);
-    if(this.fullyLocked){
-      this.gHandle.style.display="none";
-      this.slider.setAttribute("tabindex","-1");
-      this.slider.setAttribute("aria-disabled","true");
-    }else{
+    if (this.fullyLocked) {
+      this.gHandle.style.display = "none";
+      this.slider.setAttribute("tabindex", "-1");
+      this.slider.setAttribute("aria-disabled", "true");
+    } else {
       this.slider.setAttribute("aria-disabled", cfg.lockNumerator ? "true" : "false");
-      if(cfg.lockNumerator) this.handle.style.cursor="default";
+      if (cfg.lockNumerator) this.handle.style.cursor = "default";
     }
 
     // Stepper synlighet
-    const stepper=this.nMinus?.closest(".stepper");
-    if(stepper) stepper.style.display = cfg.lockDenominator ? "none" : "";
+    const stepper = (_this$nMinus = this.nMinus) === null || _this$nMinus === void 0 ? void 0 : _this$nMinus.closest(".stepper");
+    if (stepper) stepper.style.display = cfg.lockDenominator ? "none" : "";
 
     // Interaksjon
-    this._dragging=false;
-    this.nMinus?.addEventListener("click", ()=>{ if(cfg.lockDenominator) return; this.setN(this.n - this.cfg.stepN); });
-    this.nPlus ?.addEventListener("click", ()=>{ if(cfg.lockDenominator) return; this.setN(this.n + this.cfg.stepN); });
-
-    this.handle.addEventListener("pointerdown", e=>{ if(cfg.lockNumerator||this.fullyLocked) return; this._dragging=true; this.handle.setPointerCapture(e.pointerId); });
-    this.handle.addEventListener("pointerup",   e=>{ if(cfg.lockNumerator||this.fullyLocked) return; this._dragging=false; this.handle.releasePointerCapture(e.pointerId); });
-    this.svg.addEventListener("pointerleave", ()=>{ this._dragging=false; });
-    this.svg.addEventListener("pointermove", e=>{
-      if(!this._dragging || cfg.lockNumerator || this.fullyLocked) return;
-      const {x,y}=this._pt(e); const a=norm(Math.atan2(y,x)); this._setTheta(a,true);
+    this._dragging = false;
+    (_this$nMinus2 = this.nMinus) === null || _this$nMinus2 === void 0 || _this$nMinus2.addEventListener("click", () => {
+      if (cfg.lockDenominator) return;
+      this.setN(this.n - this.cfg.stepN);
     });
-    this.svg.addEventListener("click", e=>{
-      if(e.target===this.handle) return;
-      if(cfg.lockNumerator || this.fullyLocked) return;
-      const {x,y}=this._pt(e); const a=norm(Math.atan2(y,x)); this._setTheta(a,true);
+    (_this$nPlus = this.nPlus) === null || _this$nPlus === void 0 || _this$nPlus.addEventListener("click", () => {
+      if (cfg.lockDenominator) return;
+      this.setN(this.n + this.cfg.stepN);
     });
-    this.slider.addEventListener("keydown", e=>{
-      if(this.fullyLocked) return;
-      let used=true; const big=e.shiftKey?5:1;
-      switch(e.key){
-        case "ArrowRight": case "ArrowUp":    if(!cfg.lockNumerator) this.setK(this.k+this.cfg.stepK*big); else used=false; break;
-        case "ArrowLeft":  case "ArrowDown":  if(!cfg.lockNumerator) this.setK(this.k-this.cfg.stepK*big); else used=false; break;
-        case "Home": if(!cfg.lockNumerator) this.setK(0); else used=false; break;
-        case "End":  if(!cfg.lockNumerator) this.setK(this.n); else used=false; break;
-        case " ": case "Enter": if(!cfg.lockNumerator) this.setK(this.k+1); else used=false; break;
-        case "PageUp":   if(!cfg.lockDenominator) this.setN(this.n+this.cfg.stepN*(e.shiftKey?5:1)); else used=false; break;
-        case "PageDown": if(!cfg.lockDenominator) this.setN(this.n-this.cfg.stepN*(e.shiftKey?5:1)); else used=false; break;
-        default: used=false;
+    this.handle.addEventListener("pointerdown", e => {
+      if (cfg.lockNumerator || this.fullyLocked) return;
+      this._dragging = true;
+      this.handle.setPointerCapture(e.pointerId);
+    });
+    this.handle.addEventListener("pointerup", e => {
+      if (cfg.lockNumerator || this.fullyLocked) return;
+      this._dragging = false;
+      this.handle.releasePointerCapture(e.pointerId);
+    });
+    this.svg.addEventListener("pointerleave", () => {
+      this._dragging = false;
+    });
+    this.svg.addEventListener("pointermove", e => {
+      if (!this._dragging || cfg.lockNumerator || this.fullyLocked) return;
+      const {
+        x,
+        y
+      } = this._pt(e);
+      const a = norm(Math.atan2(y, x));
+      this._setTheta(a, true);
+    });
+    this.svg.addEventListener("click", e => {
+      if (e.target === this.handle) return;
+      if (cfg.lockNumerator || this.fullyLocked) return;
+      const {
+        x,
+        y
+      } = this._pt(e);
+      const a = norm(Math.atan2(y, x));
+      this._setTheta(a, true);
+    });
+    this.slider.addEventListener("keydown", e => {
+      if (this.fullyLocked) return;
+      let used = true;
+      const big = e.shiftKey ? 5 : 1;
+      switch (e.key) {
+        case "ArrowRight":
+        case "ArrowUp":
+          if (!cfg.lockNumerator) this.setK(this.k + this.cfg.stepK * big);else used = false;
+          break;
+        case "ArrowLeft":
+        case "ArrowDown":
+          if (!cfg.lockNumerator) this.setK(this.k - this.cfg.stepK * big);else used = false;
+          break;
+        case "Home":
+          if (!cfg.lockNumerator) this.setK(0);else used = false;
+          break;
+        case "End":
+          if (!cfg.lockNumerator) this.setK(this.n);else used = false;
+          break;
+        case " ":
+        case "Enter":
+          if (!cfg.lockNumerator) this.setK(this.k + 1);else used = false;
+          break;
+        case "PageUp":
+          if (!cfg.lockDenominator) this.setN(this.n + this.cfg.stepN * (e.shiftKey ? 5 : 1));else used = false;
+          break;
+        case "PageDown":
+          if (!cfg.lockDenominator) this.setN(this.n - this.cfg.stepN * (e.shiftKey ? 5 : 1));else used = false;
+          break;
+        default:
+          used = false;
       }
-      if(used) e.preventDefault();
+      if (used) e.preventDefault();
     });
-
     this.draw();
     this.syncSimpleConfig();
     REG.set(this.svg, this);
   }
-
-  _pt(e){ const p=this.svg.createSVGPoint(); p.x=e.clientX; p.y=e.clientY; return p.matrixTransform(this.svg.getScreenCTM().inverse()); }
-  _setTheta(a,updateK){
-    this.theta=norm(a);
-    if(updateK){
-      const step=TAU/this.n;
-      this.k=Math.max(0,Math.min(this.n,Math.round(this.theta/step)));
+  _pt(e) {
+    const p = this.svg.createSVGPoint();
+    p.x = e.clientX;
+    p.y = e.clientY;
+    return p.matrixTransform(this.svg.getScreenCTM().inverse());
+  }
+  _setTheta(a, updateK) {
+    this.theta = norm(a);
+    if (updateK) {
+      const step = TAU / this.n;
+      this.k = Math.max(0, Math.min(this.n, Math.round(this.theta / step)));
     }
     this.draw();
-    if(updateK) this.syncSimpleConfig();
+    if (updateK) this.syncSimpleConfig();
   }
-  setN(n){
-    const nn=Math.max(this.minN,Math.min(this.maxN,Math.round(n)));
-    this.n=nn;
-    const step=TAU/this.n;
-    this.k=Math.max(0,Math.min(this.n,Math.round(this.theta/step)));
+  setN(n) {
+    const nn = Math.max(this.minN, Math.min(this.maxN, Math.round(n)));
+    this.n = nn;
+    const step = TAU / this.n;
+    this.k = Math.max(0, Math.min(this.n, Math.round(this.theta / step)));
     this.draw();
     this.syncSimpleConfig();
   }
-  setK(k){
-    const kk=Math.max(0,Math.min(this.n,Math.round(k)));
-    this.k=kk;
-    this.theta=(this.k/this.n)*TAU;
+  setK(k) {
+    const kk = Math.max(0, Math.min(this.n, Math.round(k)));
+    this.k = kk;
+    this.theta = this.k / this.n * TAU;
     this.draw();
     this.syncSimpleConfig();
   }
-  syncSimpleConfig(){
-    if(this.index == null) return;
+  syncSimpleConfig() {
+    if (this.index == null) return;
     const idx = this.index;
-    if(Array.isArray(SIMPLE.pizzas)){
-      if(!SIMPLE.pizzas[idx]) SIMPLE.pizzas[idx] = {};
+    if (Array.isArray(SIMPLE.pizzas)) {
+      if (!SIMPLE.pizzas[idx]) SIMPLE.pizzas[idx] = {};
       SIMPLE.pizzas[idx].n = this.n;
       SIMPLE.pizzas[idx].t = this.k;
     }
     const field = id => document.getElementById(id);
     const base = idx + 1;
     const nField = field(`p${base}N`);
-    if(nField) nField.value = String(this.n);
+    if (nField) nField.value = String(this.n);
     const tField = field(`p${base}T`);
-    if(tField) tField.value = String(this.k);
+    if (tField) tField.value = String(this.k);
     const nVal = field(`nVal${base}`);
-    if(nVal) nVal.textContent = String(this.n);
+    if (nVal) nVal.textContent = String(this.n);
   }
-
-  _updateTextAbove(){
-    if(this.metaLine){
-      this.metaLine.textContent =
-        (this.textMode==="percent") ? (fmt(this.n?this.k/this.n*100:0)+" %") :
-        (this.textMode==="decimal") ? fmt(this.n?this.k/this.n:0) : "";
+  _updateTextAbove() {
+    if (this.metaLine) {
+      this.metaLine.textContent = this.textMode === "percent" ? fmt(this.n ? this.k / this.n * 100 : 0) + " %" : this.textMode === "decimal" ? fmt(this.n ? this.k / this.n : 0) : "";
     }
-    if(this.fracBox && this.textMode==="frac"){
-      if(this.fracNum) this.fracNum.textContent=this.k;
-      if(this.fracDen) this.fracDen.textContent=this.n;
+    if (this.fracBox && this.textMode === "frac") {
+      if (this.fracNum) this.fracNum.textContent = this.k;
+      if (this.fracDen) this.fracDen.textContent = this.n;
     }
   }
-  _updateAria(){
-    const g=gcd(this.k,this.n), dec=fmt(this.n?this.k/this.n:0), pct=fmt(this.n?this.k/this.n*100:0)+" %";
-    const simp=g>1?` (${this.k/g}/${this.n/g})`:"";
-    this.slider.setAttribute("aria-valuemin","0");
-    this.slider.setAttribute("aria-valuemax",String(this.n));
-    this.slider.setAttribute("aria-valuenow",String(this.k));
-    this.slider.setAttribute("aria-valuetext",`${this.k} av ${this.n}${simp}, ${dec} som desimal, ${pct}`);
-    if(this.titleEl) this.titleEl.textContent = `Brøkpizza: ${this.k}/${this.n}`;
-    if(this.descEl)  this.descEl.textContent  = `Viser ${this.n} sektorer totalt, ${this.k} av dem er fylt`;
+  _updateAria() {
+    const g = gcd(this.k, this.n),
+      dec = fmt(this.n ? this.k / this.n : 0),
+      pct = fmt(this.n ? this.k / this.n * 100 : 0) + " %";
+    const simp = g > 1 ? ` (${this.k / g}/${this.n / g})` : "";
+    this.slider.setAttribute("aria-valuemin", "0");
+    this.slider.setAttribute("aria-valuemax", String(this.n));
+    this.slider.setAttribute("aria-valuenow", String(this.k));
+    this.slider.setAttribute("aria-valuetext", `${this.k} av ${this.n}${simp}, ${dec} som desimal, ${pct}`);
+    if (this.titleEl) this.titleEl.textContent = `Brøkpizza: ${this.k}/${this.n}`;
+    if (this.descEl) this.descEl.textContent = `Viser ${this.n} sektorer totalt, ${this.k} av dem er fylt`;
   }
-
-  draw(){
-    const step=TAU/this.n, aEnd=this.k*step;
-    if(this.nVal && this.showDenominatorValue) this.nVal.textContent=this.n;
-
-    this.gFill.innerHTML="";
-    for(let i=0;i<this.n;i++){
-      const a0=i*step,a1=a0+step,filled=i<this.k;
-      this.gFill.appendChild(mk("path",{d:arcPath(this.R,a0,a1),class:`sector ${filled?"sector-fill":"sector-empty"}`}));
+  draw() {
+    const step = TAU / this.n,
+      aEnd = this.k * step;
+    if (this.nVal && this.showDenominatorValue) this.nVal.textContent = this.n;
+    this.gFill.innerHTML = "";
+    for (let i = 0; i < this.n; i++) {
+      const a0 = i * step,
+        a1 = a0 + step,
+        filled = i < this.k;
+      this.gFill.appendChild(mk("path", {
+        d: arcPath(this.R, a0, a1),
+        class: `sector ${filled ? "sector-fill" : "sector-empty"}`
+      }));
     }
-
-    this.clipFilled.innerHTML=""; this.clipEmpty.innerHTML="";
-    if(this.k<=0) this.clipEmpty.appendChild(mk("circle",{cx:0,cy:0,r:this.R}));
-    else if(this.k>=this.n) this.clipFilled.appendChild(mk("circle",{cx:0,cy:0,r:this.R}));
-    else { this.clipFilled.appendChild(mk("path",{d:arcPath(this.R,0,aEnd)})); this.clipEmpty.appendChild(mk("path",{d:arcPath(this.R,aEnd,TAU)})); }
-
-    this.gLinesBlack.innerHTML=""; this.gLinesWhite.innerHTML="";
-    if(this.n>1){
-      for(let i=0;i<this.n;i++){
-        const a=i*step,x=this.R*Math.cos(a),y=this.R*Math.sin(a);
-        const lnB=mk("line",{x1:0,y1:0,x2:x,y2:y,class:"dash"});
-        const lnW=mk("line",{x1:0,y1:0,x2:x,y2:y,class:"dash"});
-        this.gLinesBlack.appendChild(lnB); this.gLinesWhite.appendChild(lnW);
+    this.clipFilled.innerHTML = "";
+    this.clipEmpty.innerHTML = "";
+    if (this.k <= 0) this.clipEmpty.appendChild(mk("circle", {
+      cx: 0,
+      cy: 0,
+      r: this.R
+    }));else if (this.k >= this.n) this.clipFilled.appendChild(mk("circle", {
+      cx: 0,
+      cy: 0,
+      r: this.R
+    }));else {
+      this.clipFilled.appendChild(mk("path", {
+        d: arcPath(this.R, 0, aEnd)
+      }));
+      this.clipEmpty.appendChild(mk("path", {
+        d: arcPath(this.R, aEnd, TAU)
+      }));
+    }
+    this.gLinesBlack.innerHTML = "";
+    this.gLinesWhite.innerHTML = "";
+    if (this.n > 1) {
+      for (let i = 0; i < this.n; i++) {
+        const a = i * step,
+          x = this.R * Math.cos(a),
+          y = this.R * Math.sin(a);
+        const lnB = mk("line", {
+          x1: 0,
+          y1: 0,
+          x2: x,
+          y2: y,
+          class: "dash"
+        });
+        const lnW = mk("line", {
+          x1: 0,
+          y1: 0,
+          x2: x,
+          y2: y,
+          class: "dash"
+        });
+        this.gLinesBlack.appendChild(lnB);
+        this.gLinesWhite.appendChild(lnW);
       }
     }
-
-    if(this.fullyLocked){
-      this.gHandle.style.display="none";
-    }else{
-      this.gHandle.style.display="";
-      this.handle.setAttribute("cx", this.R*Math.cos(this.theta));
-      this.handle.setAttribute("cy", this.R*Math.sin(this.theta));
+    if (this.fullyLocked) {
+      this.gHandle.style.display = "none";
+    } else {
+      this.gHandle.style.display = "";
+      this.handle.setAttribute("cx", this.R * Math.cos(this.theta));
+      this.handle.setAttribute("cy", this.R * Math.sin(this.theta));
     }
-
     this._updateAria();
     this._updateTextAbove();
     scheduleCenterAlign();
@@ -402,7 +566,6 @@ const EXPORT_SVG_STYLE = `
 .meta, .fracNum, .fracDen{font-size:22px;text-anchor:middle}
 .fracLine{stroke:#000;stroke-width:2}
 `;
-
 const INTERACTIVE_SVG_SCRIPT = `
 /*<![CDATA[*/
 (function(){
@@ -570,33 +733,35 @@ const INTERACTIVE_SVG_SCRIPT = `
 /* =======================
    Last ned figurer: statisk SVG
    ======================= */
-function downloadSVG(svgEl, filename="pizza.svg") {
-  if(!svgEl) return;
+function downloadSVG(svgEl, filename = "pizza.svg") {
+  if (!svgEl) return;
   const clone = svgEl.cloneNode(true);
 
   // Fjern interaktive elementer
   clone.querySelectorAll(".handle, .a11y").forEach(el => el.remove());
-
-  clone.setAttribute("xmlns","http://www.w3.org/2000/svg");
-  clone.setAttribute("xmlns:xlink","http://www.w3.org/1999/xlink");
-
-  let [minX,minY,w,h] = (clone.getAttribute("viewBox")||"-210 -210 420 420").trim().split(/\s+/).map(Number);
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  clone.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
+  let [minX, minY, w, h] = (clone.getAttribute("viewBox") || "-210 -210 420 420").trim().split(/\s+/).map(Number);
   clone.setAttribute("width", w);
   clone.setAttribute("height", h);
-
-  const bg = mk("rect", { x: minX, y: minY, width: w, height: h, fill:"#fff" });
+  const bg = mk("rect", {
+    x: minX,
+    y: minY,
+    width: w,
+    height: h,
+    fill: "#fff"
+  });
   clone.insertBefore(bg, clone.firstChild);
-
-  const styleEl = document.createElementNS("http://www.w3.org/2000/svg","style");
-  styleEl.setAttribute("type","text/css");
+  const styleEl = document.createElementNS("http://www.w3.org/2000/svg", "style");
+  styleEl.setAttribute("type", "text/css");
   styleEl.appendChild(document.createTextNode(EXPORT_SVG_STYLE));
   clone.insertBefore(styleEl, clone.firstChild);
-
   const xml = new XMLSerializer().serializeToString(clone);
   const file = `<?xml version="1.0" encoding="UTF-8"?>\n` + xml;
-
-  const blob = new Blob([file], {type: "image/svg+xml;charset=utf-8"});
-  const url  = URL.createObjectURL(blob);
+  const blob = new Blob([file], {
+    type: "image/svg+xml;charset=utf-8"
+  });
+  const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
   a.download = filename;
@@ -610,57 +775,63 @@ function downloadSVG(svgEl, filename="pizza.svg") {
    Last ned figurer: interaktiv SVG
    – brøk OVER, +/− UNDER, pen spacing
    ======================= */
-function downloadInteractiveSVG(svgEl, filename="pizza-interaktiv.svg") {
-  if(!svgEl) return;
+function downloadInteractiveSVG(svgEl, filename = "pizza-interaktiv.svg") {
+  var _inst$minN, _inst$maxN;
+  if (!svgEl) return;
   const clone = svgEl.cloneNode(true);
-
-  clone.setAttribute("xmlns","http://www.w3.org/2000/svg");
-  clone.setAttribute("xmlns:xlink","http://www.w3.org/1999/xlink");
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  clone.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
 
   // Utvid viewBox for topp/bunn
-  let [minX,minY,w,h] = (clone.getAttribute("viewBox")||"-210 -210 420 420").trim().split(/\s+/).map(Number);
+  let [minX, minY, w, h] = (clone.getAttribute("viewBox") || "-210 -210 420 420").trim().split(/\s+/).map(Number);
   const M_TOP = 78;
   const M_BOTTOM = 96;
   minY = minY - M_TOP;
-  h    = h + M_TOP + M_BOTTOM;
+  h = h + M_TOP + M_BOTTOM;
   clone.setAttribute("viewBox", `${minX} ${minY} ${w} ${h}`);
   clone.setAttribute("width", w);
   clone.setAttribute("height", h);
 
   // Hvit bakgrunn
-  const bg = mk("rect", { x: minX, y: minY, width: w, height: h, fill:"#fff" });
+  const bg = mk("rect", {
+    x: minX,
+    y: minY,
+    width: w,
+    height: h,
+    fill: "#fff"
+  });
   clone.insertBefore(bg, clone.firstChild);
 
   // Innebygd stil
-  const styleEl = document.createElementNS("http://www.w3.org/2000/svg","style");
-  styleEl.setAttribute("type","text/css");
+  const styleEl = document.createElementNS("http://www.w3.org/2000/svg", "style");
+  styleEl.setAttribute("type", "text/css");
   styleEl.appendChild(document.createTextNode(EXPORT_SVG_STYLE));
   clone.insertBefore(styleEl, clone.firstChild);
 
   // State fra levende instans
   const inst = REG.get(svgEl);
-  const textMode = inst?.textMode || "none";
-  const nMin = inst?.minN ?? 1;
-  const nMax = inst?.maxN ?? 24;
-  const showNVal = inst?.showDenominatorValue !== false;
+  const textMode = (inst === null || inst === void 0 ? void 0 : inst.textMode) || "none";
+  const nMin = (_inst$minN = inst === null || inst === void 0 ? void 0 : inst.minN) !== null && _inst$minN !== void 0 ? _inst$minN : 1;
+  const nMax = (_inst$maxN = inst === null || inst === void 0 ? void 0 : inst.maxN) !== null && _inst$maxN !== void 0 ? _inst$maxN : 24;
+  const showNVal = (inst === null || inst === void 0 ? void 0 : inst.showDenominatorValue) !== false;
 
   // n, k, R
   const n = clone.querySelectorAll(".sector").length || 1;
   const k = clone.querySelectorAll(".sector-fill").length || 0;
   const rEl = clone.querySelector("circle.rim");
-  const R = rEl ? parseFloat(rEl.getAttribute("r")||"180") : 180;
+  const R = rEl ? parseFloat(rEl.getAttribute("r") || "180") : 180;
 
   // Oppdater beskrivelses-elementer slik at eksportert SVG forklarer
   // gjeldende brøk og totalt sektortall. Dette gjør at både skjermlesere
   // og videre interaksjon via innebygd skript starter med korrekt tekst.
   const tEl = clone.querySelector('title');
   const dEl = clone.querySelector('desc');
-  if(tEl) tEl.textContent = `Brøkpizza: ${k}/${n}`;
-  if(dEl) dEl.textContent = `Viser ${n} sektorer totalt, ${k} av dem er fylt`;
+  if (tEl) tEl.textContent = `Brøkpizza: ${k}/${n}`;
+  if (dEl) dEl.textContent = `Viser ${n} sektorer totalt, ${k} av dem er fylt`;
 
   // Sørg for at handle vises
   const hndl = clone.querySelector(".handle");
-  if(hndl && hndl.parentNode && hndl.parentNode.style) hndl.parentNode.style.display = "";
+  if (hndl && hndl.parentNode && hndl.parentNode.style) hndl.parentNode.style.display = "";
 
   // Data for skriptet
   clone.setAttribute("data-n", String(n));
@@ -672,16 +843,16 @@ function downloadInteractiveSVG(svgEl, filename="pizza-interaktiv.svg") {
   clone.setAttribute("data-show-nval", showNVal ? "1" : "0");
 
   // Inline-skript (med rettet parentes-feil)
-  const scriptEl = document.createElementNS("http://www.w3.org/2000/svg","script");
-  scriptEl.setAttribute("type","application/ecmascript");
+  const scriptEl = document.createElementNS("http://www.w3.org/2000/svg", "script");
+  scriptEl.setAttribute("type", "application/ecmascript");
   scriptEl.appendChild(document.createTextNode(INTERACTIVE_SVG_SCRIPT));
   clone.appendChild(scriptEl);
-
   const xml = new XMLSerializer().serializeToString(clone);
   const file = `<?xml version="1.0" encoding="UTF-8"?>\n` + xml;
-
-  const blob = new Blob([file], {type: "image/svg+xml;charset=utf-8"});
-  const url  = URL.createObjectURL(blob);
+  const blob = new Blob([file], {
+    type: "image/svg+xml;charset=utf-8"
+  });
+  const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
   a.download = filename;
@@ -690,111 +861,173 @@ function downloadInteractiveSVG(svgEl, filename="pizza-interaktiv.svg") {
   a.remove();
   URL.revokeObjectURL(url);
 }
-
-function getVisiblePizzas(){
-  return PIZZA_DOM
-    .map(m => document.getElementById(m.svgId))
-    .filter(svg => svg && svg.closest(".pizzaPanel")?.style.display !== "none");
+function getVisiblePizzas() {
+  return PIZZA_DOM.map(m => document.getElementById(m.svgId)).filter(svg => {
+    var _svg$closest;
+    return svg && ((_svg$closest = svg.closest(".pizzaPanel")) === null || _svg$closest === void 0 ? void 0 : _svg$closest.style.display) !== "none";
+  });
 }
-
-function buildAllPizzasSVG(){
-  const svgs=getVisiblePizzas();
-  if(!svgs.length) return null;
-  const gap=24, size=420, opW=80, ops=SIMPLE.ops||[];
-  const opCount=ops.slice(0,svgs.length-1).filter(o=>o).length;
-  const w=size*svgs.length + gap*(svgs.length-1) + opW*opCount;
-  const h=size;
-  const root=mk("svg",{xmlns:"http://www.w3.org/2000/svg", "xmlns:xlink":"http://www.w3.org/1999/xlink", width:w, height:h, viewBox:`0 0 ${w} ${h}`});
-  const bg=mk("rect",{x:0,y:0,width:w,height:h,fill:"#fff"});
+function buildAllPizzasSVG() {
+  const svgs = getVisiblePizzas();
+  if (!svgs.length) return null;
+  const gap = 24,
+    size = 420,
+    opW = 80,
+    ops = SIMPLE.ops || [];
+  const opCount = ops.slice(0, svgs.length - 1).filter(o => o).length;
+  const w = size * svgs.length + gap * (svgs.length - 1) + opW * opCount;
+  const h = size;
+  const root = mk("svg", {
+    xmlns: "http://www.w3.org/2000/svg",
+    "xmlns:xlink": "http://www.w3.org/1999/xlink",
+    width: w,
+    height: h,
+    viewBox: `0 0 ${w} ${h}`
+  });
+  const bg = mk("rect", {
+    x: 0,
+    y: 0,
+    width: w,
+    height: h,
+    fill: "#fff"
+  });
   root.appendChild(bg);
-  const styleEl=mk("style",{type:"text/css"});
+  const styleEl = mk("style", {
+    type: "text/css"
+  });
   styleEl.appendChild(document.createTextNode(EXPORT_SVG_STYLE));
   root.appendChild(styleEl);
-  let x=0;
-  svgs.forEach((svg,i)=>{
-    const clone=svg.cloneNode(true);
-    clone.querySelectorAll(".handle, .a11y").forEach(el=>el.remove());
+  let x = 0;
+  svgs.forEach((svg, i) => {
+    const clone = svg.cloneNode(true);
+    clone.querySelectorAll(".handle, .a11y").forEach(el => el.remove());
     clone.setAttribute("x", x);
     clone.setAttribute("y", 0);
     clone.setAttribute("width", size);
     clone.setAttribute("height", size);
     root.appendChild(clone);
     x += size;
-    const sign=ops[i];
-    if(i<svgs.length-1){
-      if(sign){
-        x += opW/2;
-        const t=mk("text",{x:x,y:size/2,"text-anchor":"middle","dominant-baseline":"middle","font-size":"80"});
-        t.textContent=sign;
+    const sign = ops[i];
+    if (i < svgs.length - 1) {
+      if (sign) {
+        x += opW / 2;
+        const t = mk("text", {
+          x: x,
+          y: size / 2,
+          "text-anchor": "middle",
+          "dominant-baseline": "middle",
+          "font-size": "80"
+        });
+        t.textContent = sign;
         root.appendChild(t);
-        x += opW/2;
+        x += opW / 2;
       }
       x += gap;
     }
   });
-  const xml=new XMLSerializer().serializeToString(root);
-  return `<?xml version="1.0" encoding="UTF-8"?>\n`+xml;
+  const xml = new XMLSerializer().serializeToString(root);
+  return `<?xml version="1.0" encoding="UTF-8"?>\n` + xml;
 }
-
-function downloadAllPizzasSVG(filename="broksirkler.svg"){
-  const file=buildAllPizzasSVG();
-  if(!file) return;
-  const blob=new Blob([file],{type:"image/svg+xml;charset=utf-8"});
-  const url=URL.createObjectURL(blob);
-  const a=document.createElement("a");
-  a.href=url; a.download=filename; document.body.appendChild(a); a.click(); a.remove();
+function downloadAllPizzasSVG(filename = "broksirkler.svg") {
+  const file = buildAllPizzasSVG();
+  if (!file) return;
+  const blob = new Blob([file], {
+    type: "image/svg+xml;charset=utf-8"
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
   URL.revokeObjectURL(url);
 }
-
-function downloadAllPizzasPNG(filename="broksirkler.png"){
-  const file=buildAllPizzasSVG();
-  if(!file) return;
-  const blob=new Blob([file],{type:"image/svg+xml;charset=utf-8"});
-  const url=URL.createObjectURL(blob);
-  const img=new Image();
-  img.onload=()=>{
-    const w=img.width,h=img.height;
-    const canvas=document.createElement('canvas'); canvas.width=w; canvas.height=h;
-    const ctx=canvas.getContext('2d'); ctx.fillStyle='#fff'; ctx.fillRect(0,0,w,h); ctx.drawImage(img,0,0,w,h);
+function downloadAllPizzasPNG(filename = "broksirkler.png") {
+  const file = buildAllPizzasSVG();
+  if (!file) return;
+  const blob = new Blob([file], {
+    type: "image/svg+xml;charset=utf-8"
+  });
+  const url = URL.createObjectURL(blob);
+  const img = new Image();
+  img.onload = () => {
+    const w = img.width,
+      h = img.height;
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(0, 0, w, h);
+    ctx.drawImage(img, 0, 0, w, h);
     URL.revokeObjectURL(url);
-    canvas.toBlob(b=>{ const urlPng=URL.createObjectURL(b); const a=document.createElement('a'); a.href=urlPng; a.download=filename; document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(urlPng); },'image/png');
+    canvas.toBlob(b => {
+      const urlPng = URL.createObjectURL(b);
+      const a = document.createElement('a');
+      a.href = urlPng;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(urlPng);
+    }, 'image/png');
   };
-  img.src=url;
+  img.src = url;
 }
-
-function downloadAllPizzasInteractiveSVG(filename="broksirkler-interaktiv.svg"){ 
-  const svgs=getVisiblePizzas();
-  if(!svgs.length) return;
-  const gap=24, size=420, M_TOP=78, M_BOTTOM=96, opW=80, ops=SIMPLE.ops||[];
-  const opCount=ops.slice(0,svgs.length-1).filter(o=>o).length;
-  const w=size*svgs.length + gap*(svgs.length-1) + opW*opCount;
-  const h=size + M_TOP + M_BOTTOM;
-  const root=mk("svg",{xmlns:"http://www.w3.org/2000/svg", "xmlns:xlink":"http://www.w3.org/1999/xlink", width:w, height:h, viewBox:`0 0 ${w} ${h}`});
-  const bg=mk("rect",{x:0,y:0,width:w,height:h,fill:"#fff"});
+function downloadAllPizzasInteractiveSVG(filename = "broksirkler-interaktiv.svg") {
+  const svgs = getVisiblePizzas();
+  if (!svgs.length) return;
+  const gap = 24,
+    size = 420,
+    M_TOP = 78,
+    M_BOTTOM = 96,
+    opW = 80,
+    ops = SIMPLE.ops || [];
+  const opCount = ops.slice(0, svgs.length - 1).filter(o => o).length;
+  const w = size * svgs.length + gap * (svgs.length - 1) + opW * opCount;
+  const h = size + M_TOP + M_BOTTOM;
+  const root = mk("svg", {
+    xmlns: "http://www.w3.org/2000/svg",
+    "xmlns:xlink": "http://www.w3.org/1999/xlink",
+    width: w,
+    height: h,
+    viewBox: `0 0 ${w} ${h}`
+  });
+  const bg = mk("rect", {
+    x: 0,
+    y: 0,
+    width: w,
+    height: h,
+    fill: "#fff"
+  });
   root.appendChild(bg);
-  const styleEl=mk("style",{type:"text/css"});
+  const styleEl = mk("style", {
+    type: "text/css"
+  });
   styleEl.appendChild(document.createTextNode(EXPORT_SVG_STYLE));
   root.appendChild(styleEl);
-  let x=0;
-  svgs.forEach((svg,i)=>{
-    const clone=svg.cloneNode(true);
-    const inst=REG.get(svg);
-    const textMode=inst?.textMode || "none";
-    const nMin=inst?.minN ?? 1;
-    const nMax=inst?.maxN ?? 24;
-    const showNVal=inst?.showDenominatorValue !== false;
-    const n=clone.querySelectorAll(".sector").length || 1;
-    const k=clone.querySelectorAll(".sector-fill").length || 0;
-    const rEl=clone.querySelector("circle.rim");
-    const R=rEl?parseFloat(rEl.getAttribute("r")||"180"):180;
-    const hndl=clone.querySelector(".handle");
-    if(hndl && hndl.parentNode && hndl.parentNode.style) hndl.parentNode.style.display="";
+  let x = 0;
+  svgs.forEach((svg, i) => {
+    var _inst$minN2, _inst$maxN2;
+    const clone = svg.cloneNode(true);
+    const inst = REG.get(svg);
+    const textMode = (inst === null || inst === void 0 ? void 0 : inst.textMode) || "none";
+    const nMin = (_inst$minN2 = inst === null || inst === void 0 ? void 0 : inst.minN) !== null && _inst$minN2 !== void 0 ? _inst$minN2 : 1;
+    const nMax = (_inst$maxN2 = inst === null || inst === void 0 ? void 0 : inst.maxN) !== null && _inst$maxN2 !== void 0 ? _inst$maxN2 : 24;
+    const showNVal = (inst === null || inst === void 0 ? void 0 : inst.showDenominatorValue) !== false;
+    const n = clone.querySelectorAll(".sector").length || 1;
+    const k = clone.querySelectorAll(".sector-fill").length || 0;
+    const rEl = clone.querySelector("circle.rim");
+    const R = rEl ? parseFloat(rEl.getAttribute("r") || "180") : 180;
+    const hndl = clone.querySelector(".handle");
+    if (hndl && hndl.parentNode && hndl.parentNode.style) hndl.parentNode.style.display = "";
     // Sikre at hver eksportert SVG får oppdatert <title>/<desc>
     // slik at tilgjengelighetsbeskrivelsen matcher gjeldende brøk.
-    const tEl=clone.querySelector('title');
-    const dEl=clone.querySelector('desc');
-    if(tEl) tEl.textContent=`Brøkpizza: ${k}/${n}`;
-    if(dEl) dEl.textContent=`Viser ${n} sektorer totalt, ${k} av dem er fylt`;
+    const tEl = clone.querySelector('title');
+    const dEl = clone.querySelector('desc');
+    if (tEl) tEl.textContent = `Brøkpizza: ${k}/${n}`;
+    if (dEl) dEl.textContent = `Viser ${n} sektorer totalt, ${k} av dem er fylt`;
     clone.setAttribute("data-n", String(n));
     clone.setAttribute("data-k", String(k));
     clone.setAttribute("data-r", String(R));
@@ -806,120 +1039,124 @@ function downloadAllPizzasInteractiveSVG(filename="broksirkler-interaktiv.svg"){
     clone.setAttribute("y", M_TOP);
     clone.setAttribute("width", size);
     clone.setAttribute("height", size);
-    const scriptEl=document.createElementNS("http://www.w3.org/2000/svg","script");
-    scriptEl.setAttribute("type","application/ecmascript");
+    const scriptEl = document.createElementNS("http://www.w3.org/2000/svg", "script");
+    scriptEl.setAttribute("type", "application/ecmascript");
     scriptEl.appendChild(document.createTextNode(INTERACTIVE_SVG_SCRIPT));
     clone.appendChild(scriptEl);
     root.appendChild(clone);
     x += size;
-    const sign=ops[i];
-    if(i<svgs.length-1){
-      if(sign){
-        x += opW/2;
-        const t=mk("text",{x:x,y:M_TOP+size/2,"text-anchor":"middle","dominant-baseline":"middle","font-size":"80"});
-        t.textContent=sign;
+    const sign = ops[i];
+    if (i < svgs.length - 1) {
+      if (sign) {
+        x += opW / 2;
+        const t = mk("text", {
+          x: x,
+          y: M_TOP + size / 2,
+          "text-anchor": "middle",
+          "dominant-baseline": "middle",
+          "font-size": "80"
+        });
+        t.textContent = sign;
         root.appendChild(t);
-        x += opW/2;
+        x += opW / 2;
       }
       x += gap;
     }
   });
-  const xml=new XMLSerializer().serializeToString(root);
-  const file=`<?xml version="1.0" encoding="UTF-8"?>\n`+xml;
-  const blob=new Blob([file],{type:"image/svg+xml;charset=utf-8"});
-  const url=URL.createObjectURL(blob);
-  const a=document.createElement("a");
-  a.href=url; a.download=filename; document.body.appendChild(a); a.click(); a.remove();
+  const xml = new XMLSerializer().serializeToString(root);
+  const file = `<?xml version="1.0" encoding="UTF-8"?>\n` + xml;
+  const blob = new Blob([file], {
+    type: "image/svg+xml;charset=utf-8"
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
   URL.revokeObjectURL(url);
 }
-
-function setupGlobalDownloadButtons(){
-  const btnStatic=document.getElementById("btnStaticAll");
-  const btnInteractive=document.getElementById("btnInteractiveAll");
-  const btnPng=document.getElementById("btnPngAll");
-  if(btnStatic) btnStatic.addEventListener("click",()=>downloadAllPizzasSVG());
-  if(btnInteractive) btnInteractive.addEventListener("click",()=>downloadAllPizzasInteractiveSVG());
-  if(btnPng) btnPng.addEventListener("click",()=>downloadAllPizzasPNG());
+function setupGlobalDownloadButtons() {
+  const btnStatic = document.getElementById("btnStaticAll");
+  const btnInteractive = document.getElementById("btnInteractiveAll");
+  const btnPng = document.getElementById("btnPngAll");
+  if (btnStatic) btnStatic.addEventListener("click", () => downloadAllPizzasSVG());
+  if (btnInteractive) btnInteractive.addEventListener("click", () => downloadAllPizzasInteractiveSVG());
+  if (btnPng) btnPng.addEventListener("click", () => downloadAllPizzasPNG());
 }
 
 /* =======================
    Init
    ======================= */
-function initFromHtml(){
+function initFromHtml() {
   const cfg = readConfigFromHtml();
   SIMPLE.pizzas = cfg.pizzas;
   SIMPLE.ops = cfg.ops;
   let visibleCount = 0;
   REG.clear();
-
-  PIZZA_DOM.forEach((map,i)=>{
-    const panel=document.getElementById(map.svgId)?.closest(".pizzaPanel");
-    if(!panel) return;
-    if(PANEL_HTML[i]==null) PANEL_HTML[i]=panel.innerHTML;
+  PIZZA_DOM.forEach((map, i) => {
+    var _document$getElementB12, _pcfg$minN, _pcfg$maksN, _map$index, _pcfg$n, _pcfg$t, _pcfg$n2, _pcfg$text;
+    const panel = (_document$getElementB12 = document.getElementById(map.svgId)) === null || _document$getElementB12 === void 0 ? void 0 : _document$getElementB12.closest(".pizzaPanel");
+    if (!panel) return;
+    if (PANEL_HTML[i] == null) PANEL_HTML[i] = panel.innerHTML;
     panel.innerHTML = PANEL_HTML[i];
     const isVisible = panel.style.display !== "none";
-    if(!SIMPLE.pizzas[i]) SIMPLE.pizzas[i] = {};
+    if (!SIMPLE.pizzas[i]) SIMPLE.pizzas[i] = {};
     SIMPLE.pizzas[i].visible = isVisible;
-    if(!isVisible) return;
+    if (!isVisible) return;
     visibleCount++;
     const pcfg = cfg.pizzas[i];
-
-    const minN=Math.max(1, pcfg.minN ?? 1);
-    const maxN=Math.max(minN, pcfg.maksN ?? 24);
-
+    const minN = Math.max(1, (_pcfg$minN = pcfg.minN) !== null && _pcfg$minN !== void 0 ? _pcfg$minN : 1);
+    const maxN = Math.max(minN, (_pcfg$maksN = pcfg.maksN) !== null && _pcfg$maksN !== void 0 ? _pcfg$maksN : 24);
     new Pizza({
       ...map,
-      index: map.index ?? i,
-      n: pcfg.n ?? 1,
-      k: Math.min(pcfg.t ?? 0, pcfg.n ?? 1),
-      minN, maxN,
-      textMode: (pcfg.text ?? "none"),
+      index: (_map$index = map.index) !== null && _map$index !== void 0 ? _map$index : i,
+      n: (_pcfg$n = pcfg.n) !== null && _pcfg$n !== void 0 ? _pcfg$n : 1,
+      k: Math.min((_pcfg$t = pcfg.t) !== null && _pcfg$t !== void 0 ? _pcfg$t : 0, (_pcfg$n2 = pcfg.n) !== null && _pcfg$n2 !== void 0 ? _pcfg$n2 : 1),
+      minN,
+      maxN,
+      textMode: (_pcfg$text = pcfg.text) !== null && _pcfg$text !== void 0 ? _pcfg$text : "none",
       lockDenominator: !!pcfg.lockN,
-      lockNumerator:   !!pcfg.lockT,
+      lockNumerator: !!pcfg.lockT,
       showDenominatorValue: !pcfg.hideNVal
     });
-
   });
-
-  cfg.ops.forEach((op,i)=>{
-    const el=document.getElementById(`opDisplay${i+1}`);
-    const nextPanel=document.getElementById(`panel${i+2}`);
-    if(!el) return;
-    if(op && nextPanel && nextPanel.style.display !== "none"){
-      el.textContent=op;
-      el.style.display="";
-    }else{
-      el.style.display="none";
+  cfg.ops.forEach((op, i) => {
+    const el = document.getElementById(`opDisplay${i + 1}`);
+    const nextPanel = document.getElementById(`panel${i + 2}`);
+    if (!el) return;
+    if (op && nextPanel && nextPanel.style.display !== "none") {
+      el.textContent = op;
+      el.style.display = "";
+    } else {
+      el.style.display = "none";
     }
   });
-
   scheduleCenterAlign();
   fitPizzasToLine();
   setupRemovePizzaButtons();
-
-  if(visibleCount<=0){
-    const firstPanel=document.getElementById('panel1');
-    if(firstPanel && firstPanel.style.display!=="none") visibleCount=1;
-    else visibleCount=0;
+  if (visibleCount <= 0) {
+    const firstPanel = document.getElementById('panel1');
+    if (firstPanel && firstPanel.style.display !== "none") visibleCount = 1;else visibleCount = 0;
   }
   SIMPLE.visibleCount = visibleCount || 1;
 }
-
 window.addEventListener("load", () => {
   initFromHtml();
   setupGlobalDownloadButtons();
   const addBtn = document.getElementById('addPizza');
   const fieldset2 = document.getElementById('fieldset2');
   const fieldset3 = document.getElementById('fieldset3');
-  addBtn?.addEventListener('click', () => {
+  addBtn === null || addBtn === void 0 || addBtn.addEventListener('click', () => {
     const panel2 = document.getElementById('panel2');
     const panel3 = document.getElementById('panel3');
-    if(panel2 && panel2.style.display === 'none'){
+    if (panel2 && panel2.style.display === 'none') {
       panel2.style.display = '';
-      if(fieldset2) fieldset2.style.display = '';
-    }else if(panel3 && panel3.style.display === 'none'){
+      if (fieldset2) fieldset2.style.display = '';
+    } else if (panel3 && panel3.style.display === 'none') {
       panel3.style.display = '';
-      if(fieldset3) fieldset3.style.display = '';
+      if (fieldset3) fieldset3.style.display = '';
       addBtn.style.display = 'none';
     }
     initFromHtml();
@@ -929,67 +1166,59 @@ window.addEventListener("load", () => {
     el.addEventListener("change", initFromHtml);
   });
 });
-
-function applySimpleConfigToInputs(){
+function applySimpleConfigToInputs() {
   const pizzas = Array.isArray(SIMPLE.pizzas) ? SIMPLE.pizzas : [];
   const ops = Array.isArray(SIMPLE.ops) ? SIMPLE.ops : [];
-
   const clampCount = val => {
     const num = Number(val);
-    if(!Number.isFinite(num)) return null;
+    if (!Number.isFinite(num)) return null;
     return Math.min(3, Math.max(1, Math.round(num)));
   };
-
   let visible = clampCount(SIMPLE.visibleCount);
-  if(visible == null){
-    visible = pizzas.reduce((acc,p,idx)=>{
-      if(idx===0) return acc+1;
-      if(p && (p.visible || p?.lockN || p?.lockT || p?.text || p?.t || p?.n)) return acc+1;
+  if (visible == null) {
+    visible = pizzas.reduce((acc, p, idx) => {
+      if (idx === 0) return acc + 1;
+      if (p && (p.visible || p !== null && p !== void 0 && p.lockN || p !== null && p !== void 0 && p.lockT || p !== null && p !== void 0 && p.text || p !== null && p !== void 0 && p.t || p !== null && p !== void 0 && p.n)) return acc + 1;
       return acc;
-    },0);
-    if(!visible) visible = 1;
+    }, 0);
+    if (!visible) visible = 1;
   }
-
-  for(let i=1;i<=3;i++){
-    const panel=document.getElementById(`panel${i}`);
-    const fieldset=document.getElementById(`fieldset${i}`);
-    const shouldShow=i<=visible;
-    if(panel) panel.style.display=shouldShow?"":"none";
-    if(fieldset) fieldset.style.display=shouldShow?"":"none";
-    if(!SIMPLE.pizzas[i-1]) SIMPLE.pizzas[i-1] = {};
-    SIMPLE.pizzas[i-1].visible = shouldShow;
+  for (let i = 1; i <= 3; i++) {
+    const panel = document.getElementById(`panel${i}`);
+    const fieldset = document.getElementById(`fieldset${i}`);
+    const shouldShow = i <= visible;
+    if (panel) panel.style.display = shouldShow ? "" : "none";
+    if (fieldset) fieldset.style.display = shouldShow ? "" : "none";
+    if (!SIMPLE.pizzas[i - 1]) SIMPLE.pizzas[i - 1] = {};
+    SIMPLE.pizzas[i - 1].visible = shouldShow;
   }
-
-  const addBtn=document.getElementById('addPizza');
-  if(addBtn) addBtn.style.display = visible>=3? 'none' : '';
-
+  const addBtn = document.getElementById('addPizza');
+  if (addBtn) addBtn.style.display = visible >= 3 ? 'none' : '';
   SIMPLE.visibleCount = visible;
-
   const ensurePizza = idx => {
-    const base=pizzas[idx]||{};
+    var _base$text;
+    const base = pizzas[idx] || {};
     return {
-      t: Number.isFinite(base.t)?base.t: (idx===0?3:0),
-      n: Number.isFinite(base.n)?Math.max(1,base.n):10,
+      t: Number.isFinite(base.t) ? base.t : idx === 0 ? 3 : 0,
+      n: Number.isFinite(base.n) ? Math.max(1, base.n) : 10,
       lockN: !!base.lockN,
       lockT: !!base.lockT,
-      text: base.text ?? 'none',
+      text: (_base$text = base.text) !== null && _base$text !== void 0 ? _base$text : 'none',
       hideNVal: !!base.hideNVal,
-      minN: Number.isFinite(base.minN)?base.minN:1,
-      maksN: Number.isFinite(base.maksN)?base.maksN:24
+      minN: Number.isFinite(base.minN) ? base.minN : 1,
+      maksN: Number.isFinite(base.maksN) ? base.maksN : 24
     };
   };
-
-  const setVal=(id,value)=>{
-    const el=document.getElementById(id);
-    if(el && value!=null) el.value=String(value);
+  const setVal = (id, value) => {
+    const el = document.getElementById(id);
+    if (el && value != null) el.value = String(value);
   };
-  const setChk=(id,checked)=>{
-    const el=document.getElementById(id);
-    if(el) el.checked=!!checked;
+  const setChk = (id, checked) => {
+    const el = document.getElementById(id);
+    if (el) el.checked = !!checked;
   };
-
-  for(let i=1;i<=3;i++){
-    const cfg=ensurePizza(i-1);
+  for (let i = 1; i <= 3; i++) {
+    const cfg = ensurePizza(i - 1);
     setVal(`p${i}T`, cfg.t);
     setVal(`p${i}N`, cfg.n);
     setChk(`p${i}LockN`, cfg.lockN);
@@ -998,25 +1227,24 @@ function applySimpleConfigToInputs(){
     setChk(`p${i}HideNVal`, cfg.hideNVal);
     setVal(`p${i}MinN`, cfg.minN);
     setVal(`p${i}MaxN`, cfg.maksN);
-    const textSel=document.getElementById(`p${i}Text`);
-    if(textSel && cfg.text) textSel.value=cfg.text;
+    const textSel = document.getElementById(`p${i}Text`);
+    if (textSel && cfg.text) textSel.value = cfg.text;
   }
-
-  ops.forEach((op,idx)=>{
-    setVal(`op${idx+1}`, op ?? "");
+  ops.forEach((op, idx) => {
+    setVal(`op${idx + 1}`, op !== null && op !== void 0 ? op : "");
   });
 }
-
-function applyExamplesConfig(){
-  if(document.readyState === 'loading'){
-    document.addEventListener('DOMContentLoaded', applyExamplesConfig, {once:true});
+function applyExamplesConfig() {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyExamplesConfig, {
+      once: true
+    });
     return;
   }
   applySimpleConfigToInputs();
   initFromHtml();
 }
-
-if(typeof window !== 'undefined'){
+if (typeof window !== 'undefined') {
   window.applyConfig = applyExamplesConfig;
   window.render = applyExamplesConfig;
 }

--- a/brøkvegg.js
+++ b/brøkvegg.js
@@ -1,6 +1,6 @@
-(function(){
+(function (_luminanceFromHex, _luminanceFromHex2) {
   const SVG_NS = 'http://www.w3.org/2000/svg';
-  const TEXT_MODES = ['fraction','percent','decimal'];
+  const TEXT_MODES = ['fraction', 'percent', 'decimal'];
   const MODE_LABELS = {
     fraction: 'brøk',
     percent: 'prosent',
@@ -23,11 +23,10 @@
   const DEFAULT_PERCENT_DIGITS = 1;
   const MAX_DECIMAL_DIGITS = 4;
   const MAX_PERCENT_DIGITS = 3;
-
-  function parseHexColor(hex){
-    if(typeof hex !== 'string') return null;
+  function parseHexColor(hex) {
+    if (typeof hex !== 'string') return null;
     const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
-    if(!match) return null;
+    if (!match) return null;
     const value = match[1];
     return {
       r: parseInt(value.slice(0, 2), 16),
@@ -35,45 +34,37 @@
       b: parseInt(value.slice(4, 6), 16)
     };
   }
-
-  function srgbToLinear(value){
+  function srgbToLinear(value) {
     const channel = value / 255;
     return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
   }
-
-  function relativeLuminance(r, g, b){
+  function relativeLuminance(r, g, b) {
     const R = srgbToLinear(r);
     const G = srgbToLinear(g);
     const B = srgbToLinear(b);
     return 0.2126 * R + 0.7152 * G + 0.0722 * B;
   }
-
-  function luminanceFromHex(hex){
+  function luminanceFromHex(hex) {
     const rgb = parseHexColor(hex);
-    if(!rgb) return null;
+    if (!rgb) return null;
     return relativeLuminance(rgb.r, rgb.g, rgb.b);
   }
-
-  const DARK_TEXT_LUMINANCE = luminanceFromHex(TEXT_COLOR_DARK) ?? 0;
-  const LIGHT_TEXT_LUMINANCE = luminanceFromHex(TEXT_COLOR_LIGHT) ?? 1;
-
-  function contrastRatio(l1, l2){
+  const DARK_TEXT_LUMINANCE = (_luminanceFromHex = luminanceFromHex(TEXT_COLOR_DARK)) !== null && _luminanceFromHex !== void 0 ? _luminanceFromHex : 0;
+  const LIGHT_TEXT_LUMINANCE = (_luminanceFromHex2 = luminanceFromHex(TEXT_COLOR_LIGHT)) !== null && _luminanceFromHex2 !== void 0 ? _luminanceFromHex2 : 1;
+  function contrastRatio(l1, l2) {
     const lighter = Math.max(l1, l2);
     const darker = Math.min(l1, l2);
     return (lighter + 0.05) / (darker + 0.05);
   }
-
-  function pickTileTextColor(backgroundHex){
+  function pickTileTextColor(backgroundHex) {
     const bgLuminance = luminanceFromHex(backgroundHex);
-    if(bgLuminance == null) return TEXT_COLOR_DARK;
+    if (bgLuminance == null) return TEXT_COLOR_DARK;
     const darkContrast = contrastRatio(bgLuminance, DARK_TEXT_LUMINANCE);
     const lightContrast = contrastRatio(bgLuminance, LIGHT_TEXT_LUMINANCE);
     return darkContrast >= lightContrast ? TEXT_COLOR_DARK : TEXT_COLOR_LIGHT;
   }
-
   const svg = document.getElementById('fractionWallSvg');
-  if(!svg) return;
-
+  if (!svg) return;
   const denomInput = document.getElementById('denominatorInput');
   const showLabelsCheckbox = document.getElementById('showRowLabels');
   const textScaleRange = document.getElementById('textScale');
@@ -86,49 +77,40 @@
   const resetModesButton = document.getElementById('resetModes');
   const downloadSvgButton = document.getElementById('btnDownloadSvg');
   const downloadPngButton = document.getElementById('btnDownloadPng');
-
-  const STATE = (window.STATE && typeof window.STATE === 'object') ? window.STATE : {};
+  const STATE = window.STATE && typeof window.STATE === 'object' ? window.STATE : {};
   window.STATE = STATE;
-
-  function clamp(value, min, max){
-    if(!Number.isFinite(value)) return min;
-    if(value < min) return min;
-    if(value > max) return max;
+  function clamp(value, min, max) {
+    if (!Number.isFinite(value)) return min;
+    if (value < min) return min;
+    if (value > max) return max;
     return value;
   }
-
-  function clampInt(value, min, max, fallback){
+  function clampInt(value, min, max, fallback) {
     const num = Number.parseInt(value, 10);
-    if(!Number.isFinite(num)) return clamp(fallback, min, max);
+    if (!Number.isFinite(num)) return clamp(fallback, min, max);
     return clamp(num, min, max);
   }
-
-  function sanitizeDenominators(value){
-    if(Array.isArray(value)){
-      return value
-        .map(v => Number.parseInt(v, 10))
-        .filter(v => Number.isFinite(v) && v > 0 && v <= 48)
-        .filter((v, idx, arr) => arr.indexOf(v) === idx)
-        .sort((a, b) => a - b);
+  function sanitizeDenominators(value) {
+    if (Array.isArray(value)) {
+      return value.map(v => Number.parseInt(v, 10)).filter(v => Number.isFinite(v) && v > 0 && v <= 48).filter((v, idx, arr) => arr.indexOf(v) === idx).sort((a, b) => a - b);
     }
-    if(typeof value === 'string'){
+    if (typeof value === 'string') {
       const parts = value.split(/[^0-9]+/);
       const numbers = [];
-      for(const part of parts){
-        if(!part) continue;
+      for (const part of parts) {
+        if (!part) continue;
         const num = Number.parseInt(part, 10);
-        if(Number.isFinite(num) && num > 0 && num <= 48) numbers.push(num);
+        if (Number.isFinite(num) && num > 0 && num <= 48) numbers.push(num);
       }
       return sanitizeDenominators(numbers);
     }
     return [];
   }
-
-  function ensureStateDefaults(){
+  function ensureStateDefaults() {
     const denoms = sanitizeDenominators(STATE.denominators);
     STATE.denominators = denoms.length ? denoms : DEFAULT_DENOMS.slice();
-    if(!STATE.tileModes || typeof STATE.tileModes !== 'object') STATE.tileModes = {};
-    if(!TEXT_MODES.includes(STATE.defaultMode)) STATE.defaultMode = 'fraction';
+    if (!STATE.tileModes || typeof STATE.tileModes !== 'object') STATE.tileModes = {};
+    if (!TEXT_MODES.includes(STATE.defaultMode)) STATE.defaultMode = 'fraction';
     STATE.showLabels = typeof STATE.showLabels === 'boolean' ? STATE.showLabels : true;
     const scale = Number(STATE.textScale);
     STATE.textScale = clamp(Number.isFinite(scale) ? scale : 0.7, MIN_SCALE, MAX_SCALE);
@@ -136,124 +118,107 @@
     STATE.percentDigits = clampInt(STATE.percentDigits, 0, MAX_PERCENT_DIGITS, DEFAULT_PERCENT_DIGITS);
     STATE.trimTrailingZeros = typeof STATE.trimTrailingZeros === 'boolean' ? STATE.trimTrailingZeros : false;
   }
-
   ensureStateDefaults();
-
-  function cleanTileModes(){
+  function cleanTileModes() {
     const validKeys = new Set();
-    for(const den of STATE.denominators){
-      for(let i=0;i<den;i++){
+    for (const den of STATE.denominators) {
+      for (let i = 0; i < den; i++) {
         validKeys.add(`${den}:${i}`);
       }
     }
     Object.keys(STATE.tileModes).forEach(key => {
       const mode = STATE.tileModes[key];
-      if(!validKeys.has(key) || !TEXT_MODES.includes(mode)){
+      if (!validKeys.has(key) || !TEXT_MODES.includes(mode)) {
         delete STATE.tileModes[key];
       }
     });
   }
-
   cleanTileModes();
-
-  function updateModeButtons(){
+  function updateModeButtons() {
     setModeButtons.forEach(btn => {
-      if(!btn || !btn.dataset.setMode) return;
+      if (!btn || !btn.dataset.setMode) return;
       btn.classList.toggle('is-active', btn.dataset.setMode === STATE.defaultMode);
     });
   }
-
-  function updateTextScaleDisplay(){
-    if(textScaleValue){
+  function updateTextScaleDisplay() {
+    if (textScaleValue) {
       const percentage = Math.round(STATE.textScale * 100);
       textScaleValue.textContent = `${percentage}%`;
     }
   }
-
-  function updateControlsFromState(){
-    if(denomInput){
+  function updateControlsFromState() {
+    if (denomInput) {
       const joined = STATE.denominators.join(', ');
       denomInput.value = joined;
     }
-    if(showLabelsCheckbox) showLabelsCheckbox.checked = !!STATE.showLabels;
-    if(textScaleRange) textScaleRange.value = String(STATE.textScale);
-    if(decimalDigitsInput) decimalDigitsInput.value = String(STATE.decimalDigits);
-    if(percentDigitsInput) percentDigitsInput.value = String(STATE.percentDigits);
-    if(trimTrailingZerosCheckbox) trimTrailingZerosCheckbox.checked = !!STATE.trimTrailingZeros;
+    if (showLabelsCheckbox) showLabelsCheckbox.checked = !!STATE.showLabels;
+    if (textScaleRange) textScaleRange.value = String(STATE.textScale);
+    if (decimalDigitsInput) decimalDigitsInput.value = String(STATE.decimalDigits);
+    if (percentDigitsInput) percentDigitsInput.value = String(STATE.percentDigits);
+    if (trimTrailingZerosCheckbox) trimTrailingZerosCheckbox.checked = !!STATE.trimTrailingZeros;
     updateTextScaleDisplay();
     updateModeButtons();
   }
-
   updateControlsFromState();
-
-  function createSvgElement(name, attrs){
+  function createSvgElement(name, attrs) {
     const el = document.createElementNS(SVG_NS, name);
-    if(attrs){
-      for(const [key, value] of Object.entries(attrs)){
-        if(value == null) continue;
-        if(key === 'textContent') el.textContent = value;
-        else el.setAttribute(key, value);
+    if (attrs) {
+      for (const [key, value] of Object.entries(attrs)) {
+        if (value == null) continue;
+        if (key === 'textContent') el.textContent = value;else el.setAttribute(key, value);
       }
     }
     return el;
   }
-
-  function lightenColor(hex, amount){
-    if(typeof hex !== 'string') return hex;
+  function lightenColor(hex, amount) {
+    if (typeof hex !== 'string') return hex;
     const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
-    if(!match) return hex;
+    if (!match) return hex;
     const base = match[1];
-    const r = parseInt(base.slice(0,2), 16);
-    const g = parseInt(base.slice(2,4), 16);
-    const b = parseInt(base.slice(4,6), 16);
+    const r = parseInt(base.slice(0, 2), 16);
+    const g = parseInt(base.slice(2, 4), 16);
+    const b = parseInt(base.slice(4, 6), 16);
     const ratio = clamp(Number(amount) || 0, 0, 1);
-    const mix = (channel) => Math.round(channel + (255 - channel) * ratio);
+    const mix = channel => Math.round(channel + (255 - channel) * ratio);
     const nr = mix(r);
     const ng = mix(g);
     const nb = mix(b);
-    return `#${nr.toString(16).padStart(2,'0')}${ng.toString(16).padStart(2,'0')}${nb.toString(16).padStart(2,'0')}`;
+    return `#${nr.toString(16).padStart(2, '0')}${ng.toString(16).padStart(2, '0')}${nb.toString(16).padStart(2, '0')}`;
   }
-
-  function getTileMode(den, index){
+  function getTileMode(den, index) {
     const key = `${den}:${index}`;
     const stored = STATE.tileModes[key];
-    if(TEXT_MODES.includes(stored)) return stored;
+    if (TEXT_MODES.includes(stored)) return stored;
     return STATE.defaultMode;
   }
-
-  function setTileMode(den, index, mode){
+  function setTileMode(den, index, mode) {
     const key = `${den}:${index}`;
-    if(!TEXT_MODES.includes(mode)) return;
-    if(mode === STATE.defaultMode){
+    if (!TEXT_MODES.includes(mode)) return;
+    if (mode === STATE.defaultMode) {
       delete STATE.tileModes[key];
-    }else{
+    } else {
       STATE.tileModes[key] = mode;
     }
   }
-
-  function cycleTileMode(den, index){
+  function cycleTileMode(den, index) {
     const current = getTileMode(den, index);
     const idx = TEXT_MODES.indexOf(current);
     const next = TEXT_MODES[(idx + 1) % TEXT_MODES.length];
     setTileMode(den, index, next);
     render();
   }
-
-  function formatFraction(den){
-    if(den === 1) return '1';
+  function formatFraction(den) {
+    if (den === 1) return '1';
     return `1/${den}`;
   }
-
   const decimalFormatterCache = new Map();
-  function formatDecimal(value, digits, trimZeros){
+  function formatDecimal(value, digits, trimZeros) {
     const numericDigits = Number.isFinite(digits) ? digits : Number(digits);
-    const normalizedDigits = Number.isFinite(numericDigits)
-      ? Math.max(0, Math.min(Math.floor(numericDigits), 20))
-      : 0;
+    const normalizedDigits = Number.isFinite(numericDigits) ? Math.max(0, Math.min(Math.floor(numericDigits), 20)) : 0;
     const useTrim = !!trimZeros;
     const key = `${normalizedDigits}|${useTrim ? 'trim' : 'pad'}`;
     let formatter = decimalFormatterCache.get(key);
-    if(!formatter){
+    if (!formatter) {
       const options = {
         maximumFractionDigits: normalizedDigits
       };
@@ -263,9 +228,8 @@
     }
     return formatter.format(value);
   }
-
-  function formatValue(mode, den){
-    switch(mode){
+  function formatValue(mode, den) {
+    switch (mode) {
       case 'percent':
         return `${formatDecimal(100 / den, STATE.percentDigits, STATE.trimTrailingZeros)}%`;
       case 'decimal':
@@ -275,39 +239,36 @@
         return formatFraction(den);
     }
   }
-
-  function tileAriaLabel(den, index, mode){
+  function tileAriaLabel(den, index, mode) {
     const position = index + 1;
     const total = den;
     const label = MODE_LABELS[mode] || mode;
     return `Del ${position} av ${total}. Viser ${label}. Klikk for å bytte visning.`;
   }
-
-  function createFractionGroup(den, centerX, centerY, tileWidth, textColor){
-    const group = createSvgElement('g', {'aria-hidden': 'true'});
+  function createFractionGroup(den, centerX, centerY, tileWidth, textColor) {
+    const group = createSvgElement('g', {
+      'aria-hidden': 'true'
+    });
     const numeratorText = '1';
     const denominatorText = String(den);
     const maxChars = Math.max(numeratorText.length, denominatorText.length, 1);
     const approximateDigitWidth = 0.62; // Approximate width of a digit relative to font size
     const widthPadding = 0.72; // Leave some horizontal padding on each side
     const baseFontLimit = ROW_HEIGHT * STATE.textScale;
-    const widthLimit = (tileWidth * widthPadding) / (maxChars * approximateDigitWidth);
+    const widthLimit = tileWidth * widthPadding / (maxChars * approximateDigitWidth);
     let fontSize = Math.max(10, Math.min(baseFontLimit, widthLimit));
-
     const availableHalfHeight = ROW_HEIGHT / 2 - 4;
     let gap = Math.max(4, fontSize * 0.18);
     let attempts = 0;
-    while(fontSize + gap > availableHalfHeight && attempts < 3){
+    while (fontSize + gap > availableHalfHeight && attempts < 3) {
       const heightLimit = availableHalfHeight - gap;
       const nextFont = Math.max(10, heightLimit);
-      if(nextFont >= fontSize) break;
+      if (nextFont >= fontSize) break;
       fontSize = nextFont;
       gap = Math.max(4, fontSize * 0.18);
       attempts++;
     }
-
     const lineOffset = fontSize / 2 + gap;
-
     const numerator = createSvgElement('text', {
       x: centerX,
       y: centerY - lineOffset,
@@ -316,7 +277,6 @@
     numerator.setAttribute('fill', textColor);
     numerator.style.fill = textColor;
     numerator.style.fontSize = `${fontSize}px`;
-
     const denominator = createSvgElement('text', {
       x: centerX,
       y: centerY + lineOffset,
@@ -325,7 +285,6 @@
     denominator.setAttribute('fill', textColor);
     denominator.style.fill = textColor;
     denominator.style.fontSize = `${fontSize}px`;
-
     const estimatedTextWidth = fontSize * approximateDigitWidth * maxChars;
     const lineLength = Math.min(tileWidth * widthPadding, estimatedTextWidth * 1.1);
     const line = createSvgElement('line', {
@@ -338,39 +297,40 @@
       'stroke-linecap': 'round',
       'aria-hidden': 'true'
     });
-
     group.appendChild(numerator);
     group.appendChild(line);
     group.appendChild(denominator);
     return group;
   }
-
-  function render(){
+  function render() {
     ensureStateDefaults();
     cleanTileModes();
     updateControlsFromState();
-
     const denominators = STATE.denominators;
     const labelWidth = STATE.showLabels ? LABEL_WIDTH : 0;
     const contentHeight = denominators.length * ROW_HEIGHT + Math.max(0, denominators.length - 1) * ROW_GAP;
     const totalHeight = contentHeight + MARGIN_Y * 2;
     const totalWidth = MARGIN_X * 2 + labelWidth + TILE_AREA_WIDTH;
-
     svg.setAttribute('viewBox', `0 0 ${totalWidth} ${Math.max(totalHeight, 120)}`);
-
     const fragment = document.createDocumentFragment();
-    const title = createSvgElement('title', {id:'fractionWallTitle', textContent:'Brøkvegg'});
+    const title = createSvgElement('title', {
+      id: 'fractionWallTitle',
+      textContent: 'Brøkvegg'
+    });
     const descText = denominators.length ? `Viser rader for nevnerne ${denominators.join(', ')}.` : 'Ingen rader valgt.';
-    const desc = createSvgElement('desc', {id:'fractionWallDesc', textContent:descText});
+    const desc = createSvgElement('desc', {
+      id: 'fractionWallDesc',
+      textContent: descText
+    });
     fragment.appendChild(title);
     fragment.appendChild(desc);
-
     let y = MARGIN_Y;
     denominators.forEach((den, rowIndex) => {
-      const rowGroup = createSvgElement('g', {transform:`translate(${MARGIN_X}, ${y})`});
+      const rowGroup = createSvgElement('g', {
+        transform: `translate(${MARGIN_X}, ${y})`
+      });
       const baseColor = COLOR_PALETTE[rowIndex % COLOR_PALETTE.length] || '#B25FE3';
-
-      if(STATE.showLabels){
+      if (STATE.showLabels) {
         const labelGroup = createSvgElement('g');
         const rect = createSvgElement('rect', {
           class: 'rowLabelRect',
@@ -404,14 +364,13 @@
         labelGroup.appendChild(subLabel);
         rowGroup.appendChild(labelGroup);
       }
-
       const tilesGroup = createSvgElement('g', {
         transform: `translate(${STATE.showLabels ? LABEL_WIDTH : 0}, 0)`
       });
       const tileWidth = TILE_AREA_WIDTH / den;
       const tileColor = lightenColor(baseColor, 0.12);
       const tileTextColor = pickTileTextColor(tileColor);
-      for(let i=0;i<den;i++){
+      for (let i = 0; i < den; i++) {
         const mode = getTileMode(den, i);
         const displayValue = formatValue(mode, den);
         const tile = createSvgElement('g', {
@@ -441,10 +400,10 @@
         });
         tile.appendChild(tooltip);
         tile.appendChild(rect);
-        if(mode === 'fraction' && den > 1){
+        if (mode === 'fraction' && den > 1) {
           const fractionGroup = createFractionGroup(den, tileX + tileWidth / 2, ROW_HEIGHT / 2, tileWidth, textColor);
           tile.appendChild(fractionGroup);
-        }else{
+        } else {
           const text = createSvgElement('text', {
             x: tileX + tileWidth / 2,
             y: ROW_HEIGHT / 2
@@ -456,100 +415,84 @@
           text.style.fontSize = `${fontSize}px`;
           tile.appendChild(text);
         }
-        tile.addEventListener('click', (event)=>{
+        tile.addEventListener('click', event => {
           event.preventDefault();
           cycleTileMode(den, i);
         });
-        tile.addEventListener('keydown', (event)=>{
-          if(event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar'){
+        tile.addEventListener('keydown', event => {
+          if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
             event.preventDefault();
             cycleTileMode(den, i);
           }
         });
         tilesGroup.appendChild(tile);
       }
-
       rowGroup.appendChild(tilesGroup);
       fragment.appendChild(rowGroup);
       y += ROW_HEIGHT + ROW_GAP;
     });
-
     svg.replaceChildren(fragment);
   }
-
   render();
   window.render = render;
-
-  function setDenominatorsFromInput(raw){
+  function setDenominatorsFromInput(raw) {
     const parsed = sanitizeDenominators(raw);
     STATE.denominators = parsed.length ? parsed : DEFAULT_DENOMS.slice();
     cleanTileModes();
     render();
   }
-
-  denomInput?.addEventListener('change', (event)=>{
+  denomInput === null || denomInput === void 0 || denomInput.addEventListener('change', event => {
     setDenominatorsFromInput(event.target.value);
   });
-  denomInput?.addEventListener('blur', (event)=>{
+  denomInput === null || denomInput === void 0 || denomInput.addEventListener('blur', event => {
     setDenominatorsFromInput(event.target.value);
   });
-
   presetButtons.forEach(btn => {
-    btn.addEventListener('click', ()=>{
+    btn.addEventListener('click', () => {
       const preset = btn.dataset.denomPreset || '';
       setDenominatorsFromInput(preset);
     });
   });
-
-  showLabelsCheckbox?.addEventListener('change', ()=>{
+  showLabelsCheckbox === null || showLabelsCheckbox === void 0 || showLabelsCheckbox.addEventListener('change', () => {
     STATE.showLabels = !!showLabelsCheckbox.checked;
     render();
   });
-
-  textScaleRange?.addEventListener('input', ()=>{
+  textScaleRange === null || textScaleRange === void 0 || textScaleRange.addEventListener('input', () => {
     const value = Number(textScaleRange.value);
     STATE.textScale = clamp(value, MIN_SCALE, MAX_SCALE);
     updateTextScaleDisplay();
     render();
   });
-
-  decimalDigitsInput?.addEventListener('change', ()=>{
+  decimalDigitsInput === null || decimalDigitsInput === void 0 || decimalDigitsInput.addEventListener('change', () => {
     STATE.decimalDigits = clampInt(decimalDigitsInput.value, 0, MAX_DECIMAL_DIGITS, STATE.decimalDigits);
     render();
   });
-
-  percentDigitsInput?.addEventListener('change', ()=>{
+  percentDigitsInput === null || percentDigitsInput === void 0 || percentDigitsInput.addEventListener('change', () => {
     STATE.percentDigits = clampInt(percentDigitsInput.value, 0, MAX_PERCENT_DIGITS, STATE.percentDigits);
     render();
   });
-
-  trimTrailingZerosCheckbox?.addEventListener('change', ()=>{
+  trimTrailingZerosCheckbox === null || trimTrailingZerosCheckbox === void 0 || trimTrailingZerosCheckbox.addEventListener('change', () => {
     STATE.trimTrailingZeros = !!trimTrailingZerosCheckbox.checked;
     render();
   });
-
   setModeButtons.forEach(btn => {
-    btn.addEventListener('click', ()=>{
+    btn.addEventListener('click', () => {
       const mode = btn.dataset.setMode;
-      if(!TEXT_MODES.includes(mode)) return;
+      if (!TEXT_MODES.includes(mode)) return;
       STATE.defaultMode = mode;
       STATE.tileModes = {};
       render();
     });
   });
-
-  resetModesButton?.addEventListener('click', ()=>{
+  resetModesButton === null || resetModesButton === void 0 || resetModesButton.addEventListener('click', () => {
     STATE.defaultMode = 'fraction';
     STATE.tileModes = {};
     render();
   });
-
-  function svgToString(svgEl){
+  function svgToString(svgEl) {
     const clone = svgEl.cloneNode(true);
-    const styles = Array.from(document.querySelectorAll('style'))
-      .map(style => style.textContent)
-      .join('\n');
-    if(styles){
+    const styles = Array.from(document.querySelectorAll('style')).map(style => style.textContent).join('\n');
+    if (styles) {
       const styleEl = document.createElement('style');
       styleEl.textContent = styles;
       clone.insertBefore(styleEl, clone.firstChild);
@@ -558,10 +501,11 @@
     clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
     return `<?xml version="1.0" encoding="UTF-8"?>\n${new XMLSerializer().serializeToString(clone)}`;
   }
-
-  function downloadSvg(svgEl, filename){
+  function downloadSvg(svgEl, filename) {
     const data = svgToString(svgEl);
-    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const blob = new Blob([data], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
@@ -569,17 +513,19 @@
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-    setTimeout(()=>URL.revokeObjectURL(url), 1000);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
-
-  function downloadPng(svgEl, filename, scale = 2){
+  function downloadPng(svgEl, filename, scale = 2) {
     const data = svgToString(svgEl);
-    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const blob = new Blob([data], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
     const url = URL.createObjectURL(blob);
     const img = new Image();
-    img.onload = ()=>{
+    img.onload = () => {
+      var _svgEl$viewBox;
       const canvas = document.createElement('canvas');
-      const viewBox = svgEl.viewBox?.baseVal;
+      const viewBox = (_svgEl$viewBox = svgEl.viewBox) === null || _svgEl$viewBox === void 0 ? void 0 : _svgEl$viewBox.baseVal;
       const width = viewBox ? viewBox.width : svgEl.clientWidth;
       const height = viewBox ? viewBox.height : svgEl.clientHeight;
       canvas.width = Math.round(width * scale);
@@ -590,7 +536,7 @@
       ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
       URL.revokeObjectURL(url);
       canvas.toBlob(blob => {
-        if(!blob) return;
+        if (!blob) return;
         const pngUrl = URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.href = pngUrl;
@@ -598,24 +544,21 @@
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
-        setTimeout(()=>URL.revokeObjectURL(pngUrl), 1000);
+        setTimeout(() => URL.revokeObjectURL(pngUrl), 1000);
       }, 'image/png');
     };
     img.src = url;
   }
-
-  downloadSvgButton?.addEventListener('click', ()=>{
+  downloadSvgButton === null || downloadSvgButton === void 0 || downloadSvgButton.addEventListener('click', () => {
     downloadSvg(svg, 'brokvegg');
   });
-
-  downloadPngButton?.addEventListener('click', ()=>{
+  downloadPngButton === null || downloadPngButton === void 0 || downloadPngButton.addEventListener('click', () => {
     downloadPng(svg, 'brokvegg');
   });
-
-  window.addEventListener('examples:collect', (event)=>{
-    if(!event || !event.detail) return;
-    try{
+  window.addEventListener('examples:collect', event => {
+    if (!event || !event.detail) return;
+    try {
       event.detail.svgOverride = svgToString(svg);
-    }catch(_){ }
+    } catch (_) {}
   });
 })();

--- a/diagram.js
+++ b/diagram.js
@@ -4,177 +4,175 @@
 const CFG = {
   type: 'bar',
   title: 'Favorittidretter i 5B',
-  labels: ['Klatring','Fotball','Håndball','Basket','Tennis','Bowling'],
+  labels: ['Klatring', 'Fotball', 'Håndball', 'Basket', 'Tennis', 'Bowling'],
   series1: '',
-  start:  [6,7,3,5,8,2],
-  answer: [6,7,3,5,8,2],
-  yMax:   8,
-  snap:   1,
+  start: [6, 7, 3, 5, 8, 2],
+  answer: [6, 7, 3, 5, 8, 2],
+  yMax: 8,
+  snap: 1,
   tolerance: 0,
   axisXLabel: 'Idrett',
   axisYLabel: 'Antall elever',
   locked: []
 };
-
-const DEFAULT_DIAGRAM_EXAMPLES = [
-  {
-    id: 'diagram-example-1',
-    exampleNumber: '1',
-    isDefault: true,
-    config: {
-      CFG: JSON.parse(JSON.stringify(CFG))
-    }
-  },
-  {
-    id: 'diagram-example-2',
-    exampleNumber: '2',
-    config: {
-      CFG: {
-        type: 'bar',
-        title: 'Bøker lest i 5A',
-        labels: ['Jan','Feb','Mar','Apr','Mai'],
-        series1: '',
-        start:  [3,5,6,4,7],
-        answer: [3,5,6,4,7],
-        yMax:   8,
-        snap:   1,
-        tolerance: 0,
-        axisXLabel: 'Måned',
-        axisYLabel: 'Antall bøker',
-        locked: []
-      }
-    }
-  },
-  {
-    id: 'diagram-example-3',
-    exampleNumber: '3',
-    config: {
-      CFG: {
-        type: 'grouped',
-        title: 'Fritidsaktiviteter',
-        labels: ['Korps','Teater','Fotball','Sjakk'],
-        series1: 'Jenter',
-        start:  [4,6,5,3],
-        answer: [4,6,5,3],
-        series2: 'Gutter',
-        start2: [3,2,7,4],
-        answer2:[3,2,7,4],
-        yMax:   8,
-        snap:   1,
-        tolerance: 0,
-        axisXLabel: 'Aktivitet',
-        axisYLabel: 'Antall elever',
-        locked: []
-      }
-    }
-  },
-  {
-    id: 'diagram-example-4',
-    exampleNumber: '4',
-    config: {
-      CFG: {
-        type: 'stacked',
-        title: 'Daglig skjermbruk',
-        labels: ['1','2','3','4','5','6','7'],
-        series1: 'Gutter',
-        start:  [2,5,5,2,3,2,1],
-        answer: [2,5,5,2,3,2,1],
-        series2: 'Jenter',
-        start2: [1,4,3,0,1,0,0],
-        answer2:[1,4,3,0,1,0,0],
-        yMax:   9,
-        snap:   1,
-        tolerance: 0,
-        axisXLabel: 'Timer per dag',
-        axisYLabel: 'Antall elever',
-        locked: []
-      }
-    }
-  }
-];
-
-window.DEFAULT_EXAMPLES = DEFAULT_DIAGRAM_EXAMPLES.map(ex => ({
-  ...ex,
+const DEFAULT_DIAGRAM_EXAMPLES = [{
+  id: 'diagram-example-1',
+  exampleNumber: '1',
+  isDefault: true,
   config: {
-    ...ex.config,
-    CFG: ex.config?.CFG ? JSON.parse(JSON.stringify(ex.config.CFG)) : undefined,
-    STATE: ex.config?.STATE ? JSON.parse(JSON.stringify(ex.config.STATE)) : undefined,
-    CONFIG: ex.config?.CONFIG ? JSON.parse(JSON.stringify(ex.config.CONFIG)) : undefined,
-    SIMPLE: ex.config?.SIMPLE ? JSON.parse(JSON.stringify(ex.config.SIMPLE)) : undefined
+    CFG: JSON.parse(JSON.stringify(CFG))
   }
-}));
+}, {
+  id: 'diagram-example-2',
+  exampleNumber: '2',
+  config: {
+    CFG: {
+      type: 'bar',
+      title: 'Bøker lest i 5A',
+      labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Mai'],
+      series1: '',
+      start: [3, 5, 6, 4, 7],
+      answer: [3, 5, 6, 4, 7],
+      yMax: 8,
+      snap: 1,
+      tolerance: 0,
+      axisXLabel: 'Måned',
+      axisYLabel: 'Antall bøker',
+      locked: []
+    }
+  }
+}, {
+  id: 'diagram-example-3',
+  exampleNumber: '3',
+  config: {
+    CFG: {
+      type: 'grouped',
+      title: 'Fritidsaktiviteter',
+      labels: ['Korps', 'Teater', 'Fotball', 'Sjakk'],
+      series1: 'Jenter',
+      start: [4, 6, 5, 3],
+      answer: [4, 6, 5, 3],
+      series2: 'Gutter',
+      start2: [3, 2, 7, 4],
+      answer2: [3, 2, 7, 4],
+      yMax: 8,
+      snap: 1,
+      tolerance: 0,
+      axisXLabel: 'Aktivitet',
+      axisYLabel: 'Antall elever',
+      locked: []
+    }
+  }
+}, {
+  id: 'diagram-example-4',
+  exampleNumber: '4',
+  config: {
+    CFG: {
+      type: 'stacked',
+      title: 'Daglig skjermbruk',
+      labels: ['1', '2', '3', '4', '5', '6', '7'],
+      series1: 'Gutter',
+      start: [2, 5, 5, 2, 3, 2, 1],
+      answer: [2, 5, 5, 2, 3, 2, 1],
+      series2: 'Jenter',
+      start2: [1, 4, 3, 0, 1, 0, 0],
+      answer2: [1, 4, 3, 0, 1, 0, 0],
+      yMax: 9,
+      snap: 1,
+      tolerance: 0,
+      axisXLabel: 'Timer per dag',
+      axisYLabel: 'Antall elever',
+      locked: []
+    }
+  }
+}];
+window.DEFAULT_EXAMPLES = DEFAULT_DIAGRAM_EXAMPLES.map(ex => {
+  var _ex$config, _ex$config2, _ex$config3, _ex$config4;
+  return {
+    ...ex,
+    config: {
+      ...ex.config,
+      CFG: (_ex$config = ex.config) !== null && _ex$config !== void 0 && _ex$config.CFG ? JSON.parse(JSON.stringify(ex.config.CFG)) : undefined,
+      STATE: (_ex$config2 = ex.config) !== null && _ex$config2 !== void 0 && _ex$config2.STATE ? JSON.parse(JSON.stringify(ex.config.STATE)) : undefined,
+      CONFIG: (_ex$config3 = ex.config) !== null && _ex$config3 !== void 0 && _ex$config3.CONFIG ? JSON.parse(JSON.stringify(ex.config.CONFIG)) : undefined,
+      SIMPLE: (_ex$config4 = ex.config) !== null && _ex$config4 !== void 0 && _ex$config4.SIMPLE ? JSON.parse(JSON.stringify(ex.config.SIMPLE)) : undefined
+    }
+  };
+});
 
 /* =========================================================
    OPPSETT
    ========================================================= */
 const svg = document.getElementById('barsvg');
-const W = 900, H = 560;
-const M = {l:80, r:30, t:40, b:70};
-
+const W = 900,
+  H = 560;
+const M = {
+  l: 80,
+  r: 30,
+  t: 40,
+  b: 70
+};
 const innerW = W - M.l - M.r;
 const innerH = H - M.t - M.b;
 
 /* Lagrekkefølge: grid, akser, dataserier, håndtak, a11y, verdier (øverst), labels, legend */
-const gGrid   = add('g');
-const gAxis   = add('g');
-const gBars   = add('g');
-const gHands  = add('g');
-const gA11y   = add('g');
-const gVals   = add('g');
+const gGrid = add('g');
+const gAxis = add('g');
+const gBars = add('g');
+const gHands = add('g');
+const gA11y = add('g');
+const gVals = add('g');
 const gLabels = add('g');
 const gLegend = add('g');
-
 let values = [];
 let values2 = null;
 let series2Enabled = false;
 let seriesNames = [];
 let locked = [];
 let N = 0;
-
 let yMax = 0;
-
 const btnSvg = document.getElementById('btnSvg');
 const btnPng = document.getElementById('btnPng');
-btnSvg?.addEventListener('click', ()=> downloadSVG(svg, 'diagram.svg'));
-btnPng?.addEventListener('click', ()=> downloadPNG(svg, 'diagram.png', 2));
+btnSvg === null || btnSvg === void 0 || btnSvg.addEventListener('click', () => downloadSVG(svg, 'diagram.svg'));
+btnPng === null || btnPng === void 0 || btnPng.addEventListener('click', () => downloadPNG(svg, 'diagram.png', 2));
 const addSeriesBtn = document.getElementById('addSeries');
 const series2Fields = document.getElementById('series2Fields');
-addSeriesBtn?.addEventListener('click', () => {
+addSeriesBtn === null || addSeriesBtn === void 0 || addSeriesBtn.addEventListener('click', () => {
   series2Enabled = true;
   addSeriesBtn.style.display = 'none';
-  if(series2Fields) series2Fields.style.display = '';
+  if (series2Fields) series2Fields.style.display = '';
   applyCfg();
 });
 const yMin = 0;
 
 // skalaer
 let xBand = 0;
-let barW  = 0;
-function xPos(i){ return M.l + xBand*i + xBand/2; }
-function yPos(v){ return M.t + innerH - (v - yMin) / (yMax - yMin) * innerH; }
+let barW = 0;
+function xPos(i) {
+  return M.l + xBand * i + xBand / 2;
+}
+function yPos(v) {
+  return M.t + innerH - (v - yMin) / (yMax - yMin) * innerH;
+}
 
 // husk sist fokusert søyle mellom redraw
 let lastFocusIndex = null;
-
 initFromCfg();
-
-function initFromCfg(){
-  const hasSeries2Config = (Array.isArray(CFG.start2) && CFG.start2.length > 0)
-    || (Array.isArray(CFG.answer2) && CFG.answer2.length > 0)
-    || (typeof CFG.series2 === 'string' && CFG.series2.trim().length > 0);
+function initFromCfg() {
+  var _CFG$yMax;
+  const hasSeries2Config = Array.isArray(CFG.start2) && CFG.start2.length > 0 || Array.isArray(CFG.answer2) && CFG.answer2.length > 0 || typeof CFG.series2 === 'string' && CFG.series2.trim().length > 0;
   series2Enabled = hasSeries2Config;
   values = CFG.start.slice();
   values2 = series2Enabled && CFG.start2 ? CFG.start2.slice() : null;
   seriesNames = [CFG.series1 || '', series2Enabled ? CFG.series2 || '' : ''];
   N = CFG.labels.length;
   xBand = innerW / N;
-  barW  = xBand * 0.6;
-  const allVals = [...CFG.start, ...(CFG.start2||[]), ...(CFG.answer||[]), ...(CFG.answer2||[])];
-  yMax  = CFG.yMax ?? niceMax(allVals);
+  barW = xBand * 0.6;
+  const allVals = [...CFG.start, ...(CFG.start2 || []), ...(CFG.answer || []), ...(CFG.answer2 || [])];
+  yMax = (_CFG$yMax = CFG.yMax) !== null && _CFG$yMax !== void 0 ? _CFG$yMax : niceMax(allVals);
   locked = alignLength(CFG.locked || [], N, false);
   lastFocusIndex = null;
   document.getElementById('chartTitle').textContent = CFG.title || '';
-
   const typeInput = document.getElementById('cfgType');
   const titleInput = document.getElementById('cfgTitle');
   const labelsInput = document.getElementById('cfgLabels');
@@ -190,234 +188,475 @@ function initFromCfg(){
   const series2Input = document.getElementById('cfgSeries2');
   const start2Input = document.getElementById('cfgStart2');
   const answer2Input = document.getElementById('cfgAnswer2');
-
-  if(titleInput) titleInput.value = CFG.title || '';
-  if(labelsInput) labelsInput.value = (CFG.labels || []).join(',');
-  if(lockedInput){
-    const lockedStr = locked.some(Boolean)
-      ? locked.map(v => v ? '1' : '0').join(',')
-      : '';
+  if (titleInput) titleInput.value = CFG.title || '';
+  if (labelsInput) labelsInput.value = (CFG.labels || []).join(',');
+  if (lockedInput) {
+    const lockedStr = locked.some(Boolean) ? locked.map(v => v ? '1' : '0').join(',') : '';
     lockedInput.value = lockedStr;
   }
-  if(yMaxInput) yMaxInput.value = Number.isFinite(CFG.yMax) ? formatNumber(CFG.yMax) : '';
-  if(axisXInput) axisXInput.value = CFG.axisXLabel || '';
-  if(axisYInput) axisYInput.value = CFG.axisYLabel || '';
-  if(snapInput) snapInput.value = Number.isFinite(CFG.snap) ? formatNumber(CFG.snap) : '';
-  if(tolInput) tolInput.value = Number.isFinite(CFG.tolerance) ? formatNumber(CFG.tolerance) : '';
-  if(series1Input) series1Input.value = CFG.series1 || '';
-  if(startInput) startInput.value = formatNumberList(values);
-  if(answerInput) answerInput.value = formatNumberList(CFG.answer || []);
-
-  if(addSeriesBtn){
+  if (yMaxInput) yMaxInput.value = Number.isFinite(CFG.yMax) ? formatNumber(CFG.yMax) : '';
+  if (axisXInput) axisXInput.value = CFG.axisXLabel || '';
+  if (axisYInput) axisYInput.value = CFG.axisYLabel || '';
+  if (snapInput) snapInput.value = Number.isFinite(CFG.snap) ? formatNumber(CFG.snap) : '';
+  if (tolInput) tolInput.value = Number.isFinite(CFG.tolerance) ? formatNumber(CFG.tolerance) : '';
+  if (series1Input) series1Input.value = CFG.series1 || '';
+  if (startInput) startInput.value = formatNumberList(values);
+  if (answerInput) answerInput.value = formatNumberList(CFG.answer || []);
+  if (addSeriesBtn) {
     addSeriesBtn.style.display = series2Enabled ? 'none' : '';
   }
-  if(series2Fields){
+  if (series2Fields) {
     series2Fields.style.display = series2Enabled ? '' : 'none';
   }
-  if(series2Input) series2Input.value = series2Enabled ? (CFG.series2 || '') : '';
-  if(start2Input) start2Input.value = series2Enabled && Array.isArray(values2) ? formatNumberList(values2) : '';
-  if(answer2Input) answer2Input.value = series2Enabled && Array.isArray(CFG.answer2) ? formatNumberList(CFG.answer2) : '';
+  if (series2Input) series2Input.value = series2Enabled ? CFG.series2 || '' : '';
+  if (start2Input) start2Input.value = series2Enabled && Array.isArray(values2) ? formatNumberList(values2) : '';
+  if (answer2Input) answer2Input.value = series2Enabled && Array.isArray(CFG.answer2) ? formatNumberList(CFG.answer2) : '';
 
   // disable stacking/grouping options when only one dataserie
   const typeSel = typeInput;
   const hasTwo = values2 && values2.length;
-  if(typeSel){
-    [...typeSel.options].forEach(opt=>{
-      if(!hasTwo && (opt.value==='stacked' || opt.value==='grouped')) opt.disabled = true;
-      else opt.disabled = false;
+  if (typeSel) {
+    [...typeSel.options].forEach(opt => {
+      if (!hasTwo && (opt.value === 'stacked' || opt.value === 'grouped')) opt.disabled = true;else opt.disabled = false;
     });
-    const order = hasTwo
-      ? ['bar','grouped','stacked','line']
-      : ['bar','line','grouped','stacked'];
-    order.forEach(val=>{
+    const order = hasTwo ? ['bar', 'grouped', 'stacked', 'line'] : ['bar', 'line', 'grouped', 'stacked'];
+    order.forEach(val => {
       const opt = typeSel.querySelector(`option[value="${val}"]`);
-      if(opt) typeSel.appendChild(opt);
+      if (opt) typeSel.appendChild(opt);
     });
-    const allowedTypes = hasTwo ? ['bar','grouped','stacked','line'] : ['bar','line'];
+    const allowedTypes = hasTwo ? ['bar', 'grouped', 'stacked', 'line'] : ['bar', 'line'];
     const desiredType = allowedTypes.includes(CFG.type) ? CFG.type : 'bar';
     typeSel.value = desiredType;
     CFG.type = desiredType;
   }
-
   drawAxesAndGrid();
   drawData();
-  updateStatus((CFG.type==='bar' || CFG.type==='line') && !hasTwo ? 'Dra i søylene/punktene – eller bruk tastaturet.' : '');
+  updateStatus((CFG.type === 'bar' || CFG.type === 'line') && !hasTwo ? 'Dra i søylene/punktene – eller bruk tastaturet.' : '');
 }
 
 /* =========================================================
    RENDER
    ========================================================= */
-function drawAxesAndGrid(){
-  gGrid.innerHTML = ''; gAxis.innerHTML = ''; gLabels.innerHTML = '';
-
+function drawAxesAndGrid() {
+  gGrid.innerHTML = '';
+  gAxis.innerHTML = '';
+  gLabels.innerHTML = '';
   const step = chooseStep(yMax);
-  for(let y=0; y<=yMax + 1e-9; y+=step){
+  for (let y = 0; y <= yMax + 1e-9; y += step) {
     const yy = yPos(y);
-    addTo(gGrid,'line',{x1:M.l, y1:yy, x2:W-M.r, y2:yy, class:'gridline'});
-    addTo(gGrid,'text',{x:M.l-6,y:yy+4,class:'yTickText'}).textContent = y;
+    addTo(gGrid, 'line', {
+      x1: M.l,
+      y1: yy,
+      x2: W - M.r,
+      y2: yy,
+      class: 'gridline'
+    });
+    addTo(gGrid, 'text', {
+      x: M.l - 6,
+      y: yy + 4,
+      class: 'yTickText'
+    }).textContent = y;
   }
 
   // y-akse
-  addTo(gAxis,'line',{x1:M.l, y1:M.t-8, x2:M.l, y2:H-M.b, class:'axis'});
+  addTo(gAxis, 'line', {
+    x1: M.l,
+    y1: M.t - 8,
+    x2: M.l,
+    y2: H - M.b,
+    class: 'axis'
+  });
   // x-akse
-  addTo(gAxis,'line',{x1:M.l, y1:H-M.b, x2:W-M.r, y2:H-M.b, class:'axis'});
+  addTo(gAxis, 'line', {
+    x1: M.l,
+    y1: H - M.b,
+    x2: W - M.r,
+    y2: H - M.b,
+    class: 'axis'
+  });
 
   // x-etiketter
-  CFG.labels.forEach((lab,i)=>{
-    addTo(gLabels,'text',{x:xPos(i), y:H-M.b+28, class:'xLabel'}).textContent = lab;
+  CFG.labels.forEach((lab, i) => {
+    addTo(gLabels, 'text', {
+      x: xPos(i),
+      y: H - M.b + 28,
+      class: 'xLabel'
+    }).textContent = lab;
   });
 
   // aksetekster
-  const yLab = addTo(gLabels,'text',{x:M.l-56, y:M.t + innerH/2, class:'yLabel'});
-  yLab.setAttribute('transform',`rotate(-90, ${M.l-56}, ${M.t + innerH/2})`);
+  const yLab = addTo(gLabels, 'text', {
+    x: M.l - 56,
+    y: M.t + innerH / 2,
+    class: 'yLabel'
+  });
+  yLab.setAttribute('transform', `rotate(-90, ${M.l - 56}, ${M.t + innerH / 2})`);
   yLab.textContent = CFG.axisYLabel || '';
-  addTo(gLabels,'text',{x:M.l + innerW/2, y:H - 24, class:'xAxisLabel'}).textContent = CFG.axisXLabel || '';
+  addTo(gLabels, 'text', {
+    x: M.l + innerW / 2,
+    y: H - 24,
+    class: 'xAxisLabel'
+  }).textContent = CFG.axisXLabel || '';
 }
-
-function drawData(){
-  gBars.innerHTML=''; gVals.innerHTML=''; gHands.innerHTML=''; gA11y.innerHTML=''; gLegend.innerHTML='';
+function drawData() {
+  gBars.innerHTML = '';
+  gVals.innerHTML = '';
+  gHands.innerHTML = '';
+  gA11y.innerHTML = '';
+  gLegend.innerHTML = '';
   const hasTwo = values2 && values2.length;
-  if(CFG.type === 'line'){
+  if (CFG.type === 'line') {
     drawLines();
-  }else if(hasTwo && CFG.type === 'grouped'){
+  } else if (hasTwo && CFG.type === 'grouped') {
     drawGroupedBars();
-  }else if(hasTwo && CFG.type === 'stacked'){
+  } else if (hasTwo && CFG.type === 'stacked') {
     drawStackedBars();
-  }else{
+  } else {
     drawBars();
   }
   drawLegend();
 }
-
-function drawLegend(){
+function drawLegend() {
   const names = [];
-  if(seriesNames[0]) names.push({name:seriesNames[0], cls:'series0'});
-  if(values2 && values2.length && seriesNames[1]) names.push({name:seriesNames[1], cls:'series1'});
-  names.forEach((s,i)=>{
-    const x = M.l + i*120;
+  if (seriesNames[0]) names.push({
+    name: seriesNames[0],
+    cls: 'series0'
+  });
+  if (values2 && values2.length && seriesNames[1]) names.push({
+    name: seriesNames[1],
+    cls: 'series1'
+  });
+  names.forEach((s, i) => {
+    const x = M.l + i * 120;
     const y = M.t - 10;
-    addTo(gLegend,'rect',{x:x, y:y-10, width:20, height:10, class:'legendbox '+s.cls});
-    addTo(gLegend,'text',{x:x+26,y:y,class:'legendtext'}).textContent = s.name;
+    addTo(gLegend, 'rect', {
+      x: x,
+      y: y - 10,
+      width: 20,
+      height: 10,
+      class: 'legendbox ' + s.cls
+    });
+    addTo(gLegend, 'text', {
+      x: x + 26,
+      y: y,
+      class: 'legendtext'
+    }).textContent = s.name;
   });
 }
-
-function drawLines(){
+function drawLines() {
   const datasets = [values];
-  if(values2 && values2.length) datasets.push(values2);
-  datasets.forEach((arr,idx)=>{
-    const path = arr.map((v,i)=> (i?'L':'M') + xPos(i) + ',' + yPos(v)).join(' ');
-    addTo(gBars,'path',{d:path,class:'line series'+idx});
-    arr.forEach((v,i)=>{
+  if (values2 && values2.length) datasets.push(values2);
+  datasets.forEach((arr, idx) => {
+    const path = arr.map((v, i) => (i ? 'L' : 'M') + xPos(i) + ',' + yPos(v)).join(' ');
+    addTo(gBars, 'path', {
+      d: path,
+      class: 'line series' + idx
+    });
+    arr.forEach((v, i) => {
       const cx = xPos(i);
       const cy = yPos(v);
-      addTo(gBars,'circle',{cx:cx, cy:cy, r:4, class:'line-dot series'+idx});
-      if(!locked[i]){
-        addTo(gHands,'circle',{cx:cx, cy:cy+2, r:16, class:'handleShadow'});
-        const h = addTo(gHands,'circle',{cx:cx, cy:cy, r:14, class:'handle'});
-        h.dataset.index = i; h.dataset.series = idx; h.dataset.base = 0;
+      addTo(gBars, 'circle', {
+        cx: cx,
+        cy: cy,
+        r: 4,
+        class: 'line-dot series' + idx
+      });
+      if (!locked[i]) {
+        addTo(gHands, 'circle', {
+          cx: cx,
+          cy: cy + 2,
+          r: 16,
+          class: 'handleShadow'
+        });
+        const h = addTo(gHands, 'circle', {
+          cx: cx,
+          cy: cy,
+          r: 14,
+          class: 'handle'
+        });
+        h.dataset.index = i;
+        h.dataset.series = idx;
+        h.dataset.base = 0;
         h.addEventListener('pointerdown', onDragStart);
       }
-      const a11y = addTo(gA11y,'circle',{cx:cx, cy:cy, r:20, fill:'transparent', class:'a11y', tabindex:0, role:'slider', 'aria-orientation':'vertical', 'aria-label':`${CFG.labels[i]}`, 'aria-valuemin':String(yMin), 'aria-valuemax':String(yMax), 'aria-valuenow':String(v), 'aria-valuetext':`${CFG.labels[i]}: ${fmt(v)}`});
-      if(locked[i]) a11y.setAttribute('aria-disabled','true');
-      a11y.dataset.index = i; a11y.dataset.series = idx; a11y.dataset.base = 0; a11y.addEventListener('pointerdown', onDragStart); a11y.addEventListener('keydown', onKeyAdjust);
+      const a11y = addTo(gA11y, 'circle', {
+        cx: cx,
+        cy: cy,
+        r: 20,
+        fill: 'transparent',
+        class: 'a11y',
+        tabindex: 0,
+        role: 'slider',
+        'aria-orientation': 'vertical',
+        'aria-label': `${CFG.labels[i]}`,
+        'aria-valuemin': String(yMin),
+        'aria-valuemax': String(yMax),
+        'aria-valuenow': String(v),
+        'aria-valuetext': `${CFG.labels[i]}: ${fmt(v)}`
+      });
+      if (locked[i]) a11y.setAttribute('aria-disabled', 'true');
+      a11y.dataset.index = i;
+      a11y.dataset.series = idx;
+      a11y.dataset.base = 0;
+      a11y.addEventListener('pointerdown', onDragStart);
+      a11y.addEventListener('keydown', onKeyAdjust);
     });
   });
 }
-
-function drawGroupedBars(){
+function drawGroupedBars() {
   const hasTwo = values2 && values2.length;
-  const barTotal = xBand*0.6;
-  const barSingle = hasTwo ? barTotal/2 : barTotal;
-  for(let i=0;i<N;i++){
-    const x0 = xPos(i) - barTotal/2;
+  const barTotal = xBand * 0.6;
+  const barSingle = hasTwo ? barTotal / 2 : barTotal;
+  for (let i = 0; i < N; i++) {
+    const x0 = xPos(i) - barTotal / 2;
     // serie 1
     const v1 = values[i];
     const y1 = yPos(v1);
-    const rect1 = addTo(gBars,'rect',{x:x0, y:y1, width:barSingle, height:Math.max(2,(H-M.b)-y1), class:'bar series0'+(locked[i]?' locked':'')});
+    const rect1 = addTo(gBars, 'rect', {
+      x: x0,
+      y: y1,
+      width: barSingle,
+      height: Math.max(2, H - M.b - y1),
+      class: 'bar series0' + (locked[i] ? ' locked' : '')
+    });
     rect1.dataset.index = i;
     rect1.dataset.series = 0;
     rect1.dataset.base = 0;
     rect1.addEventListener('pointerdown', onDragStart);
-    if(!locked[i]){
-      addTo(gHands,'circle',{cx:x0+barSingle/2, cy:y1-2+2, r:16, class:'handleShadow'});
-      const h1 = addTo(gHands,'circle',{cx:x0+barSingle/2, cy:y1-2, r:14, class:'handle'});
-      h1.dataset.index = i; h1.dataset.series = 0; h1.dataset.base = 0;
+    if (!locked[i]) {
+      addTo(gHands, 'circle', {
+        cx: x0 + barSingle / 2,
+        cy: y1 - 2 + 2,
+        r: 16,
+        class: 'handleShadow'
+      });
+      const h1 = addTo(gHands, 'circle', {
+        cx: x0 + barSingle / 2,
+        cy: y1 - 2,
+        r: 14,
+        class: 'handle'
+      });
+      h1.dataset.index = i;
+      h1.dataset.series = 0;
+      h1.dataset.base = 0;
       h1.addEventListener('pointerdown', onDragStart);
     }
-    const a1 = addTo(gA11y,'rect',{x:x0, y:M.t, width:barSingle, height:innerH, fill:'transparent', class:'a11y', tabindex:0, role:'slider', 'aria-orientation':'vertical', 'aria-label':`${CFG.labels[i]}`, 'aria-valuemin':String(yMin), 'aria-valuemax':String(yMax), 'aria-valuenow':String(v1), 'aria-valuetext':`${CFG.labels[i]}: ${fmt(v1)}`});
-    if(locked[i]) a1.setAttribute('aria-disabled','true');
-    a1.dataset.index = i; a1.dataset.series = 0; a1.dataset.base = 0; a1.addEventListener('pointerdown', onDragStart); a1.addEventListener('keydown', onKeyAdjust);
+    const a1 = addTo(gA11y, 'rect', {
+      x: x0,
+      y: M.t,
+      width: barSingle,
+      height: innerH,
+      fill: 'transparent',
+      class: 'a11y',
+      tabindex: 0,
+      role: 'slider',
+      'aria-orientation': 'vertical',
+      'aria-label': `${CFG.labels[i]}`,
+      'aria-valuemin': String(yMin),
+      'aria-valuemax': String(yMax),
+      'aria-valuenow': String(v1),
+      'aria-valuetext': `${CFG.labels[i]}: ${fmt(v1)}`
+    });
+    if (locked[i]) a1.setAttribute('aria-disabled', 'true');
+    a1.dataset.index = i;
+    a1.dataset.series = 0;
+    a1.dataset.base = 0;
+    a1.addEventListener('pointerdown', onDragStart);
+    a1.addEventListener('keydown', onKeyAdjust);
     // Verdietikettene fjernet
 
-    if(hasTwo){
+    if (hasTwo) {
       const v2 = values2[i];
       const y2 = yPos(v2);
       const x1 = x0 + barSingle;
-      const rect2 = addTo(gBars,'rect',{x:x1, y:y2, width:barSingle, height:Math.max(2,(H-M.b)-y2), class:'bar series1'+(locked[i]?' locked':'')});
-      rect2.dataset.index = i; rect2.dataset.series = 1; rect2.dataset.base = 0; rect2.addEventListener('pointerdown', onDragStart);
-      if(!locked[i]){
-        addTo(gHands,'circle',{cx:x1+barSingle/2, cy:y2-2+2, r:16, class:'handleShadow'});
-        const h2 = addTo(gHands,'circle',{cx:x1+barSingle/2, cy:y2-2, r:14, class:'handle'});
-        h2.dataset.index = i; h2.dataset.series = 1; h2.dataset.base = 0; h2.addEventListener('pointerdown', onDragStart);
+      const rect2 = addTo(gBars, 'rect', {
+        x: x1,
+        y: y2,
+        width: barSingle,
+        height: Math.max(2, H - M.b - y2),
+        class: 'bar series1' + (locked[i] ? ' locked' : '')
+      });
+      rect2.dataset.index = i;
+      rect2.dataset.series = 1;
+      rect2.dataset.base = 0;
+      rect2.addEventListener('pointerdown', onDragStart);
+      if (!locked[i]) {
+        addTo(gHands, 'circle', {
+          cx: x1 + barSingle / 2,
+          cy: y2 - 2 + 2,
+          r: 16,
+          class: 'handleShadow'
+        });
+        const h2 = addTo(gHands, 'circle', {
+          cx: x1 + barSingle / 2,
+          cy: y2 - 2,
+          r: 14,
+          class: 'handle'
+        });
+        h2.dataset.index = i;
+        h2.dataset.series = 1;
+        h2.dataset.base = 0;
+        h2.addEventListener('pointerdown', onDragStart);
       }
-      const a2 = addTo(gA11y,'rect',{x:x1, y:M.t, width:barSingle, height:innerH, fill:'transparent', class:'a11y', tabindex:0, role:'slider', 'aria-orientation':'vertical', 'aria-label':`${CFG.labels[i]}`, 'aria-valuemin':String(yMin), 'aria-valuemax':String(yMax), 'aria-valuenow':String(v2), 'aria-valuetext':`${CFG.labels[i]}: ${fmt(v2)}`});
-      if(locked[i]) a2.setAttribute('aria-disabled','true');
-      a2.dataset.index = i; a2.dataset.series = 1; a2.dataset.base = 0; a2.addEventListener('pointerdown', onDragStart); a2.addEventListener('keydown', onKeyAdjust);
+      const a2 = addTo(gA11y, 'rect', {
+        x: x1,
+        y: M.t,
+        width: barSingle,
+        height: innerH,
+        fill: 'transparent',
+        class: 'a11y',
+        tabindex: 0,
+        role: 'slider',
+        'aria-orientation': 'vertical',
+        'aria-label': `${CFG.labels[i]}`,
+        'aria-valuemin': String(yMin),
+        'aria-valuemax': String(yMax),
+        'aria-valuenow': String(v2),
+        'aria-valuetext': `${CFG.labels[i]}: ${fmt(v2)}`
+      });
+      if (locked[i]) a2.setAttribute('aria-disabled', 'true');
+      a2.dataset.index = i;
+      a2.dataset.series = 1;
+      a2.dataset.base = 0;
+      a2.addEventListener('pointerdown', onDragStart);
+      a2.addEventListener('keydown', onKeyAdjust);
       // Verdietikettene fjernet
     }
   }
 }
-
-function drawStackedBars(){
-  const barTotal = xBand*0.6;
-  for(let i=0;i<N;i++){
-    const base = H-M.b;
+function drawStackedBars() {
+  const barTotal = xBand * 0.6;
+  for (let i = 0; i < N; i++) {
+    const base = H - M.b;
     const v1 = values[i];
     const v2 = values2 ? values2[i] : 0;
     const cx = xPos(i);
     const y1 = yPos(v1);
-    const rect1 = addTo(gBars,'rect',{x:cx-barTotal/2, y:y1, width:barTotal, height:Math.max(2,base-y1), class:'bar series0'+(locked[i]?' locked':'')});
-    rect1.dataset.index = i; rect1.dataset.series = 0; rect1.dataset.base = 0; rect1.addEventListener('pointerdown', onDragStart);
-    if(!locked[i]){
-      addTo(gHands,'circle',{cx:cx, cy:y1-2+2, r:16, class:'handleShadow'});
-      const h1 = addTo(gHands,'circle',{cx:cx, cy:y1-2, r:14, class:'handle'});
-      h1.dataset.index = i; h1.dataset.series = 0; h1.dataset.base = 0; h1.addEventListener('pointerdown', onDragStart);
+    const rect1 = addTo(gBars, 'rect', {
+      x: cx - barTotal / 2,
+      y: y1,
+      width: barTotal,
+      height: Math.max(2, base - y1),
+      class: 'bar series0' + (locked[i] ? ' locked' : '')
+    });
+    rect1.dataset.index = i;
+    rect1.dataset.series = 0;
+    rect1.dataset.base = 0;
+    rect1.addEventListener('pointerdown', onDragStart);
+    if (!locked[i]) {
+      addTo(gHands, 'circle', {
+        cx: cx,
+        cy: y1 - 2 + 2,
+        r: 16,
+        class: 'handleShadow'
+      });
+      const h1 = addTo(gHands, 'circle', {
+        cx: cx,
+        cy: y1 - 2,
+        r: 14,
+        class: 'handle'
+      });
+      h1.dataset.index = i;
+      h1.dataset.series = 0;
+      h1.dataset.base = 0;
+      h1.addEventListener('pointerdown', onDragStart);
     }
-    const a1 = addTo(gA11y,'rect',{x:cx-barTotal/2, y:y1, width:barTotal, height:base-y1, fill:'transparent', class:'a11y', tabindex:0, role:'slider', 'aria-orientation':'vertical', 'aria-label':`${CFG.labels[i]}`, 'aria-valuemin':String(yMin), 'aria-valuemax':String(yMax - v2), 'aria-valuenow':String(v1), 'aria-valuetext':`${CFG.labels[i]}: ${fmt(v1)}`});
-    if(locked[i]) a1.setAttribute('aria-disabled','true');
-    a1.dataset.index=i; a1.dataset.series=0; a1.dataset.base=0; a1.addEventListener('pointerdown', onDragStart); a1.addEventListener('keydown', onKeyAdjust);
+    const a1 = addTo(gA11y, 'rect', {
+      x: cx - barTotal / 2,
+      y: y1,
+      width: barTotal,
+      height: base - y1,
+      fill: 'transparent',
+      class: 'a11y',
+      tabindex: 0,
+      role: 'slider',
+      'aria-orientation': 'vertical',
+      'aria-label': `${CFG.labels[i]}`,
+      'aria-valuemin': String(yMin),
+      'aria-valuemax': String(yMax - v2),
+      'aria-valuenow': String(v1),
+      'aria-valuetext': `${CFG.labels[i]}: ${fmt(v1)}`
+    });
+    if (locked[i]) a1.setAttribute('aria-disabled', 'true');
+    a1.dataset.index = i;
+    a1.dataset.series = 0;
+    a1.dataset.base = 0;
+    a1.addEventListener('pointerdown', onDragStart);
+    a1.addEventListener('keydown', onKeyAdjust);
     // Verdietikettene fjernet
 
-    if(values2){
-      const y2 = yPos(v1+v2);
-      const rect2 = addTo(gBars,'rect',{x:cx-barTotal/2, y:y2, width:barTotal, height:Math.max(2,y1-y2), class:'bar series1'+(locked[i]?' locked':'')});
-      rect2.dataset.index = i; rect2.dataset.series = 1; rect2.dataset.base = v1; rect2.addEventListener('pointerdown', onDragStart);
-      if(!locked[i]){
-        addTo(gHands,'circle',{cx:cx, cy:y2-2+2, r:16, class:'handleShadow'});
-        const h2 = addTo(gHands,'circle',{cx:cx, cy:y2-2, r:14, class:'handle'});
-        h2.dataset.index = i; h2.dataset.series = 1; h2.dataset.base = v1; h2.addEventListener('pointerdown', onDragStart);
+    if (values2) {
+      const y2 = yPos(v1 + v2);
+      const rect2 = addTo(gBars, 'rect', {
+        x: cx - barTotal / 2,
+        y: y2,
+        width: barTotal,
+        height: Math.max(2, y1 - y2),
+        class: 'bar series1' + (locked[i] ? ' locked' : '')
+      });
+      rect2.dataset.index = i;
+      rect2.dataset.series = 1;
+      rect2.dataset.base = v1;
+      rect2.addEventListener('pointerdown', onDragStart);
+      if (!locked[i]) {
+        addTo(gHands, 'circle', {
+          cx: cx,
+          cy: y2 - 2 + 2,
+          r: 16,
+          class: 'handleShadow'
+        });
+        const h2 = addTo(gHands, 'circle', {
+          cx: cx,
+          cy: y2 - 2,
+          r: 14,
+          class: 'handle'
+        });
+        h2.dataset.index = i;
+        h2.dataset.series = 1;
+        h2.dataset.base = v1;
+        h2.addEventListener('pointerdown', onDragStart);
       }
-      const a2 = addTo(gA11y,'rect',{x:cx-barTotal/2, y:y2, width:barTotal, height:y1-y2, fill:'transparent', class:'a11y', tabindex:0, role:'slider', 'aria-orientation':'vertical', 'aria-label':`${CFG.labels[i]}`, 'aria-valuemin':String(yMin), 'aria-valuemax':String(yMax), 'aria-valuenow':String(v2), 'aria-valuetext':`${CFG.labels[i]}: ${fmt(v2)}`});
-      if(locked[i]) a2.setAttribute('aria-disabled','true');
-      a2.dataset.index=i; a2.dataset.series=1; a2.dataset.base=v1; a2.addEventListener('pointerdown', onDragStart); a2.addEventListener('keydown', onKeyAdjust);
+      const a2 = addTo(gA11y, 'rect', {
+        x: cx - barTotal / 2,
+        y: y2,
+        width: barTotal,
+        height: y1 - y2,
+        fill: 'transparent',
+        class: 'a11y',
+        tabindex: 0,
+        role: 'slider',
+        'aria-orientation': 'vertical',
+        'aria-label': `${CFG.labels[i]}`,
+        'aria-valuemin': String(yMin),
+        'aria-valuemax': String(yMax),
+        'aria-valuenow': String(v2),
+        'aria-valuetext': `${CFG.labels[i]}: ${fmt(v2)}`
+      });
+      if (locked[i]) a2.setAttribute('aria-disabled', 'true');
+      a2.dataset.index = i;
+      a2.dataset.series = 1;
+      a2.dataset.base = v1;
+      a2.addEventListener('pointerdown', onDragStart);
+      a2.addEventListener('keydown', onKeyAdjust);
       // Verdietikettene fjernet
     }
   }
 }
-
-function drawBars(){
-  gBars.innerHTML=''; gVals.innerHTML=''; gHands.innerHTML=''; gA11y.innerHTML='';
-
-  values.forEach((v,i)=>{
+function drawBars() {
+  gBars.innerHTML = '';
+  gVals.innerHTML = '';
+  gHands.innerHTML = '';
+  gA11y.innerHTML = '';
+  values.forEach((v, i) => {
     const cx = xPos(i);
-    const y  = yPos(v);
+    const y = yPos(v);
 
     // 1) SØYLE (draggbar)
-    const rect = addTo(gBars,'rect',{
-      x: cx - barW/2,
+    const rect = addTo(gBars, 'rect', {
+      x: cx - barW / 2,
       y: y,
       width: barW,
-      height: Math.max(2, (H-M.b) - y),
+      height: Math.max(2, H - M.b - y),
       class: 'bar series0' + (locked[i] ? ' locked' : '')
     });
     rect.dataset.index = i;
@@ -427,8 +666,18 @@ function drawBars(){
 
     // 2) HÅNDTAK (draggbar)
     if (!locked[i]) {
-      addTo(gHands,'circle',{cx:cx, cy:y-2+2, r:16, class:'handleShadow'});
-      const h = addTo(gHands,'circle',{cx:cx, cy:y-2, r:14, class:'handle'});
+      addTo(gHands, 'circle', {
+        cx: cx,
+        cy: y - 2 + 2,
+        r: 16,
+        class: 'handleShadow'
+      });
+      const h = addTo(gHands, 'circle', {
+        cx: cx,
+        cy: y - 2,
+        r: 14,
+        class: 'handle'
+      });
       h.dataset.index = i;
       h.dataset.series = 0;
       h.dataset.base = 0;
@@ -436,10 +685,10 @@ function drawBars(){
     }
 
     // 3) A11y‐overlay (fokus + tastatur + stor klikkflate)
-    const a11y = addTo(gA11y,'rect',{
-      x: cx - xBand*0.5,
+    const a11y = addTo(gA11y, 'rect', {
+      x: cx - xBand * 0.5,
       y: M.t,
-      width: xBand*0.98,
+      width: xBand * 0.98,
       height: innerH,
       fill: 'transparent',
       class: 'a11y',
@@ -452,7 +701,7 @@ function drawBars(){
       'aria-valuenow': String(v),
       'aria-valuetext': `${CFG.labels[i]}: ${fmt(v)}`
     });
-    if(locked[i]) a11y.setAttribute('aria-disabled','true');
+    if (locked[i]) a11y.setAttribute('aria-disabled', 'true');
     a11y.dataset.index = i;
     a11y.dataset.series = 0;
     a11y.dataset.base = 0;
@@ -461,7 +710,9 @@ function drawBars(){
 
     // gjenopprett fokus på samme søyle synkront
     if (lastFocusIndex === i) {
-      a11y.focus({ preventScroll: true });
+      a11y.focus({
+        preventScroll: true
+      });
     }
 
     // 4) Verdi (øverst, ikke-interaktiv)
@@ -472,16 +723,14 @@ function drawBars(){
 /* =========================================================
    DRAGGING (mus/berøring)
    ========================================================= */
-function onDragStart(e){
+function onDragStart(e) {
   e.preventDefault();
   const target = e.currentTarget;
   const idx = +target.dataset.index;
   let series = +target.dataset.series || 0;
   if (locked[idx]) return;
   lastFocusIndex = idx;
-
   let base = +target.dataset.base || 0;
-
   if (CFG.type === 'stacked' && values2 && values2.length) {
     const pointer = clientToSvg(e.clientX, e.clientY);
     const boundaryY = yPos(values[idx]);
@@ -494,52 +743,70 @@ function onDragStart(e){
       base = values[idx];
     }
   }
-
-  const move = ev=>{
+  const move = ev => {
     ev.preventDefault();
     const p = clientToSvg(ev.clientX, ev.clientY);
-    const clampedY = Math.min(H-M.b, Math.max(M.t, p.y));
+    const clampedY = Math.min(H - M.b, Math.max(M.t, p.y));
     const v = yToValue(clampedY) - base;
     setValue(idx, v, true, series);
   };
-  const up = ev=>{
+  const up = ev => {
     ev.preventDefault();
     window.removeEventListener('pointermove', move);
     window.removeEventListener('pointerup', up);
-    if(target.releasePointerCapture){
-      try{ target.releasePointerCapture(ev.pointerId); }catch{}
+    if (target.releasePointerCapture) {
+      try {
+        target.releasePointerCapture(ev.pointerId);
+      } catch {}
     }
   };
-  window.addEventListener('pointermove', move, { passive: false });
-  window.addEventListener('pointerup', up, { passive: false });
-  if(target.setPointerCapture){
-    try{ target.setPointerCapture(e.pointerId); }catch{}
+  window.addEventListener('pointermove', move, {
+    passive: false
+  });
+  window.addEventListener('pointerup', up, {
+    passive: false
+  });
+  if (target.setPointerCapture) {
+    try {
+      target.setPointerCapture(e.pointerId);
+    } catch {}
   }
 }
 
 /* =========================================================
    TASTATUR (UU)
    ========================================================= */
-function onKeyAdjust(e){
+function onKeyAdjust(e) {
   const idx = +e.currentTarget.dataset.index;
   const series = +e.currentTarget.dataset.series || 0;
   if (locked[idx]) return;
   lastFocusIndex = idx;
-
   const step = CFG.snap || 1;
-  const big  = step * 5;
-  let target = series===0 ? values[idx] : (values2 ? values2[idx] : 0);
-
-  switch(e.key){
+  const big = step * 5;
+  let target = series === 0 ? values[idx] : values2 ? values2[idx] : 0;
+  switch (e.key) {
     case 'ArrowUp':
-    case 'ArrowRight': target += step; break;
+    case 'ArrowRight':
+      target += step;
+      break;
     case 'ArrowDown':
-    case 'ArrowLeft':  target -= step; break;
-    case 'PageUp':     target += big;  break;
-    case 'PageDown':   target -= big;  break;
-    case 'Home':       target = 0;     break;
-    case 'End':        target = yMax - (series===0 ? (values2 ? values2[idx] : 0) : values[idx]); break;
-    default: return;
+    case 'ArrowLeft':
+      target -= step;
+      break;
+    case 'PageUp':
+      target += big;
+      break;
+    case 'PageDown':
+      target -= big;
+      break;
+    case 'Home':
+      target = 0;
+      break;
+    case 'End':
+      target = yMax - (series === 0 ? values2 ? values2[idx] : 0 : values[idx]);
+      break;
+    default:
+      return;
   }
   e.preventDefault();
   setValue(idx, target, true, series);
@@ -548,40 +815,38 @@ function onKeyAdjust(e){
 /* =========================================================
    STATE / BEREGNING
    ========================================================= */
-function setValue(idx, newVal, announce=false, series=0){
+function setValue(idx, newVal, announce = false, series = 0) {
   if (locked[idx]) return;
-  const other = series===0 ? (values2 ? values2[idx] : 0) : values[idx];
+  const other = series === 0 ? values2 ? values2[idx] : 0 : values[idx];
   const snapped = snap(newVal, CFG.snap || 1);
   const v = clamp(snapped, yMin, yMax - other);
-  if(series===0){
+  if (series === 0) {
     values[idx] = v;
-  }else{
-    if(!values2) values2 = alignLength([], N, 0);
+  } else {
+    if (!values2) values2 = alignLength([], N, 0);
     values2[idx] = v;
   }
   syncConfigFromValues(series);
   drawData(); // oppdater grafikk + aria
-  if(announce){
+  if (announce) {
     const sName = seriesNames[series] || '';
     const label = sName ? `${CFG.labels[idx]} – ${sName}` : `${CFG.labels[idx]}`;
     updateStatus(`${label}: ${fmt(v)}`);
   }
 }
-
-function yToValue(py){
-  const frac = (H - M.b - py) / innerH;     // inverse av yPos
+function yToValue(py) {
+  const frac = (H - M.b - py) / innerH; // inverse av yPos
   return yMin + frac * (yMax - yMin);
 }
-
-function syncConfigFromValues(series){
-  const updateInput = (id, arr)=>{
+function syncConfigFromValues(series) {
+  const updateInput = (id, arr) => {
     const input = document.getElementById(id);
-    if(input) input.value = formatNumberList(arr);
+    if (input) input.value = formatNumberList(arr);
   };
-  if(series === 0){
+  if (series === 0) {
     CFG.start = values.slice();
     updateInput('cfgStart', values);
-  } else if(series === 1 && values2){
+  } else if (series === 1 && values2) {
     CFG.start2 = values2.slice();
     updateInput('cfgStart2', values2);
   }
@@ -590,33 +855,31 @@ function syncConfigFromValues(series){
 /* =========================================================
    KNAPPER
    ========================================================= */
-document.getElementById('btnReset').addEventListener('click', ()=>{
+document.getElementById('btnReset').addEventListener('click', () => {
   values = CFG.start.slice();
-  if(values2) values2 = CFG.start2 ? CFG.start2.slice() : null;
+  if (values2) values2 = CFG.start2 ? CFG.start2.slice() : null;
   clearBadges();
   lastFocusIndex = null;
   drawData();
   updateStatus('Nullstilt.');
 });
-document.getElementById('btnShow').addEventListener('click', ()=>{
+document.getElementById('btnShow').addEventListener('click', () => {
   values = CFG.answer.slice();
-  if(values2) values2 = CFG.answer2 ? CFG.answer2.slice() : null;
+  if (values2) values2 = CFG.answer2 ? CFG.answer2.slice() : null;
   lastFocusIndex = null;
   drawData();
   markCorrectness();
   updateStatus('Dette er én fasit.');
 });
-document.getElementById('btnCheck').addEventListener('click', ()=>{
+document.getElementById('btnCheck').addEventListener('click', () => {
   markCorrectness();
-  const ok1 = isCorrect(values, CFG.answer, CFG.tolerance||0);
-  const ok2 = values2 ? isCorrect(values2, CFG.answer2, CFG.tolerance||0) : true;
+  const ok1 = isCorrect(values, CFG.answer, CFG.tolerance || 0);
+  const ok2 = values2 ? isCorrect(values2, CFG.answer2, CFG.tolerance || 0) : true;
   const ok = ok1 && ok2;
   updateStatus(ok ? 'Riktig! 🎉' : 'Prøv igjen 🙂');
 });
-
 document.querySelector('.settings').addEventListener('input', applyCfg);
-
-function applyCfg(){
+function applyCfg() {
   const lbls = parseList(document.getElementById('cfgLabels').value);
   const starts = parseNumList(document.getElementById('cfgStart').value);
   const answers = parseNumList(document.getElementById('cfgAnswer').value);
@@ -625,9 +888,9 @@ function applyCfg(){
   CFG.type = document.getElementById('cfgType').value;
   CFG.series1 = document.getElementById('cfgSeries1').value;
   CFG.labels = lbls;
-  CFG.start  = alignLength(starts, lbls.length, 0);
+  CFG.start = alignLength(starts, lbls.length, 0);
   CFG.answer = alignLength(answers, lbls.length, 0);
-  if(series2Enabled){
+  if (series2Enabled) {
     CFG.series2 = document.getElementById('cfgSeries2').value;
     const starts2 = parseNumList(document.getElementById('cfgStart2').value);
     const answers2 = parseNumList(document.getElementById('cfgAnswer2').value);
@@ -638,14 +901,14 @@ function applyCfg(){
     CFG.start2 = null;
     CFG.answer2 = null;
   }
-  CFG.yMax   = isNaN(yMaxVal) ? undefined : yMaxVal;
+  CFG.yMax = isNaN(yMaxVal) ? undefined : yMaxVal;
   CFG.axisXLabel = document.getElementById('cfgAxisXLabel').value;
   CFG.axisYLabel = document.getElementById('cfgAxisYLabel').value;
   const snapVal = parseFloat(document.getElementById('cfgSnap').value);
   CFG.snap = isNaN(snapVal) ? 1 : snapVal;
   const tolVal = parseFloat(document.getElementById('cfgTolerance').value);
   CFG.tolerance = isNaN(tolVal) ? 0 : tolVal;
-  const lockedVals = parseNumList(document.getElementById('cfgLocked').value).map(v=>v!==0);
+  const lockedVals = parseNumList(document.getElementById('cfgLocked').value).map(v => v !== 0);
   CFG.locked = alignLength(lockedVals, lbls.length, false);
   initFromCfg();
 }
@@ -653,104 +916,110 @@ function applyCfg(){
 /* =========================================================
    HJELPERE
    ========================================================= */
-function add(name, attrs={}){
+function add(name, attrs = {}) {
   const el = document.createElementNS('http://www.w3.org/2000/svg', name);
-  Object.entries(attrs).forEach(([k,v])=>el.setAttribute(k,v));
-  svg.appendChild(el); return el;
+  Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+  svg.appendChild(el);
+  return el;
 }
-function addTo(group, name, attrs={}){
+function addTo(group, name, attrs = {}) {
   const el = document.createElementNS(svg.namespaceURI, name);
-  Object.entries(attrs).forEach(([k,v])=>el.setAttribute(k,v));
-  group.appendChild(el); return el;
+  Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+  group.appendChild(el);
+  return el;
 }
-function clientToSvg(clientX, clientY){
+function clientToSvg(clientX, clientY) {
   const rect = svg.getBoundingClientRect();
-  const sx = W / rect.width, sy = H / rect.height;
-  return { x:(clientX-rect.left)*sx, y:(clientY-rect.top)*sy };
+  const sx = W / rect.width,
+    sy = H / rect.height;
+  return {
+    x: (clientX - rect.left) * sx,
+    y: (clientY - rect.top) * sy
+  };
 }
-function fmt(x){ return (Math.round(x*100)/100).toString().replace('.',','); }
-function snap(v, s){ return Math.round(v / s) * s; }
-function clamp(v,a,b){ return Math.max(a, Math.min(b,v)); }
-
-function parseList(str){
-  return str.split(',').map(s=>s.trim()).filter(s=>s.length>0);
+function fmt(x) {
+  return (Math.round(x * 100) / 100).toString().replace('.', ',');
 }
-function parseNumList(str){
-  return parseList(str).map(s=>Number(s.replace(',', '.'))).map(v=>isNaN(v)?0:v);
+function snap(v, s) {
+  return Math.round(v / s) * s;
 }
-function alignLength(arr, len, fill=0){
-  if(arr.length < len) return arr.concat(Array(len-arr.length).fill(fill));
-  if(arr.length > len) return arr.slice(0,len);
+function clamp(v, a, b) {
+  return Math.max(a, Math.min(b, v));
+}
+function parseList(str) {
+  return str.split(',').map(s => s.trim()).filter(s => s.length > 0);
+}
+function parseNumList(str) {
+  return parseList(str).map(s => Number(s.replace(',', '.'))).map(v => isNaN(v) ? 0 : v);
+}
+function alignLength(arr, len, fill = 0) {
+  if (arr.length < len) return arr.concat(Array(len - arr.length).fill(fill));
+  if (arr.length > len) return arr.slice(0, len);
   return arr;
 }
-
-function formatNumberList(arr){
+function formatNumberList(arr) {
   return arr.map(formatNumber).join(',');
 }
-
-function formatNumber(value){
-  if(!Number.isFinite(value)) return '0';
+function formatNumber(value) {
+  if (!Number.isFinite(value)) return '0';
   let str = value.toFixed(6);
-  if(str.includes('.')){
-    str = str.replace(/0+$/,'').replace(/\.$/,'');
+  if (str.includes('.')) {
+    str = str.replace(/0+$/, '').replace(/\.$/, '');
   }
   return str.length ? str : '0';
 }
-
-function niceMax(arr){
+function niceMax(arr) {
   const m = Math.max(...arr);
-  if(m<=10) return 10;
-  if(m<=12) return 12;
+  if (m <= 10) return 10;
+  if (m <= 12) return 12;
   const pow = Math.pow(10, Math.floor(Math.log10(m)));
   const r = Math.ceil(m / pow);
   return r * pow;
 }
-function chooseStep(maxY){
-  if(maxY<=10) return 1;
-  if(maxY<=20) return 2;
-  if(maxY<=50) return 5;
+function chooseStep(maxY) {
+  if (maxY <= 10) return 1;
+  if (maxY <= 20) return 2;
+  if (maxY <= 50) return 5;
   return 10;
 }
-function updateStatus(msg){
+function updateStatus(msg) {
   document.getElementById('status').textContent = msg; // aria-live="polite"
 }
-function clearBadges(){
-  [...gBars.querySelectorAll('.bar')].forEach(b=>b.classList.remove('badge-ok','badge-no'));
+function clearBadges() {
+  [...gBars.querySelectorAll('.bar')].forEach(b => b.classList.remove('badge-ok', 'badge-no'));
 }
-function markCorrectness(){
+function markCorrectness() {
   clearBadges();
-  const tol = CFG.tolerance||0;
-  [...gBars.children].forEach(rect=>{
+  const tol = CFG.tolerance || 0;
+  [...gBars.children].forEach(rect => {
     const idx = +rect.dataset.index;
     const series = +rect.dataset.series || 0;
-    const arr = series===0 ? values : values2;
-    const ans = series===0 ? CFG.answer : CFG.answer2;
-    if(!arr || !ans) return;
+    const arr = series === 0 ? values : values2;
+    const ans = series === 0 ? CFG.answer : CFG.answer2;
+    if (!arr || !ans) return;
     const ok = Math.abs(arr[idx] - ans[idx]) <= tol;
     rect.classList.add(ok ? 'badge-ok' : 'badge-no');
   });
 }
-function isCorrect(vs, ans, tol){
-  if(vs.length !== ans.length) return false;
-  return vs.every((v,i)=> Math.abs(v-ans[i]) <= tol);
+function isCorrect(vs, ans, tol) {
+  if (vs.length !== ans.length) return false;
+  return vs.every((v, i) => Math.abs(v - ans[i]) <= tol);
 }
-
-async function svgToString(svgEl){
+async function svgToString(svgEl) {
+  var _titleEl$textContent;
   const clone = svgEl.cloneNode(true);
 
   // Kopier beregnede stilverdier som attributter for å unngå svarte figurer
-  const srcEls   = svgEl.querySelectorAll('*');
+  const srcEls = svgEl.querySelectorAll('*');
   const cloneEls = clone.querySelectorAll('*');
-  srcEls.forEach((src, i)=>{
-    const dst   = cloneEls[i];
-    const comp  = getComputedStyle(src);
-    const props = ['fill','stroke','stroke-width','font-family','font-size','font-weight',
-                   'opacity','text-anchor','paint-order','stroke-linecap','stroke-linejoin',
-                   'stroke-dasharray'];
-    props.forEach(p=>{
+  srcEls.forEach((src, i) => {
+    const dst = cloneEls[i];
+    const comp = getComputedStyle(src);
+    const props = ['fill', 'stroke', 'stroke-width', 'font-family', 'font-size', 'font-weight', 'opacity', 'text-anchor', 'paint-order', 'stroke-linecap', 'stroke-linejoin', 'stroke-dasharray'];
+    props.forEach(p => {
       const val = comp.getPropertyValue(p);
       // Include 'none' for fill and stroke to preserve transparency
-      if(val && val !== 'normal' && val !== '0px'){
+      if (val && val !== 'normal' && val !== '0px') {
         dst.setAttribute(p, val);
       }
     });
@@ -758,66 +1027,73 @@ async function svgToString(svgEl){
 
   // legg til overskrift fra h2-elementet i eksporten
   const titleEl = document.getElementById('chartTitle');
-  const titleText = titleEl?.textContent?.trim();
-  if(titleText){
-    const t = document.createElementNS('http://www.w3.org/2000/svg','text');
+  const titleText = titleEl === null || titleEl === void 0 || (_titleEl$textContent = titleEl.textContent) === null || _titleEl$textContent === void 0 ? void 0 : _titleEl$textContent.trim();
+  if (titleText) {
+    const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');
     t.textContent = titleText;
-    t.setAttribute('x', W/2);
-    t.setAttribute('y', M.t/2);
-    t.setAttribute('text-anchor','middle');
+    t.setAttribute('x', W / 2);
+    t.setAttribute('y', M.t / 2);
+    t.setAttribute('text-anchor', 'middle');
     const comp = getComputedStyle(titleEl);
     const color = comp.getPropertyValue('color');
-    if(color) t.setAttribute('fill', color);
+    if (color) t.setAttribute('fill', color);
     const ff = comp.getPropertyValue('font-family');
-    if(ff) t.setAttribute('font-family', ff);
+    if (ff) t.setAttribute('font-family', ff);
     const fs = comp.getPropertyValue('font-size');
-    if(fs) t.setAttribute('font-size', fs);
+    if (fs) t.setAttribute('font-size', fs);
     const fw = comp.getPropertyValue('font-weight');
-    if(fw && fw !== 'normal') t.setAttribute('font-weight', fw);
+    if (fw && fw !== 'normal') t.setAttribute('font-weight', fw);
     clone.insertBefore(t, clone.firstChild);
   }
 
   // fjern interaktive håndtak før eksport
-  clone.querySelectorAll('.handle, .handleShadow').forEach(el=>el.remove());
-
-  clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
-  clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
+  clone.querySelectorAll('.handle, .handleShadow').forEach(el => el.remove());
+  clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
   return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
 }
-async function downloadSVG(svgEl, filename){
+async function downloadSVG(svgEl, filename) {
   const data = await svgToString(svgEl);
-  const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+  const blob = new Blob([data], {
+    type: 'image/svg+xml;charset=utf-8'
+  });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
   a.download = filename.endsWith('.svg') ? filename : filename + '.svg';
-  document.body.appendChild(a); a.click(); a.remove();
-  setTimeout(()=>URL.revokeObjectURL(url), 1000);
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
-async function downloadPNG(svgEl, filename, scale=2, bg='#fff'){
+async function downloadPNG(svgEl, filename, scale = 2, bg = '#fff') {
   const vb = svgEl.viewBox.baseVal;
-  const w = vb?.width  || svgEl.clientWidth  || 900;
-  const h = vb?.height || svgEl.clientHeight || 560;
+  const w = (vb === null || vb === void 0 ? void 0 : vb.width) || svgEl.clientWidth || 900;
+  const h = (vb === null || vb === void 0 ? void 0 : vb.height) || svgEl.clientHeight || 560;
   const data = await svgToString(svgEl);
-  const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
-  const url  = URL.createObjectURL(blob);
+  const blob = new Blob([data], {
+    type: 'image/svg+xml;charset=utf-8'
+  });
+  const url = URL.createObjectURL(blob);
   const img = new Image();
-  img.onload = ()=>{
+  img.onload = () => {
     const canvas = document.createElement('canvas');
-    canvas.width  = Math.round(w * scale);
+    canvas.width = Math.round(w * scale);
     canvas.height = Math.round(h * scale);
     const ctx = canvas.getContext('2d');
     ctx.fillStyle = bg;
-    ctx.fillRect(0,0,canvas.width,canvas.height);
-    ctx.drawImage(img,0,0,canvas.width,canvas.height);
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
     URL.revokeObjectURL(url);
-    canvas.toBlob(blob=>{
+    canvas.toBlob(blob => {
       const urlPng = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = urlPng;
       a.download = filename.endsWith('.png') ? filename : filename + '.png';
-      document.body.appendChild(a); a.click(); a.remove();
-      setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(urlPng), 1000);
     }, 'image/png');
   };
   img.src = url;

--- a/examples.js
+++ b/examples.js
@@ -1,265 +1,249 @@
-(function(){
-  const globalScope = typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : null);
-
-  function createFallbackStorage(){
+(function () {
+  const globalScope = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
+  function createFallbackStorage() {
     const data = new Map();
     return {
-      get length(){
+      get length() {
         return data.size;
       },
-      key(index){
-        if(!Number.isInteger(index) || index < 0) return null;
-        if(index >= data.size) return null;
+      key(index) {
+        if (!Number.isInteger(index) || index < 0) return null;
+        if (index >= data.size) return null;
         let i = 0;
-        for(const key of data.keys()){
-          if(i === index) return key;
+        for (const key of data.keys()) {
+          if (i === index) return key;
           i++;
         }
         return null;
       },
-      getItem(key){
-        if(key == null) return null;
+      getItem(key) {
+        if (key == null) return null;
         const normalized = String(key);
         return data.has(normalized) ? data.get(normalized) : null;
       },
-      setItem(key, value){
-        if(key == null) return;
+      setItem(key, value) {
+        if (key == null) return;
         const normalized = String(key);
         data.set(normalized, value == null ? 'null' : String(value));
       },
-      removeItem(key){
-        if(key == null) return;
+      removeItem(key) {
+        if (key == null) return;
         data.delete(String(key));
       },
-      clear(){
+      clear() {
         data.clear();
       }
     };
   }
-
   const fallbackStorage = (() => {
-    if(globalScope && globalScope.__EXAMPLES_FALLBACK_STORAGE__ && typeof globalScope.__EXAMPLES_FALLBACK_STORAGE__.getItem === 'function'){
+    if (globalScope && globalScope.__EXAMPLES_FALLBACK_STORAGE__ && typeof globalScope.__EXAMPLES_FALLBACK_STORAGE__.getItem === 'function') {
       return globalScope.__EXAMPLES_FALLBACK_STORAGE__;
     }
     const store = createFallbackStorage();
-    if(globalScope){
+    if (globalScope) {
       globalScope.__EXAMPLES_FALLBACK_STORAGE__ = store;
     }
     return store;
   })();
-
   let usingFallbackStorage = false;
-
-  function ensureFallbackStorage(){
-    if(!usingFallbackStorage){
+  function ensureFallbackStorage() {
+    if (!usingFallbackStorage) {
       usingFallbackStorage = true;
-      if(typeof localStorage !== 'undefined'){
-        try{
+      if (typeof localStorage !== 'undefined') {
+        try {
           const total = Number(localStorage.length) || 0;
-          for(let i = 0; i < total; i++){
+          for (let i = 0; i < total; i++) {
             let key = null;
-            try{ key = localStorage.key(i); }
-            catch(_){ key = null; }
-            if(!key) continue;
-            try{
+            try {
+              key = localStorage.key(i);
+            } catch (_) {
+              key = null;
+            }
+            if (!key) continue;
+            try {
               const value = localStorage.getItem(key);
-              if(value != null) fallbackStorage.setItem(key, value);
-            }catch(_){ }
+              if (value != null) fallbackStorage.setItem(key, value);
+            } catch (_) {}
           }
-        }catch(_){ }
+        } catch (_) {}
       }
-      if(globalScope){
+      if (globalScope) {
         globalScope.__EXAMPLES_STORAGE__ = fallbackStorage;
       }
     }
     return fallbackStorage;
   }
-
-  function safeGetItem(key){
-    if(usingFallbackStorage){
+  function safeGetItem(key) {
+    if (usingFallbackStorage) {
       return fallbackStorage.getItem(key);
     }
-    try{
-      if(typeof localStorage === 'undefined') throw new Error('Storage not available');
+    try {
+      if (typeof localStorage === 'undefined') throw new Error('Storage not available');
       return localStorage.getItem(key);
-    }catch(_){
+    } catch (_) {
       return ensureFallbackStorage().getItem(key);
     }
   }
-
-  function safeSetItem(key, value){
-    if(usingFallbackStorage){
+  function safeSetItem(key, value) {
+    if (usingFallbackStorage) {
       fallbackStorage.setItem(key, value);
       return;
     }
-    try{
-      if(typeof localStorage === 'undefined') throw new Error('Storage not available');
+    try {
+      if (typeof localStorage === 'undefined') throw new Error('Storage not available');
       localStorage.setItem(key, value);
-    }catch(_){
+    } catch (_) {
       ensureFallbackStorage().setItem(key, value);
     }
   }
-
-  function safeRemoveItem(key){
-    if(usingFallbackStorage){
+  function safeRemoveItem(key) {
+    if (usingFallbackStorage) {
       fallbackStorage.removeItem(key);
       return;
     }
-    try{
-      if(typeof localStorage === 'undefined') throw new Error('Storage not available');
+    try {
+      if (typeof localStorage === 'undefined') throw new Error('Storage not available');
       localStorage.removeItem(key);
-    }catch(_){
+    } catch (_) {
       ensureFallbackStorage().removeItem(key);
     }
   }
-
-  if(globalScope && !globalScope.__EXAMPLES_STORAGE__){
-    try{
-      if(typeof localStorage !== 'undefined'){
+  if (globalScope && !globalScope.__EXAMPLES_STORAGE__) {
+    try {
+      if (typeof localStorage !== 'undefined') {
         globalScope.__EXAMPLES_STORAGE__ = localStorage;
-      }else{
+      } else {
         globalScope.__EXAMPLES_STORAGE__ = fallbackStorage;
         usingFallbackStorage = true;
       }
-    }catch(_){
+    } catch (_) {
       globalScope.__EXAMPLES_STORAGE__ = ensureFallbackStorage();
     }
   }
-
-  function normalizePathname(pathname){
-    if(typeof pathname !== 'string') return '/';
+  function normalizePathname(pathname) {
+    if (typeof pathname !== 'string') return '/';
     let path = pathname.trim();
-    if(!path) return '/';
-    if(!path.startsWith('/')) path = '/' + path;
+    if (!path) return '/';
+    if (!path.startsWith('/')) path = '/' + path;
     // Replace backslashes (possible in file:// URLs) and collapse duplicate slashes
     path = path.replace(/\+/g, '/');
     path = path.replace(/\/+/g, '/');
     // Remove trailing index.html or index.htm
     path = path.replace(/\/index\.html?$/i, '/');
-    if(path.length > 1 && path.endsWith('/')){
+    if (path.length > 1 && path.endsWith('/')) {
       path = path.slice(0, -1);
     }
     return path || '/';
   }
-
-  function computeLegacyStorageKeys(rawPath, canonicalPath){
+  function computeLegacyStorageKeys(rawPath, canonicalPath) {
     const prefix = 'examples_';
     const canonicalKey = prefix + canonicalPath;
     const paths = new Set();
     const addPath = value => {
-      if(typeof value !== 'string') return;
+      if (typeof value !== 'string') return;
       const trimmed = value.trim();
-      if(!trimmed) return;
+      if (!trimmed) return;
       paths.add(trimmed);
     };
-
     addPath(rawPath);
-    if(typeof rawPath === 'string'){
+    if (typeof rawPath === 'string') {
       const trimmed = rawPath.trim();
-      if(trimmed){
-        if(trimmed.endsWith('/')){
-          const normalized = trimmed
-            .replace(/\+/g, '/')
-            .replace(/\/+/g, '/')
-            .replace(/\/+$/, '');
+      if (trimmed) {
+        if (trimmed.endsWith('/')) {
+          const normalized = trimmed.replace(/\+/g, '/').replace(/\/+/g, '/').replace(/\/+$/, '');
           addPath(normalized);
-        }else{
+        } else {
           addPath(trimmed + '/');
         }
-        if(/index\.html?$/i.test(trimmed)){
+        if (/index\.html?$/i.test(trimmed)) {
           addPath(trimmed.replace(/index\.html?$/i, ''));
-        }else{
+        } else {
           const base = trimmed.endsWith('/') ? trimmed : trimmed + '/';
           addPath(base + 'index.html');
         }
       }
     }
-
     addPath(canonicalPath);
-    if(canonicalPath && canonicalPath !== '/' && !canonicalPath.endsWith('/')){
+    if (canonicalPath && canonicalPath !== '/' && !canonicalPath.endsWith('/')) {
       addPath(canonicalPath + '/');
     }
     const canonicalBase = canonicalPath.endsWith('/') ? canonicalPath : `${canonicalPath}/`;
     addPath(canonicalBase + 'index.html');
-
     const keys = [];
     paths.forEach(path => {
-      if(!path) return;
+      if (!path) return;
       const key = prefix + path;
-      if(key !== canonicalKey) keys.push(key);
+      if (key !== canonicalKey) keys.push(key);
     });
     return keys;
   }
-
   const rawPath = location && typeof location.pathname === 'string' ? location.pathname : '/';
   const storagePath = normalizePathname(rawPath);
   const key = 'examples_' + storagePath;
   const legacyKeys = computeLegacyStorageKeys(rawPath, storagePath);
-  try{
-    if(typeof localStorage !== 'undefined' || usingFallbackStorage){
+  try {
+    if (typeof localStorage !== 'undefined' || usingFallbackStorage) {
       let canonicalValue = safeGetItem(key);
-      if(canonicalValue == null){
-        for(const legacyKey of legacyKeys){
+      if (canonicalValue == null) {
+        for (const legacyKey of legacyKeys) {
           const legacyValue = safeGetItem(legacyKey);
-          if(legacyValue != null){
+          if (legacyValue != null) {
             safeSetItem(key, legacyValue);
             canonicalValue = legacyValue;
             break;
           }
         }
       }
-      if(canonicalValue != null){
+      if (canonicalValue != null) {
         legacyKeys.forEach(legacyKey => {
-          if(legacyKey === key) return;
-          try{
+          if (legacyKey === key) return;
+          try {
             const legacyValue = safeGetItem(legacyKey);
-            if(legacyValue != null && legacyValue === canonicalValue){
+            if (legacyValue != null && legacyValue === canonicalValue) {
               safeRemoveItem(legacyKey);
             }
-          }catch(_){ }
+          } catch (_) {}
         });
       }
-
       const deletedKey = key + '_deletedProvidedExamples';
       let canonicalDeletedValue = safeGetItem(deletedKey);
-      if(canonicalDeletedValue == null){
-        for(const legacyKey of legacyKeys){
+      if (canonicalDeletedValue == null) {
+        for (const legacyKey of legacyKeys) {
           const candidate = legacyKey + '_deletedProvidedExamples';
           const legacyValue = safeGetItem(candidate);
-          if(legacyValue != null){
+          if (legacyValue != null) {
             safeSetItem(deletedKey, legacyValue);
             canonicalDeletedValue = legacyValue;
             break;
           }
         }
       }
-      if(canonicalDeletedValue != null){
+      if (canonicalDeletedValue != null) {
         legacyKeys.forEach(legacyKey => {
           const candidate = legacyKey + '_deletedProvidedExamples';
-          try{
+          try {
             const legacyValue = safeGetItem(candidate);
-            if(legacyValue != null && legacyValue === canonicalDeletedValue){
+            if (legacyValue != null && legacyValue === canonicalDeletedValue) {
               safeRemoveItem(candidate);
             }
-          }catch(_){ }
+          } catch (_) {}
         });
       }
     }
-  }catch(_){ }
+  } catch (_) {}
   let initialLoadPerformed = false;
   let currentExampleIndex = null;
   let tabsContainer = null;
   let tabButtons = [];
   let defaultEnsureScheduled = false;
   let tabsHostCard = null;
-
   const hasUrlOverrides = (() => {
-    if(typeof URLSearchParams === 'undefined') return false;
+    if (typeof URLSearchParams === 'undefined') return false;
     const search = new URLSearchParams(window.location.search);
-    for(const key of search.keys()){
-      if(key === 'example') continue;
-      if(/^fun\d+$/i.test(key) || /^dom\d+$/i.test(key)) return true;
-      switch(key){
+    for (const key of search.keys()) {
+      if (key === 'example') continue;
+      if (/^fun\d+$/i.test(key) || /^dom\d+$/i.test(key)) return true;
+      switch (key) {
         case 'coords':
         case 'points':
         case 'startx':
@@ -276,99 +260,96 @@
     }
     return false;
   })();
-  if(hasUrlOverrides){
+  if (hasUrlOverrides) {
     initialLoadPerformed = true;
   }
   let cachedExamples = [];
   let cachedExamplesInitialized = false;
-  function getExamples(){
-    if(!cachedExamplesInitialized){
+  function getExamples() {
+    if (!cachedExamplesInitialized) {
       cachedExamplesInitialized = true;
       cachedExamples = [];
     }
     const stored = safeGetItem(key);
-    if(stored == null){
+    if (stored == null) {
       return cachedExamples;
     }
-    try{
+    try {
       const parsed = JSON.parse(stored);
       cachedExamples = Array.isArray(parsed) ? parsed : [];
-    }catch(_){
+    } catch (_) {
       cachedExamples = [];
     }
     return cachedExamples;
   }
-  function store(examples){
+  function store(examples) {
     cachedExamples = Array.isArray(examples) ? examples : [];
     cachedExamplesInitialized = true;
     safeSetItem(key, JSON.stringify(cachedExamples));
   }
-  const BINDING_NAMES = ['STATE','CFG','CONFIG','SIMPLE'];
+  const BINDING_NAMES = ['STATE', 'CFG', 'CONFIG', 'SIMPLE'];
   const DELETED_PROVIDED_KEY = key + '_deletedProvidedExamples';
   let deletedProvidedExamples = null;
-
-  function normalizeKey(value){
+  function normalizeKey(value) {
     return (typeof value === 'string' ? value.trim() : '') || '';
   }
-
-  function getDeletedProvidedExamples(){
-    if(deletedProvidedExamples) return deletedProvidedExamples;
+  function getDeletedProvidedExamples() {
+    if (deletedProvidedExamples) return deletedProvidedExamples;
     deletedProvidedExamples = new Set();
-    try{
+    try {
       const stored = safeGetItem(DELETED_PROVIDED_KEY);
-      if(stored){
+      if (stored) {
         const parsed = JSON.parse(stored);
-        if(Array.isArray(parsed)){
+        if (Array.isArray(parsed)) {
           parsed.forEach(value => {
             const key = normalizeKey(value);
-            if(key) deletedProvidedExamples.add(key);
+            if (key) deletedProvidedExamples.add(key);
           });
         }
       }
-    }catch{
+    } catch {
       deletedProvidedExamples = new Set();
     }
     return deletedProvidedExamples;
   }
-
-  function persistDeletedProvidedExamples(){
-    if(!deletedProvidedExamples) return;
-    try{
+  function persistDeletedProvidedExamples() {
+    if (!deletedProvidedExamples) return;
+    try {
       safeSetItem(DELETED_PROVIDED_KEY, JSON.stringify(Array.from(deletedProvidedExamples)));
-    }catch{}
+    } catch {}
   }
-
-  function markProvidedExampleDeleted(value){
+  function markProvidedExampleDeleted(value) {
     const key = normalizeKey(value);
-    if(!key) return;
+    if (!key) return;
     const set = getDeletedProvidedExamples();
-    if(!set.has(key)){
+    if (!set.has(key)) {
       set.add(key);
       persistDeletedProvidedExamples();
     }
   }
-
-  function flushPendingChanges(){
+  function flushPendingChanges() {
     const fields = document.querySelectorAll('input, textarea, select');
     fields.forEach(field => {
       ['input', 'change'].forEach(type => {
-        try{
-          field.dispatchEvent(new Event(type, {bubbles:true}));
-        }catch(_){ }
+        try {
+          field.dispatchEvent(new Event(type, {
+            bubbles: true
+          }));
+        } catch (_) {}
       });
     });
     const syncFns = ['applyCfg', 'applyConfig'];
     syncFns.forEach(name => {
       const fn = window[name];
-      if(typeof fn === 'function'){
-        try{ fn(); }
-        catch(_){ }
+      if (typeof fn === 'function') {
+        try {
+          fn();
+        } catch (_) {}
       }
     });
   }
-
-  function ensureTabStyles(){
-    if(document.getElementById('exampleTabStyles')) return;
+  function ensureTabStyles() {
+    if (document.getElementById('exampleTabStyles')) return;
     const style = document.createElement('style');
     style.id = 'exampleTabStyles';
     style.textContent = `
@@ -384,40 +365,39 @@
 `;
     document.head.appendChild(style);
   }
-
-  function adjustTabsSpacing(){
-    if(!tabsContainer || !tabsHostCard) return;
-    if(!tabsHostCard.isConnected){
+  function adjustTabsSpacing() {
+    if (!tabsContainer || !tabsHostCard) return;
+    if (!tabsHostCard.isConnected) {
       tabsHostCard = null;
       tabsContainer.style.removeProperty('margin-bottom');
       return;
     }
-    if(!tabsHostCard.classList.contains('card-has-settings')){
+    if (!tabsHostCard.classList.contains('card-has-settings')) {
       tabsContainer.style.removeProperty('margin-bottom');
       return;
     }
     let gapValue = '';
-    try{
+    try {
       const styles = window.getComputedStyle(tabsHostCard);
       gapValue = styles.getPropertyValue('row-gap');
-      if(!gapValue || gapValue === '0px' || gapValue === 'normal'){
+      if (!gapValue || gapValue === '0px' || gapValue === 'normal') {
         gapValue = styles.getPropertyValue('gap');
       }
-    }catch(_){ }
-    if(gapValue){
+    } catch (_) {}
+    if (gapValue) {
       gapValue = gapValue.trim();
     }
-    if(gapValue && gapValue !== '0px' && gapValue !== 'normal'){
+    if (gapValue && gapValue !== '0px' && gapValue !== 'normal') {
       const match = gapValue.match(/^(-?\d*\.?\d+)(.*)$/);
-      if(match){
+      if (match) {
         const numeric = Number.parseFloat(match[1]);
-        if(Number.isFinite(numeric)){
+        if (Number.isFinite(numeric)) {
           const unit = match[2].trim() || 'px';
           tabsContainer.style.marginBottom = `${numeric * -1}${unit}`;
           return;
         }
       }
-      if(!gapValue.startsWith('-')){
+      if (!gapValue.startsWith('-')) {
         tabsContainer.style.marginBottom = `-${gapValue}`;
         return;
       }
@@ -426,48 +406,45 @@
     }
     tabsContainer.style.marginBottom = '-6px';
   }
-
-  function moveSettingsIntoExampleCard(){
-    if(!toolbar) return;
+  function moveSettingsIntoExampleCard() {
+    if (!toolbar) return;
     const exampleCard = toolbar.closest('.card');
-    if(!exampleCard) return;
+    if (!exampleCard) return;
     tabsHostCard = exampleCard;
-    if(exampleCard.classList.contains('card-has-settings')){
+    if (exampleCard.classList.contains('card-has-settings')) {
       adjustTabsSpacing();
       return;
     }
     let candidate = exampleCard.nextElementSibling;
     let settingsCard = null;
-    while(candidate){
-      if(candidate.nodeType !== Node.ELEMENT_NODE){
+    while (candidate) {
+      if (candidate.nodeType !== Node.ELEMENT_NODE) {
         candidate = candidate.nextElementSibling;
         continue;
       }
-      if(!candidate.classList.contains('card')){
+      if (!candidate.classList.contains('card')) {
         candidate = candidate.nextElementSibling;
         continue;
       }
-      if(candidate.classList.contains('card--settings') || candidate.getAttribute('data-card') === 'settings'){
+      if (candidate.classList.contains('card--settings') || candidate.getAttribute('data-card') === 'settings') {
         settingsCard = candidate;
         break;
       }
       const heading = candidate.querySelector(':scope > h2');
       const text = heading ? heading.textContent.trim().toLowerCase() : '';
-      if(text === 'innstillinger' || text === 'innstilling'){
+      if (text === 'innstillinger' || text === 'innstilling') {
         settingsCard = candidate;
         break;
       }
       candidate = candidate.nextElementSibling;
     }
-
-    if(!settingsCard){
+    if (!settingsCard) {
       adjustTabsSpacing();
       return;
     }
-
     const settingsWrapper = document.createElement('div');
     settingsWrapper.className = 'example-settings';
-    while(settingsCard.firstChild){
+    while (settingsCard.firstChild) {
       settingsWrapper.appendChild(settingsCard.firstChild);
     }
     exampleCard.appendChild(settingsWrapper);
@@ -475,204 +452,211 @@
     exampleCard.classList.add('card-has-settings');
     adjustTabsSpacing();
   }
-
-  function getBinding(name){
-    if(name in window && window[name]) return window[name];
-    try{
-      switch(name){
+  function getBinding(name) {
+    if (name in window && window[name]) return window[name];
+    try {
+      switch (name) {
         case 'STATE':
-          return (typeof STATE !== 'undefined' && STATE) ? STATE : undefined;
+          return typeof STATE !== 'undefined' && STATE ? STATE : undefined;
         case 'CFG':
-          return (typeof CFG !== 'undefined' && CFG) ? CFG : undefined;
+          return typeof CFG !== 'undefined' && CFG ? CFG : undefined;
         case 'CONFIG':
-          return (typeof CONFIG !== 'undefined' && CONFIG) ? CONFIG : undefined;
+          return typeof CONFIG !== 'undefined' && CONFIG ? CONFIG : undefined;
         case 'SIMPLE':
-          return (typeof SIMPLE !== 'undefined' && SIMPLE) ? SIMPLE : undefined;
+          return typeof SIMPLE !== 'undefined' && SIMPLE ? SIMPLE : undefined;
         default:
           return undefined;
       }
-    }catch{
+    } catch {
       return undefined;
     }
   }
-
-  function cloneValue(value){
-    if(value == null) return value;
-    try{
+  function cloneValue(value) {
+    if (value == null) return value;
+    try {
       return JSON.parse(JSON.stringify(value));
-    }catch{
+    } catch {
       return value;
     }
   }
-
-  function sanitizeProvidedExample(example, idx){
-    if(!example || typeof example !== 'object') return null;
+  function sanitizeProvidedExample(example, idx) {
+    if (!example || typeof example !== 'object') return null;
     const sourceConfig = example.config;
-    if(!sourceConfig || typeof sourceConfig !== 'object') return null;
+    if (!sourceConfig || typeof sourceConfig !== 'object') return null;
     const config = {};
-    for(const name of BINDING_NAMES){
-      if(sourceConfig[name] != null){
+    for (const name of BINDING_NAMES) {
+      if (sourceConfig[name] != null) {
         config[name] = cloneValue(sourceConfig[name]);
       }
     }
-    if(Object.keys(config).length === 0) return null;
-    const sanitized = {config};
-    if(typeof example.svg === 'string') sanitized.svg = example.svg;
-    if(typeof example.title === 'string') sanitized.title = example.title;
-    if(typeof example.description === 'string') sanitized.description = example.description;
-    if(typeof example.exampleNumber === 'string' || typeof example.exampleNumber === 'number'){
+    if (Object.keys(config).length === 0) return null;
+    const sanitized = {
+      config
+    };
+    if (typeof example.svg === 'string') sanitized.svg = example.svg;
+    if (typeof example.title === 'string') sanitized.title = example.title;
+    if (typeof example.description === 'string') sanitized.description = example.description;
+    if (typeof example.exampleNumber === 'string' || typeof example.exampleNumber === 'number') {
       sanitized.exampleNumber = String(example.exampleNumber).trim();
-    }else if(typeof example.label === 'string'){
+    } else if (typeof example.label === 'string') {
       sanitized.exampleNumber = example.label.trim();
     }
-    if(example.isDefault === true) sanitized.isDefault = true;
-    if(typeof example.id === 'string' && example.id.trim().length){
+    if (example.isDefault === true) sanitized.isDefault = true;
+    if (typeof example.id === 'string' && example.id.trim().length) {
       sanitized.__builtinKey = example.id.trim();
-    }else{
+    } else {
       sanitized.__builtinKey = `provided-${idx}`;
     }
     return sanitized;
   }
-
-  function getProvidedExamples(){
-    if(typeof window === 'undefined') return [];
+  function getProvidedExamples() {
+    if (typeof window === 'undefined') return [];
     const provided = window.DEFAULT_EXAMPLES;
-    if(!Array.isArray(provided)) return [];
+    if (!Array.isArray(provided)) return [];
     const sanitized = [];
-    provided.forEach((ex, idx)=>{
+    provided.forEach((ex, idx) => {
       const normalized = sanitizeProvidedExample(ex, idx);
-      if(normalized) sanitized.push(normalized);
+      if (normalized) sanitized.push(normalized);
     });
-    if(sanitized.length > 0 && !sanitized.some(ex => ex.isDefault)){
+    if (sanitized.length > 0 && !sanitized.some(ex => ex.isDefault)) {
       sanitized[0].isDefault = true;
     }
     return sanitized;
   }
-
-  function replaceContents(target, source){
-    if(!target || source == null) return false;
-    if(Array.isArray(target) && Array.isArray(source)){
+  function replaceContents(target, source) {
+    if (!target || source == null) return false;
+    if (Array.isArray(target) && Array.isArray(source)) {
       target.length = 0;
       target.push(...source);
       return true;
     }
-    if(typeof target === 'object' && typeof source === 'object'){
+    if (typeof target === 'object' && typeof source === 'object') {
       Object.keys(target).forEach(key => {
-        if(!Object.prototype.hasOwnProperty.call(source, key)) delete target[key];
+        if (!Object.prototype.hasOwnProperty.call(source, key)) delete target[key];
       });
       Object.assign(target, source);
       return true;
     }
     return false;
   }
-
-  function applyBinding(name, value){
-    if(value == null) return;
+  function applyBinding(name, value) {
+    if (value == null) return;
     const target = getBinding(name);
-    if(replaceContents(target, value)){
-      if(name in window && window[name] !== target){
+    if (replaceContents(target, value)) {
+      if (name in window && window[name] !== target) {
         window[name] = target;
       }
       return;
     }
     const winVal = name in window ? window[name] : undefined;
-    if(replaceContents(winVal, value)) return;
-    window[name] = Array.isArray(value) ? value.slice() : (typeof value === 'object' ? {...value} : value);
+    if (replaceContents(winVal, value)) return;
+    window[name] = Array.isArray(value) ? value.slice() : typeof value === 'object' ? {
+      ...value
+    } : value;
   }
-
-  function triggerRefresh(index){
+  function triggerRefresh(index) {
     const tried = new Set();
-    const candidates = ['render','renderAll','draw','drawAll','update','updateAll','init','initAll','initFromCfg','initFromHtml','refresh','redraw','rerender','recalc','applyCfg','applyConfig','applyState','setup','rebuild'];
-    for(const name of candidates){
+    const candidates = ['render', 'renderAll', 'draw', 'drawAll', 'update', 'updateAll', 'init', 'initAll', 'initFromCfg', 'initFromHtml', 'refresh', 'redraw', 'rerender', 'recalc', 'applyCfg', 'applyConfig', 'applyState', 'setup', 'rebuild'];
+    for (const name of candidates) {
       const fn = window[name];
-      if(typeof fn === 'function' && !tried.has(fn)){
-        try{ fn(); }
-        catch(_){}
+      if (typeof fn === 'function' && !tried.has(fn)) {
+        try {
+          fn();
+        } catch (_) {}
         tried.add(fn);
       }
     }
     let dispatched = false;
-    if(typeof CustomEvent === 'function'){
-      try{
-        window.dispatchEvent(new CustomEvent('examples:loaded', {detail:{index}}));
+    if (typeof CustomEvent === 'function') {
+      try {
+        window.dispatchEvent(new CustomEvent('examples:loaded', {
+          detail: {
+            index
+          }
+        }));
         dispatched = true;
-      }catch(_){ }
+      } catch (_) {}
     }
-    if(!dispatched){
-      try{ window.dispatchEvent(new Event('examples:loaded')); }
-      catch(_){ }
+    if (!dispatched) {
+      try {
+        window.dispatchEvent(new Event('examples:loaded'));
+      } catch (_) {}
     }
   }
-
-  function collectConfig(){
+  function collectConfig() {
     flushPendingChanges();
-    const collectionDetail = {svgOverride:null};
-    try{
-      if(typeof window !== 'undefined' && window){
+    const collectionDetail = {
+      svgOverride: null
+    };
+    try {
+      if (typeof window !== 'undefined' && window) {
         let evt;
-        if(typeof CustomEvent === 'function'){
-          evt = new CustomEvent('examples:collect', {detail:collectionDetail});
-        }else{
+        if (typeof CustomEvent === 'function') {
+          evt = new CustomEvent('examples:collect', {
+            detail: collectionDetail
+          });
+        } else {
           evt = new Event('examples:collect');
-          try{ evt.detail = collectionDetail; }
-          catch(_){ }
+          try {
+            evt.detail = collectionDetail;
+          } catch (_) {}
         }
         window.dispatchEvent(evt);
       }
-    }catch(_){
-      try{
+    } catch (_) {
+      try {
         const evt = new Event('examples:collect');
-        try{ evt.detail = collectionDetail; }
-        catch(_){ }
+        try {
+          evt.detail = collectionDetail;
+        } catch (_) {}
         window.dispatchEvent(evt);
-      }
-      catch(_){ }
+      } catch (_) {}
     }
     const cfg = {};
-    for(const name of BINDING_NAMES){
+    for (const name of BINDING_NAMES) {
       const binding = getBinding(name);
-      if(binding != null && typeof binding !== 'function'){
+      if (binding != null && typeof binding !== 'function') {
         cfg[name] = cloneValue(binding);
       }
     }
     let svgMarkup = '';
-    if(collectionDetail.svgOverride != null){
-      if(typeof collectionDetail.svgOverride === 'string') svgMarkup = collectionDetail.svgOverride;
-      else if(collectionDetail.svgOverride && typeof collectionDetail.svgOverride.outerHTML === 'string'){
+    if (collectionDetail.svgOverride != null) {
+      if (typeof collectionDetail.svgOverride === 'string') svgMarkup = collectionDetail.svgOverride;else if (collectionDetail.svgOverride && typeof collectionDetail.svgOverride.outerHTML === 'string') {
         svgMarkup = collectionDetail.svgOverride.outerHTML;
       }
     }
-    if(!svgMarkup){
+    if (!svgMarkup) {
       const svg = document.querySelector('svg');
       svgMarkup = svg ? svg.outerHTML : '';
     }
-    return {config: cfg, svg: svgMarkup};
+    return {
+      config: cfg,
+      svg: svgMarkup
+    };
   }
-
-  function loadExample(index){
+  function loadExample(index) {
     const examples = getExamples();
     const ex = examples[index];
-    if(!ex || !ex.config) return false;
+    if (!ex || !ex.config) return false;
     const cfg = ex.config;
     let applied = false;
-    for(const name of BINDING_NAMES){
-      if(cfg[name] != null){
+    for (const name of BINDING_NAMES) {
+      if (cfg[name] != null) {
         applyBinding(name, cfg[name]);
         applied = true;
       }
     }
-    if(applied){
+    if (applied) {
       currentExampleIndex = index;
       updateTabSelection();
       triggerRefresh(index);
     }
     return applied;
   }
-
-  function updateTabSelection(){
-    if(!tabsContainer || !Array.isArray(tabButtons)) return;
-    tabButtons.forEach((btn, idx)=>{
-      if(!btn) return;
+  function updateTabSelection() {
+    if (!tabsContainer || !Array.isArray(tabButtons)) return;
+    tabButtons.forEach((btn, idx) => {
+      if (!btn) return;
       const isActive = idx === currentExampleIndex;
       btn.classList.toggle('is-active', isActive);
       btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
@@ -680,110 +664,106 @@
     });
   }
   // Load example if viewer requested
-  (function(){
-    if(hasUrlOverrides) return;
+  (function () {
+    if (hasUrlOverrides) return;
     const loadInfo = safeGetItem('example_to_load');
-    if(!loadInfo) return;
-    try{
-      const {path, index} = JSON.parse(loadInfo);
-      if(path === location.pathname){
-        if(loadExample(index)) initialLoadPerformed = true;
+    if (!loadInfo) return;
+    try {
+      const {
+        path,
+        index
+      } = JSON.parse(loadInfo);
+      if (path === location.pathname) {
+        if (loadExample(index)) initialLoadPerformed = true;
       }
-    }catch{}
+    } catch {}
     safeRemoveItem('example_to_load');
   })();
-
   const saveBtn = document.getElementById('btnSaveExample');
   const deleteBtn = document.getElementById('btnDeleteExample');
-  if(!saveBtn && !deleteBtn) return;
-
+  if (!saveBtn && !deleteBtn) return;
   ensureTabStyles();
-
-  const toolbar = saveBtn?.parentElement || deleteBtn?.parentElement;
+  const toolbar = (saveBtn === null || saveBtn === void 0 ? void 0 : saveBtn.parentElement) || (deleteBtn === null || deleteBtn === void 0 ? void 0 : deleteBtn.parentElement);
   tabsContainer = document.createElement('div');
   tabsContainer.id = 'exampleTabs';
   tabsContainer.className = 'example-tabs';
   tabsContainer.setAttribute('role', 'tablist');
   tabsContainer.setAttribute('aria-orientation', 'horizontal');
   tabsContainer.setAttribute('aria-label', 'Lagrede eksempler');
-  const toolbarParent = toolbar?.parentElement || toolbar;
-  if(toolbarParent){
-    if(toolbar?.nextSibling){
+  const toolbarParent = (toolbar === null || toolbar === void 0 ? void 0 : toolbar.parentElement) || toolbar;
+  if (toolbarParent) {
+    if (toolbar !== null && toolbar !== void 0 && toolbar.nextSibling) {
       toolbarParent.insertBefore(tabsContainer, toolbar.nextSibling);
-    }else{
+    } else {
       toolbarParent.appendChild(tabsContainer);
     }
-  }else{
+  } else {
     document.body.appendChild(tabsContainer);
   }
-
   moveSettingsIntoExampleCard();
   window.addEventListener('resize', adjustTabsSpacing);
-
-  function updateDeleteButtonState(count){
-    if(deleteBtn) deleteBtn.disabled = count <= 1;
+  function updateDeleteButtonState(count) {
+    if (deleteBtn) deleteBtn.disabled = count <= 1;
   }
-
   const requestedInitialIndex = parseInitialExampleIndex();
-
-  function attemptInitialLoad(){
-    if(initialLoadPerformed) return;
-    if(requestedInitialIndex == null) return;
+  function attemptInitialLoad() {
+    if (initialLoadPerformed) return;
+    if (requestedInitialIndex == null) return;
     const examples = getExamples();
-    if(requestedInitialIndex < 0 || requestedInitialIndex >= examples.length) return;
-    const loadNow = ()=>{
-      if(initialLoadPerformed) return;
-      if(loadExample(requestedInitialIndex)) initialLoadPerformed = true;
+    if (requestedInitialIndex < 0 || requestedInitialIndex >= examples.length) return;
+    const loadNow = () => {
+      if (initialLoadPerformed) return;
+      if (loadExample(requestedInitialIndex)) initialLoadPerformed = true;
     };
-    if(document.readyState === 'loading') document.addEventListener('DOMContentLoaded', loadNow, {once:true});
-    else setTimeout(loadNow, 0);
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', loadNow, {
+      once: true
+    });else setTimeout(loadNow, 0);
   }
-
-  function renderOptions(){
+  function renderOptions() {
     const examples = getExamples();
-    if(examples.length === 0){
+    if (examples.length === 0) {
       currentExampleIndex = null;
-    }else if(currentExampleIndex == null || currentExampleIndex >= examples.length){
+    } else if (currentExampleIndex == null || currentExampleIndex >= examples.length) {
       const fallback = currentExampleIndex == null ? 0 : examples.length - 1;
       currentExampleIndex = Math.min(examples.length - 1, Math.max(0, fallback));
     }
-
-    if(tabsContainer){
+    if (tabsContainer) {
       tabsContainer.innerHTML = '';
       tabButtons = [];
-      if(examples.length === 0){
+      if (examples.length === 0) {
         const empty = document.createElement('div');
         empty.className = 'example-tabs-empty';
         empty.textContent = 'Ingen eksempler';
         tabsContainer.appendChild(empty);
-      }else{
-        examples.forEach((ex, idx)=>{
+      } else {
+        examples.forEach((ex, idx) => {
           const btn = document.createElement('button');
           btn.type = 'button';
           btn.className = 'example-tab';
           let label = String(idx + 1);
-          if(ex && typeof ex.exampleNumber === 'string' && ex.exampleNumber.trim()){
+          if (ex && typeof ex.exampleNumber === 'string' && ex.exampleNumber.trim()) {
             label = ex.exampleNumber.trim();
           }
           btn.textContent = label;
           btn.dataset.exampleIndex = String(idx);
           btn.setAttribute('role', 'tab');
           btn.setAttribute('aria-label', `Eksempel ${label}`);
-          btn.addEventListener('click', ()=>{
+          btn.addEventListener('click', () => {
             loadExample(idx);
           });
-          btn.addEventListener('keydown', (event)=>{
-            if(event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+          btn.addEventListener('keydown', event => {
+            var _tabButtons$next;
+            if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
             event.preventDefault();
-            if(!tabButtons.length) return;
+            if (!tabButtons.length) return;
             const dir = event.key === 'ArrowRight' ? 1 : -1;
             const total = tabButtons.length;
             let next = idx;
-            do{
+            do {
               next = (next + dir + total) % total;
-            }while(next !== idx && !tabButtons[next]);
+            } while (next !== idx && !tabButtons[next]);
             loadExample(next);
-            tabButtons[next]?.focus();
+            (_tabButtons$next = tabButtons[next]) === null || _tabButtons$next === void 0 || _tabButtons$next.focus();
           });
           tabsContainer.appendChild(btn);
           tabButtons.push(btn);
@@ -793,16 +773,14 @@
     }
     updateDeleteButtonState(examples.length);
     attemptInitialLoad();
-
-    if(!initialLoadPerformed && examples.length > 0){
+    if (!initialLoadPerformed && examples.length > 0) {
       let idx = Number.isInteger(currentExampleIndex) ? currentExampleIndex : 0;
-      if(idx < 0) idx = 0;
-      if(idx >= examples.length) idx = examples.length - 1;
-      if(loadExample(idx)) initialLoadPerformed = true;
+      if (idx < 0) idx = 0;
+      if (idx >= examples.length) idx = examples.length - 1;
+      if (loadExample(idx)) initialLoadPerformed = true;
     }
   }
-
-  saveBtn?.addEventListener('click', async ()=>{
+  saveBtn === null || saveBtn === void 0 || saveBtn.addEventListener('click', async () => {
     const examples = getExamples();
     const ex = collectConfig();
     examples.push(ex);
@@ -812,271 +790,257 @@
     alert('Eksempel lagret');
 
     // Also offer download of the example as a JS file
-    try{
+    try {
       const lines = [];
       const cfg = ex.config || {};
-      if(cfg.STATE)  lines.push(`window.STATE=${JSON.stringify(cfg.STATE)};`);
-      if(cfg.CFG)    lines.push(`window.CFG=${JSON.stringify(cfg.CFG)};`);
-      if(cfg.CONFIG) lines.push(`window.CONFIG=${JSON.stringify(cfg.CONFIG)};`);
-      if(cfg.SIMPLE) lines.push(`window.SIMPLE=${JSON.stringify(cfg.SIMPLE)};`);
+      if (cfg.STATE) lines.push(`window.STATE=${JSON.stringify(cfg.STATE)};`);
+      if (cfg.CFG) lines.push(`window.CFG=${JSON.stringify(cfg.CFG)};`);
+      if (cfg.CONFIG) lines.push(`window.CONFIG=${JSON.stringify(cfg.CONFIG)};`);
+      if (cfg.SIMPLE) lines.push(`window.SIMPLE=${JSON.stringify(cfg.SIMPLE)};`);
 
       // Include all external scripts in the downloaded file
-      const scripts = Array.from(document.querySelectorAll('script[src]'))
-        .filter(s => !s.src.endsWith('examples.js'));
-      for(const s of scripts){
-        try{
+      const scripts = Array.from(document.querySelectorAll('script[src]')).filter(s => !s.src.endsWith('examples.js'));
+      for (const s of scripts) {
+        try {
           const res = await fetch(s.src);
           const txt = await res.text();
           lines.push(`// Source: ${s.src}`);
           lines.push(txt);
-        }catch{}
+        } catch {}
       }
-
-      const blob = new Blob([lines.join('\n')], {type:'application/javascript'});
+      const blob = new Blob([lines.join('\n')], {
+        type: 'application/javascript'
+      });
       const a = document.createElement('a');
       a.href = URL.createObjectURL(blob);
-      const base = location.pathname.split('/').pop().replace(/\.html$/,'');
+      const base = location.pathname.split('/').pop().replace(/\.html$/, '');
       a.download = `${base}-example-${examples.length}.js`;
       document.body.appendChild(a);
       a.click();
-      setTimeout(()=>{
+      setTimeout(() => {
         URL.revokeObjectURL(a.href);
         document.body.removeChild(a);
       }, 1000);
-    }catch{}
+    } catch {}
   });
-  deleteBtn?.addEventListener('click', ()=>{
+  deleteBtn === null || deleteBtn === void 0 || deleteBtn.addEventListener('click', () => {
     const examples = getExamples();
-    if(examples.length <= 1){
+    if (examples.length <= 1) {
       return;
     }
-
     let indexToRemove = Number.isInteger(currentExampleIndex) ? currentExampleIndex : NaN;
-    if(!Number.isInteger(indexToRemove)){
-      const activeTab = tabsContainer?.querySelector('.example-tab.is-active');
+    if (!Number.isInteger(indexToRemove)) {
+      var _tabsContainer;
+      const activeTab = (_tabsContainer = tabsContainer) === null || _tabsContainer === void 0 ? void 0 : _tabsContainer.querySelector('.example-tab.is-active');
       const parsed = activeTab ? Number(activeTab.dataset.exampleIndex) : NaN;
-      if(Number.isInteger(parsed)) indexToRemove = parsed;
+      if (Number.isInteger(parsed)) indexToRemove = parsed;
     }
-    if(!Number.isInteger(indexToRemove)){
+    if (!Number.isInteger(indexToRemove)) {
       indexToRemove = examples.length - 1;
     }
     indexToRemove = Math.max(0, Math.min(examples.length - 1, indexToRemove));
-
     const removed = examples.splice(indexToRemove, 1);
-    if(removed && removed.length){
+    if (removed && removed.length) {
       const removedExample = removed[0];
-      if(removedExample && typeof removedExample === 'object'){
+      if (removedExample && typeof removedExample === 'object') {
         markProvidedExampleDeleted(removedExample.__builtinKey);
       }
     }
-
-    examples.forEach((ex, idx)=>{
-      if(!ex || typeof ex !== 'object') return;
-      if(idx === 0){
+    examples.forEach((ex, idx) => {
+      if (!ex || typeof ex !== 'object') return;
+      if (idx === 0) {
         ex.isDefault = true;
-      }else if(Object.prototype.hasOwnProperty.call(ex, 'isDefault')){
+      } else if (Object.prototype.hasOwnProperty.call(ex, 'isDefault')) {
         delete ex.isDefault;
       }
     });
-
     store(examples);
-
-    if(examples.length === 0){
+    if (examples.length === 0) {
       currentExampleIndex = null;
-    }else if(indexToRemove >= examples.length){
+    } else if (indexToRemove >= examples.length) {
       currentExampleIndex = examples.length - 1;
-    }else{
+    } else {
       currentExampleIndex = indexToRemove;
     }
-
     renderOptions();
-    if(currentExampleIndex != null && currentExampleIndex >= 0 && examples.length > 0){
+    if (currentExampleIndex != null && currentExampleIndex >= 0 && examples.length > 0) {
       loadExample(currentExampleIndex);
     }
     alert('Eksempel slettet');
   });
-
   renderOptions();
-
-  function parseInitialExampleIndex(){
-    const parseValue = (value)=>{
-      if(value == null) return null;
+  function parseInitialExampleIndex() {
+    const parseValue = value => {
+      if (value == null) return null;
       const num = Number(value);
-      if(!Number.isFinite(num) || !Number.isInteger(num)) return null;
-      if(num > 0) return num - 1;
-      if(num === 0) return 0;
+      if (!Number.isFinite(num) || !Number.isInteger(num)) return null;
+      if (num > 0) return num - 1;
+      if (num === 0) return 0;
       return null;
     };
-    if(typeof URLSearchParams !== 'undefined'){
+    if (typeof URLSearchParams !== 'undefined') {
       const search = new URLSearchParams(window.location.search);
       const fromSearch = parseValue(search.get('example'));
-      if(fromSearch != null) return fromSearch;
+      if (fromSearch != null) return fromSearch;
     }
     const hashMatch = window.location.hash && window.location.hash.match(/example=([0-9]+)/i);
-    if(hashMatch) return parseValue(hashMatch[1]);
+    if (hashMatch) return parseValue(hashMatch[1]);
     return null;
   }
-
-  function ensureDefaultExample(){
-    if(defaultEnsureScheduled) return;
+  function ensureDefaultExample() {
+    if (defaultEnsureScheduled) return;
     defaultEnsureScheduled = true;
-    const ensure = ()=>{
+    const ensure = () => {
       let examples = getExamples();
       let updated = false;
       const requireProvided = typeof window !== 'undefined' && window && window.__EXAMPLES_FORCE_PROVIDED__ === true;
-
       const deletedProvided = getDeletedProvidedExamples();
       let deletedUpdated = false;
       examples.forEach(ex => {
-        if(!ex || typeof ex !== 'object') return;
+        if (!ex || typeof ex !== 'object') return;
         const key = normalizeKey(ex.__builtinKey);
-        if(key && deletedProvided.has(key)){
+        if (key && deletedProvided.has(key)) {
           deletedProvided.delete(key);
           deletedUpdated = true;
         }
       });
-      if(deletedUpdated) persistDeletedProvidedExamples();
-
+      if (deletedUpdated) persistDeletedProvidedExamples();
       const firstValidIndex = examples.findIndex(ex => ex && typeof ex === 'object');
-      if(firstValidIndex === -1){
-        if(examples.length){
+      if (firstValidIndex === -1) {
+        if (examples.length) {
           examples = [];
           updated = true;
         }
-      }else if(firstValidIndex > 0){
+      } else if (firstValidIndex > 0) {
         examples = examples.slice(firstValidIndex);
-        if(Number.isInteger(currentExampleIndex)){
+        if (Number.isInteger(currentExampleIndex)) {
           currentExampleIndex = Math.max(0, currentExampleIndex - firstValidIndex);
         }
         updated = true;
       }
-
       const providedDefaults = getProvidedExamples();
       const availableDefaults = providedDefaults.filter(ex => {
         const key = normalizeKey(ex && ex.__builtinKey);
         return !key || !deletedProvided.has(key);
       });
-      if(requireProvided && availableDefaults.length > 0 && examples.length === 1){
+      if (requireProvided && availableDefaults.length > 0 && examples.length === 1) {
         const only = examples[0];
         const onlyObj = only && typeof only === 'object' ? only : null;
         const hasKey = onlyObj ? !!normalizeKey(onlyObj.__builtinKey) : false;
         const hasSvg = onlyObj && typeof onlyObj.svg === 'string' ? onlyObj.svg.trim().length > 0 : false;
-        if(onlyObj && onlyObj.isDefault === true && !hasKey && !hasSvg){
+        if (onlyObj && onlyObj.isDefault === true && !hasKey && !hasSvg) {
           examples = [];
           currentExampleIndex = 0;
           updated = true;
         }
       }
-      if(examples.length === 0){
-        if(availableDefaults.length > 0){
+      if (examples.length === 0) {
+        if (availableDefaults.length > 0) {
           let defaultIdx = availableDefaults.findIndex(ex => ex.isDefault);
-          if(defaultIdx < 0) defaultIdx = 0;
-          examples = availableDefaults.map((ex, idx)=>{
+          if (defaultIdx < 0) defaultIdx = 0;
+          examples = availableDefaults.map((ex, idx) => {
             const copy = {
               config: cloneValue(ex.config),
               svg: typeof ex.svg === 'string' ? ex.svg : ''
             };
-            if(ex.__builtinKey) copy.__builtinKey = ex.__builtinKey;
-            if(ex.title) copy.title = ex.title;
-            if(ex.description) copy.description = ex.description;
-            if(ex.exampleNumber) copy.exampleNumber = ex.exampleNumber;
-            if(idx === defaultIdx){
+            if (ex.__builtinKey) copy.__builtinKey = ex.__builtinKey;
+            if (ex.title) copy.title = ex.title;
+            if (ex.description) copy.description = ex.description;
+            if (ex.exampleNumber) copy.exampleNumber = ex.exampleNumber;
+            if (idx === defaultIdx) {
               copy.isDefault = true;
             }
             return copy;
           });
           currentExampleIndex = Math.min(Math.max(defaultIdx, 0), examples.length - 1);
           updated = true;
-        }else{
+        } else {
           const defaultExample = collectConfig();
           defaultExample.isDefault = true;
           examples = [defaultExample];
           currentExampleIndex = 0;
           updated = true;
         }
-      }else{
+      } else {
         const first = examples[0];
-        if(first.isDefault !== true){
+        if (first.isDefault !== true) {
           first.isDefault = true;
           updated = true;
         }
-        for(let i = 1; i < examples.length; i++){
+        for (let i = 1; i < examples.length; i++) {
           const ex = examples[i];
-          if(ex && typeof ex === 'object' && Object.prototype.hasOwnProperty.call(ex, 'isDefault')){
+          if (ex && typeof ex === 'object' && Object.prototype.hasOwnProperty.call(ex, 'isDefault')) {
             delete ex.isDefault;
             updated = true;
           }
         }
-        if(availableDefaults.length > 0){
+        if (availableDefaults.length > 0) {
           const existingKeys = new Set();
           let hasCustomExample = false;
           examples.forEach(ex => {
-            if(!ex || typeof ex !== 'object') return;
+            if (!ex || typeof ex !== 'object') return;
             const key = normalizeKey(ex.__builtinKey);
-            if(key){
+            if (key) {
               existingKeys.add(key);
-            }else{
+            } else {
               hasCustomExample = true;
             }
           });
-          if(!hasCustomExample){
+          if (!hasCustomExample) {
             let appended = false;
             availableDefaults.forEach(ex => {
               const key = normalizeKey(ex.__builtinKey);
-              if(key && existingKeys.has(key)) return;
+              if (key && existingKeys.has(key)) return;
               const copy = {
                 config: cloneValue(ex.config),
                 svg: typeof ex.svg === 'string' ? ex.svg : ''
               };
-              if(key) copy.__builtinKey = key;
-              if(ex.title) copy.title = ex.title;
-              if(ex.description) copy.description = ex.description;
-              if(ex.exampleNumber) copy.exampleNumber = ex.exampleNumber;
+              if (key) copy.__builtinKey = key;
+              if (ex.title) copy.title = ex.title;
+              if (ex.description) copy.description = ex.description;
+              if (ex.exampleNumber) copy.exampleNumber = ex.exampleNumber;
               examples.push(copy);
-              if(key) existingKeys.add(key);
+              if (key) existingKeys.add(key);
               appended = true;
             });
-            if(appended) updated = true;
+            if (appended) updated = true;
           }
         }
       }
-
-      if(updated){
+      if (updated) {
         store(examples);
         examples = getExamples();
       }
-
-      if(currentExampleIndex == null && examples.length > 0){
+      if (currentExampleIndex == null && examples.length > 0) {
         currentExampleIndex = 0;
       }
-      if(currentExampleIndex != null && examples.length > 0){
+      if (currentExampleIndex != null && examples.length > 0) {
         const maxIdx = examples.length - 1;
         currentExampleIndex = Math.min(Math.max(currentExampleIndex, 0), maxIdx);
       }
       renderOptions();
-
-      if(!initialLoadPerformed){
+      if (!initialLoadPerformed) {
         const refreshed = getExamples();
-        if(refreshed.length > 0){
+        if (refreshed.length > 0) {
           let targetIndex = Number.isInteger(currentExampleIndex) ? currentExampleIndex : NaN;
-          if(!Number.isInteger(targetIndex) || targetIndex < 0 || targetIndex >= refreshed.length){
+          if (!Number.isInteger(targetIndex) || targetIndex < 0 || targetIndex >= refreshed.length) {
             targetIndex = refreshed.findIndex(ex => ex && ex.isDefault === true);
           }
-          if(!Number.isInteger(targetIndex) || targetIndex < 0 || targetIndex >= refreshed.length){
+          if (!Number.isInteger(targetIndex) || targetIndex < 0 || targetIndex >= refreshed.length) {
             targetIndex = 0;
           }
-          if(loadExample(targetIndex)){
+          if (loadExample(targetIndex)) {
             initialLoadPerformed = true;
           }
         }
       }
-      if(requireProvided && typeof window !== 'undefined' && window){
+      if (requireProvided && typeof window !== 'undefined' && window) {
         window.__EXAMPLES_FORCE_PROVIDED__ = false;
       }
     };
-    if(document.readyState === 'complete') setTimeout(ensure, 0);
-    else window.addEventListener('load', ensure, {once:true});
+    if (document.readyState === 'complete') setTimeout(ensure, 0);else window.addEventListener('load', ensure, {
+      once: true
+    });
   }
-
   ensureDefaultExample();
 })();

--- a/figurtall.js
+++ b/figurtall.js
@@ -1,541 +1,528 @@
-(function(){
-  const boxes=[];
-  const MAX_DIM=20;
-  const MAX_COLORS=6;
-  let rows=3;
-  let cols=3;
-
-  const colorCountInp=document.getElementById('colorCount');
-  const colorInputs=[];
-  for(let i=1;;i++){
-    const inp=document.getElementById('color_'+i);
-    if(!inp) break;
+(function () {
+  const boxes = [];
+  const MAX_DIM = 20;
+  const MAX_COLORS = 6;
+  let rows = 3;
+  let cols = 3;
+  const colorCountInp = document.getElementById('colorCount');
+  const colorInputs = [];
+  for (let i = 1;; i++) {
+    const inp = document.getElementById('color_' + i);
+    if (!inp) break;
     colorInputs.push(inp);
   }
-  const DEFAULT_COLOR_SETS={
-    1:['#6C1BA2'],
-    2:['#BF4474','#534477'],
-    3:['#B25FE3','#6C1BA2','#BF4474'],
-    4:['#B25FE3','#6C1BA2','#534477','#BF4474'],
-    5:['#B25FE3','#6C1BA2','#534477','#873E79','#BF4474'],
-    6:['#B25FE3','#6C1BA2','#534477','#873E79','#BF4474','#E31C3D']
+  const DEFAULT_COLOR_SETS = {
+    1: ['#6C1BA2'],
+    2: ['#BF4474', '#534477'],
+    3: ['#B25FE3', '#6C1BA2', '#BF4474'],
+    4: ['#B25FE3', '#6C1BA2', '#534477', '#BF4474'],
+    5: ['#B25FE3', '#6C1BA2', '#534477', '#873E79', '#BF4474'],
+    6: ['#B25FE3', '#6C1BA2', '#534477', '#873E79', '#BF4474', '#E31C3D']
   };
-  const STATE=(typeof window.STATE==='object' && window.STATE)?window.STATE:{};
-  window.STATE=STATE;
-  const modifiedColorIndexes=new Set();
-  if(Array.isArray(STATE.colors)){
-    STATE.colors.forEach((color,idx)=>{
-      if(typeof color==='string' && color) modifiedColorIndexes.add(idx);
+  const STATE = typeof window.STATE === 'object' && window.STATE ? window.STATE : {};
+  window.STATE = STATE;
+  const modifiedColorIndexes = new Set();
+  if (Array.isArray(STATE.colors)) {
+    STATE.colors.forEach((color, idx) => {
+      if (typeof color === 'string' && color) modifiedColorIndexes.add(idx);
     });
   }
-  let autoPaletteEnabled=modifiedColorIndexes.size===0;
-  let lastAppliedPaletteSize=null;
-
-  function clampInt(value,min,max){
-    const num=parseInt(value,10);
-    if(!Number.isFinite(num)) return min;
-    return Math.max(min,Math.min(max,num));
+  let autoPaletteEnabled = modifiedColorIndexes.size === 0;
+  let lastAppliedPaletteSize = null;
+  function clampInt(value, min, max) {
+    const num = parseInt(value, 10);
+    if (!Number.isFinite(num)) return min;
+    return Math.max(min, Math.min(max, num));
   }
-
-  function normalizeCells(cells,rowCount,colCount){
-    const matrix=Array.from({length:rowCount},()=>Array(colCount).fill(0));
-    if(!Array.isArray(cells)) return matrix;
-    for(let r=0;r<rowCount;r++){
-      const row=Array.isArray(cells[r])?cells[r]:[];
-      for(let c=0;c<colCount;c++){
-        const val=parseInt(row[c],10);
-        matrix[r][c]=Number.isFinite(val)&&val>0?val:0;
+  function normalizeCells(cells, rowCount, colCount) {
+    const matrix = Array.from({
+      length: rowCount
+    }, () => Array(colCount).fill(0));
+    if (!Array.isArray(cells)) return matrix;
+    for (let r = 0; r < rowCount; r++) {
+      const row = Array.isArray(cells[r]) ? cells[r] : [];
+      for (let c = 0; c < colCount; c++) {
+        const val = parseInt(row[c], 10);
+        matrix[r][c] = Number.isFinite(val) && val > 0 ? val : 0;
       }
     }
     return matrix;
   }
-
-  function ensureColors(count){
-    const palette=DEFAULT_COLOR_SETS[count]||DEFAULT_COLOR_SETS[MAX_COLORS]||['#6C1BA2'];
-    const fillPalette=DEFAULT_COLOR_SETS[MAX_COLORS]||palette;
-    if(autoPaletteEnabled){
-      if(lastAppliedPaletteSize!==count || !Array.isArray(STATE.colors)){
-        STATE.colors=palette.slice();
+  function ensureColors(count) {
+    const palette = DEFAULT_COLOR_SETS[count] || DEFAULT_COLOR_SETS[MAX_COLORS] || ['#6C1BA2'];
+    const fillPalette = DEFAULT_COLOR_SETS[MAX_COLORS] || palette;
+    if (autoPaletteEnabled) {
+      if (lastAppliedPaletteSize !== count || !Array.isArray(STATE.colors)) {
+        STATE.colors = palette.slice();
       }
-    }else if(!Array.isArray(STATE.colors)){
-      STATE.colors=[];
+    } else if (!Array.isArray(STATE.colors)) {
+      STATE.colors = [];
     }
-    if(!Array.isArray(STATE.colors)) STATE.colors=[];
-    const required=Math.max(count,MAX_COLORS);
-    for(let i=0;i<required;i++){
-      const withinCount=i<count;
-      const source=withinCount?palette:fillPalette;
-      let defaultColor='#6C1BA2';
-      if(Array.isArray(source) && source.length>0){
-        defaultColor=source[Math.min(i,source.length-1)] ?? '#6C1BA2';
-      }else if(Array.isArray(palette) && palette.length>0){
-        defaultColor=palette[Math.min(withinCount?i:palette.length-1,palette.length-1)] ?? '#6C1BA2';
+    if (!Array.isArray(STATE.colors)) STATE.colors = [];
+    const required = Math.max(count, MAX_COLORS);
+    for (let i = 0; i < required; i++) {
+      const withinCount = i < count;
+      const source = withinCount ? palette : fillPalette;
+      let defaultColor = '#6C1BA2';
+      if (Array.isArray(source) && source.length > 0) {
+        var _source$Math$min;
+        defaultColor = (_source$Math$min = source[Math.min(i, source.length - 1)]) !== null && _source$Math$min !== void 0 ? _source$Math$min : '#6C1BA2';
+      } else if (Array.isArray(palette) && palette.length > 0) {
+        var _palette$Math$min;
+        defaultColor = (_palette$Math$min = palette[Math.min(withinCount ? i : palette.length - 1, palette.length - 1)]) !== null && _palette$Math$min !== void 0 ? _palette$Math$min : '#6C1BA2';
       }
-      const hasColor=typeof STATE.colors[i]==='string' && STATE.colors[i];
-      const shouldUseDefault=autoPaletteEnabled || !modifiedColorIndexes.has(i);
-      if(shouldUseDefault || !hasColor){
-        STATE.colors[i]=defaultColor||'#6C1BA2';
+      const hasColor = typeof STATE.colors[i] === 'string' && STATE.colors[i];
+      const shouldUseDefault = autoPaletteEnabled || !modifiedColorIndexes.has(i);
+      if (shouldUseDefault || !hasColor) {
+        STATE.colors[i] = defaultColor || '#6C1BA2';
       }
-      if(typeof STATE.colors[i]!=='string' || !STATE.colors[i]){
-        STATE.colors[i]='#6C1BA2';
+      if (typeof STATE.colors[i] !== 'string' || !STATE.colors[i]) {
+        STATE.colors[i] = '#6C1BA2';
       }
     }
-    if(STATE.colors.length>required) STATE.colors.length=required;
-    lastAppliedPaletteSize=count;
+    if (STATE.colors.length > required) STATE.colors.length = required;
+    lastAppliedPaletteSize = count;
   }
-
-  function createFigureState(name,rowCount,colCount,coords){
-    const label=typeof name==='string' && name.trim()?name:`Figur ${STATE.figures?.length?STATE.figures.length+1:1}`;
-    const cells=normalizeCells([],rowCount,colCount);
-    (coords||[]).forEach(coord=>{
-      if(!Array.isArray(coord)) return;
-      const [r,c,colorIdx=1]=coord;
-      if(r>=0 && r<rowCount && c>=0 && c<colCount){
-        const idx=parseInt(colorIdx,10);
-        cells[r][c]=Number.isFinite(idx)&&idx>0?idx:1;
+  function createFigureState(name, rowCount, colCount, coords) {
+    var _STATE$figures;
+    const label = typeof name === 'string' && name.trim() ? name : `Figur ${(_STATE$figures = STATE.figures) !== null && _STATE$figures !== void 0 && _STATE$figures.length ? STATE.figures.length + 1 : 1}`;
+    const cells = normalizeCells([], rowCount, colCount);
+    (coords || []).forEach(coord => {
+      if (!Array.isArray(coord)) return;
+      const [r, c, colorIdx = 1] = coord;
+      if (r >= 0 && r < rowCount && c >= 0 && c < colCount) {
+        const idx = parseInt(colorIdx, 10);
+        cells[r][c] = Number.isFinite(idx) && idx > 0 ? idx : 1;
       }
     });
-    return {name:label,cells};
+    return {
+      name: label,
+      cells
+    };
   }
-
-  function sanitizeState(){
-    const maxColors=colorInputs.length||MAX_COLORS;
-    rows=clampInt(STATE.rows??rows,1,MAX_DIM);
-    cols=clampInt(STATE.cols??cols,1,MAX_DIM);
-    STATE.rows=rows;
-    STATE.cols=cols;
-    STATE.circleMode=STATE.circleMode!==false;
-    STATE.offset=STATE.offset!==false;
-    STATE.showGrid=STATE.showGrid!==false;
-    STATE.colorCount=clampInt(STATE.colorCount??(colorCountInp?colorCountInp.value:1),1,maxColors);
+  function sanitizeState() {
+    var _STATE$rows, _STATE$cols, _STATE$colorCount;
+    const maxColors = colorInputs.length || MAX_COLORS;
+    rows = clampInt((_STATE$rows = STATE.rows) !== null && _STATE$rows !== void 0 ? _STATE$rows : rows, 1, MAX_DIM);
+    cols = clampInt((_STATE$cols = STATE.cols) !== null && _STATE$cols !== void 0 ? _STATE$cols : cols, 1, MAX_DIM);
+    STATE.rows = rows;
+    STATE.cols = cols;
+    STATE.circleMode = STATE.circleMode !== false;
+    STATE.offset = STATE.offset !== false;
+    STATE.showGrid = STATE.showGrid !== false;
+    STATE.colorCount = clampInt((_STATE$colorCount = STATE.colorCount) !== null && _STATE$colorCount !== void 0 ? _STATE$colorCount : colorCountInp ? colorCountInp.value : 1, 1, maxColors);
     ensureColors(STATE.colorCount);
-    if(!Array.isArray(STATE.figures)) STATE.figures=[];
-    if(STATE.figures.length===0){
-      STATE.figures=[
-        createFigureState('Figur 1',rows,cols,[[0,1]]),
-        createFigureState('Figur 2',rows,cols,[[0,1],[1,0],[1,1]]),
-        createFigureState('Figur 3',rows,cols,[[0,1],[1,0],[1,1],[2,0],[2,1],[2,2]])
-      ];
-    }else{
-      STATE.figures=STATE.figures.map((fig,idx)=>{
-        const name=typeof fig?.name==='string' && fig.name.trim()?fig.name:`Figur ${idx+1}`;
-        return {name,cells:normalizeCells(fig?.cells,rows,cols)};
+    if (!Array.isArray(STATE.figures)) STATE.figures = [];
+    if (STATE.figures.length === 0) {
+      STATE.figures = [createFigureState('Figur 1', rows, cols, [[0, 1]]), createFigureState('Figur 2', rows, cols, [[0, 1], [1, 0], [1, 1]]), createFigureState('Figur 3', rows, cols, [[0, 1], [1, 0], [1, 1], [2, 0], [2, 1], [2, 2]])];
+    } else {
+      STATE.figures = STATE.figures.map((fig, idx) => {
+        const name = typeof (fig === null || fig === void 0 ? void 0 : fig.name) === 'string' && fig.name.trim() ? fig.name : `Figur ${idx + 1}`;
+        return {
+          name,
+          cells: normalizeCells(fig === null || fig === void 0 ? void 0 : fig.cells, rows, cols)
+        };
       });
     }
   }
-
-  function getColors(){
+  function getColors() {
     ensureColors(STATE.colorCount);
-    return STATE.colors.slice(0,STATE.colorCount);
+    return STATE.colors.slice(0, STATE.colorCount);
   }
-
-  function applyCellAppearance(cell,idx,colors){
-    cell.dataset.color=String(idx);
-    if(idx===0){
-      cell.style.backgroundColor='#fff';
-    }else{
-      cell.style.backgroundColor=colors[idx-1]||'#fff';
+  function applyCellAppearance(cell, idx, colors) {
+    cell.dataset.color = String(idx);
+    if (idx === 0) {
+      cell.style.backgroundColor = '#fff';
+    } else {
+      cell.style.backgroundColor = colors[idx - 1] || '#fff';
     }
-    if(STATE.circleMode && idx!==0){
+    if (STATE.circleMode && idx !== 0) {
       cell.classList.add('circle');
-    }else{
+    } else {
       cell.classList.remove('circle');
     }
   }
-
-  function updateCellColors(){
-    const colors=getColors();
-    container?.querySelectorAll('.cell').forEach(cell=>{
-      const figIndex=parseInt(cell.dataset.figIndex,10);
-      const r=parseInt(cell.dataset.row,10);
-      const c=parseInt(cell.dataset.col,10);
-      const fig=STATE.figures[figIndex];
-      if(!fig || !Array.isArray(fig.cells)) return;
-      let idxVal=fig.cells?.[r]?.[c]||0;
-      if(idxVal>colors.length){
-        idxVal=0;
-        if(fig.cells[r]) fig.cells[r][c]=0;
+  function updateCellColors() {
+    const colors = getColors();
+    container === null || container === void 0 || container.querySelectorAll('.cell').forEach(cell => {
+      var _fig$cells;
+      const figIndex = parseInt(cell.dataset.figIndex, 10);
+      const r = parseInt(cell.dataset.row, 10);
+      const c = parseInt(cell.dataset.col, 10);
+      const fig = STATE.figures[figIndex];
+      if (!fig || !Array.isArray(fig.cells)) return;
+      let idxVal = ((_fig$cells = fig.cells) === null || _fig$cells === void 0 || (_fig$cells = _fig$cells[r]) === null || _fig$cells === void 0 ? void 0 : _fig$cells[c]) || 0;
+      if (idxVal > colors.length) {
+        idxVal = 0;
+        if (fig.cells[r]) fig.cells[r][c] = 0;
       }
-      applyCellAppearance(cell,idxVal,colors);
+      applyCellAppearance(cell, idxVal, colors);
     });
   }
-
-  function updateColorVisibility(){
-    const count=STATE.colorCount;
+  function updateColorVisibility() {
+    const count = STATE.colorCount;
     ensureColors(count);
-    colorInputs.forEach((inp,idx)=>{
-      if(idx<count){
-        inp.style.display='';
-        inp.value=STATE.colors[idx];
-      }else{
-        inp.style.display='none';
+    colorInputs.forEach((inp, idx) => {
+      if (idx < count) {
+        inp.style.display = '';
+        inp.value = STATE.colors[idx];
+      } else {
+        inp.style.display = 'none';
       }
     });
     updateCellColors();
   }
-
-  function createGridForFigure(boxEl,index){
-    const fig=STATE.figures[index];
-    boxEl.innerHTML='';
-    boxEl.style.setProperty('--cols',cols);
-    boxEl.style.setProperty('--rows',rows);
-    boxEl.style.setProperty('--aspect',cols/rows);
-    boxEl.style.setProperty('--cellSize',(100/cols)+'%');
-    boxEl.classList.toggle('hide-grid',!STATE.showGrid);
-    for(let r=0;r<rows;r++){
-      const rowEl=document.createElement('div');
-      rowEl.className='row';
-      if(STATE.offset && r%2===1) rowEl.classList.add('offset');
-      for(let c=0;c<cols;c++){
-        const cell=document.createElement('div');
-        cell.className='cell';
-        const idxVal=fig?.cells?.[r]?.[c]||0;
-        cell.dataset.color=String(idxVal);
-        cell.dataset.figIndex=String(index);
-        cell.dataset.row=String(r);
-        cell.dataset.col=String(c);
-        cell.addEventListener('click',()=>cycleCell(index,r,c,cell));
+  function createGridForFigure(boxEl, index) {
+    const fig = STATE.figures[index];
+    boxEl.innerHTML = '';
+    boxEl.style.setProperty('--cols', cols);
+    boxEl.style.setProperty('--rows', rows);
+    boxEl.style.setProperty('--aspect', cols / rows);
+    boxEl.style.setProperty('--cellSize', 100 / cols + '%');
+    boxEl.classList.toggle('hide-grid', !STATE.showGrid);
+    for (let r = 0; r < rows; r++) {
+      const rowEl = document.createElement('div');
+      rowEl.className = 'row';
+      if (STATE.offset && r % 2 === 1) rowEl.classList.add('offset');
+      for (let c = 0; c < cols; c++) {
+        var _fig$cells2;
+        const cell = document.createElement('div');
+        cell.className = 'cell';
+        const idxVal = (fig === null || fig === void 0 || (_fig$cells2 = fig.cells) === null || _fig$cells2 === void 0 || (_fig$cells2 = _fig$cells2[r]) === null || _fig$cells2 === void 0 ? void 0 : _fig$cells2[c]) || 0;
+        cell.dataset.color = String(idxVal);
+        cell.dataset.figIndex = String(index);
+        cell.dataset.row = String(r);
+        cell.dataset.col = String(c);
+        cell.addEventListener('click', () => cycleCell(index, r, c, cell));
         rowEl.appendChild(cell);
       }
       boxEl.appendChild(rowEl);
     }
   }
-
-  function createPanelForFigure(index){
-    const panel=document.createElement('div');
-    panel.className='figurePanel';
-    panel.dataset.index=String(index);
-    panel.innerHTML=`
+  function createPanelForFigure(index) {
+    const panel = document.createElement('div');
+    panel.className = 'figurePanel';
+    panel.dataset.index = String(index);
+    panel.innerHTML = `
       <div class="figure"><div class="box"></div></div>
       <input class="nameInput" type="text" placeholder="Navn" />
     `;
-    const boxEl=panel.querySelector('.box');
+    const boxEl = panel.querySelector('.box');
     boxes.push(boxEl);
-    createGridForFigure(boxEl,index);
-    const nameInput=panel.querySelector('.nameInput');
-    const fig=STATE.figures[index];
-    const baseName=fig?.name || `Figur ${index+1}`;
-    nameInput.value=baseName;
-    STATE.figures[index].name=baseName;
-    nameInput.addEventListener('input',()=>{
-      STATE.figures[index].name=nameInput.value;
+    createGridForFigure(boxEl, index);
+    const nameInput = panel.querySelector('.nameInput');
+    const fig = STATE.figures[index];
+    const baseName = (fig === null || fig === void 0 ? void 0 : fig.name) || `Figur ${index + 1}`;
+    nameInput.value = baseName;
+    STATE.figures[index].name = baseName;
+    nameInput.addEventListener('input', () => {
+      STATE.figures[index].name = nameInput.value;
     });
-    const removeBtn=document.createElement('button');
-    removeBtn.type='button';
-    removeBtn.className='removeFigureBtn';
-    removeBtn.textContent='Fjern figur';
-    if(STATE.figures.length<=1){
-      removeBtn.disabled=true;
-      removeBtn.setAttribute('aria-disabled','true');
-    }else{
-      removeBtn.disabled=false;
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'removeFigureBtn';
+    removeBtn.textContent = 'Fjern figur';
+    if (STATE.figures.length <= 1) {
+      removeBtn.disabled = true;
+      removeBtn.setAttribute('aria-disabled', 'true');
+    } else {
+      removeBtn.disabled = false;
       removeBtn.removeAttribute('aria-disabled');
     }
-    removeBtn.setAttribute('aria-label',`Fjern figur ${index+1}`);
-    removeBtn.addEventListener('click',()=>{
+    removeBtn.setAttribute('aria-label', `Fjern figur ${index + 1}`);
+    removeBtn.addEventListener('click', () => {
       removeFigure(index);
     });
     panel.appendChild(removeBtn);
     return panel;
   }
-
-  const container=document.getElementById('figureContainer');
-  const addBtn=document.getElementById('addFigure');
-
-  function rebuildFigurePanels(){
-    if(!container) return;
-    boxes.length=0;
-    container.querySelectorAll('.figurePanel').forEach(panel=>panel.remove());
-    STATE.figures.forEach((_,idx)=>{
-      const panel=createPanelForFigure(idx);
-      container.insertBefore(panel,addBtn);
+  const container = document.getElementById('figureContainer');
+  const addBtn = document.getElementById('addFigure');
+  function rebuildFigurePanels() {
+    if (!container) return;
+    boxes.length = 0;
+    container.querySelectorAll('.figurePanel').forEach(panel => panel.remove());
+    STATE.figures.forEach((_, idx) => {
+      const panel = createPanelForFigure(idx);
+      container.insertBefore(panel, addBtn);
     });
     updateCellColors();
     updateGridVisibility();
     updateFigureLayout();
   }
-
-  const MIN_PANEL_WIDTH=80;
-  const MAX_PANEL_WIDTH=260;
-
-  function updateFigureLayout(){
-    if(!container) return;
-    const panelCount=container.querySelectorAll('.figurePanel').length + (addBtn?1:0);
-    if(panelCount<=0) return;
-    const styles=getComputedStyle(container);
-    const gapStr=styles.columnGap||styles.gap||'0';
-    const gap=parseFloat(gapStr)||0;
-    const available=container.clientWidth;
-    if(available<=0) return;
-    let computed=(available - gap*(panelCount-1))/panelCount;
-    if(!Number.isFinite(computed)) return;
-    if(computed>MAX_PANEL_WIDTH) computed=MAX_PANEL_WIDTH;
-    if(computed<MIN_PANEL_WIDTH) computed=MIN_PANEL_WIDTH;
-    container.style.setProperty('--panel-min',`${computed}px`);
+  const MIN_PANEL_WIDTH = 80;
+  const MAX_PANEL_WIDTH = 260;
+  function updateFigureLayout() {
+    if (!container) return;
+    const panelCount = container.querySelectorAll('.figurePanel').length + (addBtn ? 1 : 0);
+    if (panelCount <= 0) return;
+    const styles = getComputedStyle(container);
+    const gapStr = styles.columnGap || styles.gap || '0';
+    const gap = parseFloat(gapStr) || 0;
+    const available = container.clientWidth;
+    if (available <= 0) return;
+    let computed = (available - gap * (panelCount - 1)) / panelCount;
+    if (!Number.isFinite(computed)) return;
+    if (computed > MAX_PANEL_WIDTH) computed = MAX_PANEL_WIDTH;
+    if (computed < MIN_PANEL_WIDTH) computed = MIN_PANEL_WIDTH;
+    container.style.setProperty('--panel-min', `${computed}px`);
   }
-  window.addEventListener('resize',updateFigureLayout);
-
-  function updateGridVisibility(){
-    boxes.forEach(box=>box.classList.toggle('hide-grid',!STATE.showGrid));
+  window.addEventListener('resize', updateFigureLayout);
+  function updateGridVisibility() {
+    boxes.forEach(box => box.classList.toggle('hide-grid', !STATE.showGrid));
   }
-
-  function cycleCell(figIndex,r,c,cell){
-    const colors=getColors();
-    const fig=STATE.figures[figIndex];
-    if(!fig) return;
-    const current=fig.cells?.[r]?.[c]||0;
-    const next=(current+1)%(colors.length+1);
-    fig.cells[r][c]=next;
-    applyCellAppearance(cell,next,colors);
+  function cycleCell(figIndex, r, c, cell) {
+    var _fig$cells3;
+    const colors = getColors();
+    const fig = STATE.figures[figIndex];
+    if (!fig) return;
+    const current = ((_fig$cells3 = fig.cells) === null || _fig$cells3 === void 0 || (_fig$cells3 = _fig$cells3[r]) === null || _fig$cells3 === void 0 ? void 0 : _fig$cells3[c]) || 0;
+    const next = (current + 1) % (colors.length + 1);
+    fig.cells[r][c] = next;
+    applyCellAppearance(cell, next, colors);
   }
-
-  const rowsMinus=document.getElementById('rowsMinus');
-  const rowsPlus=document.getElementById('rowsPlus');
-  const rowsVal=document.getElementById('rowsVal');
-  const colsMinus=document.getElementById('colsMinus');
-  const colsPlus=document.getElementById('colsPlus');
-  const colsVal=document.getElementById('colsVal');
-
-  function applyStateToControls(){
-    if(rowsVal) rowsVal.textContent=rows;
-    if(colsVal) colsVal.textContent=cols;
-    const circleInp=document.getElementById('circleMode');
-    const offsetInp=document.getElementById('offsetRows');
-    const gridInp=document.getElementById('showGrid');
-    if(circleInp) circleInp.checked=!!STATE.circleMode;
-    if(offsetInp) offsetInp.checked=!!STATE.offset;
-    if(gridInp) gridInp.checked=!!STATE.showGrid;
-    if(colorCountInp) colorCountInp.value=String(STATE.colorCount);
+  const rowsMinus = document.getElementById('rowsMinus');
+  const rowsPlus = document.getElementById('rowsPlus');
+  const rowsVal = document.getElementById('rowsVal');
+  const colsMinus = document.getElementById('colsMinus');
+  const colsPlus = document.getElementById('colsPlus');
+  const colsVal = document.getElementById('colsVal');
+  function applyStateToControls() {
+    if (rowsVal) rowsVal.textContent = rows;
+    if (colsVal) colsVal.textContent = cols;
+    const circleInp = document.getElementById('circleMode');
+    const offsetInp = document.getElementById('offsetRows');
+    const gridInp = document.getElementById('showGrid');
+    if (circleInp) circleInp.checked = !!STATE.circleMode;
+    if (offsetInp) offsetInp.checked = !!STATE.offset;
+    if (gridInp) gridInp.checked = !!STATE.showGrid;
+    if (colorCountInp) colorCountInp.value = String(STATE.colorCount);
     updateColorVisibility();
   }
-
-  function setRows(next){
-    const clamped=clampInt(next,1,MAX_DIM);
-    if(clamped===rows) return;
-    STATE.rows=clamped;
+  function setRows(next) {
+    const clamped = clampInt(next, 1, MAX_DIM);
+    if (clamped === rows) return;
+    STATE.rows = clamped;
     render();
   }
-
-  function setCols(next){
-    const clamped=clampInt(next,1,MAX_DIM);
-    if(clamped===cols) return;
-    STATE.cols=clamped;
+  function setCols(next) {
+    const clamped = clampInt(next, 1, MAX_DIM);
+    if (clamped === cols) return;
+    STATE.cols = clamped;
     render();
   }
-
-  rowsMinus?.addEventListener('click',()=>{ if(rows>1) setRows(rows-1); });
-  rowsPlus?.addEventListener('click',()=>{ if(rows<MAX_DIM) setRows(rows+1); });
-  colsMinus?.addEventListener('click',()=>{ if(cols>1) setCols(cols-1); });
-  colsPlus?.addEventListener('click',()=>{ if(cols<MAX_DIM) setCols(cols+1); });
-
-  const circleInp=document.getElementById('circleMode');
-  circleInp?.addEventListener('change',()=>{
-    STATE.circleMode=circleInp.checked;
+  rowsMinus === null || rowsMinus === void 0 || rowsMinus.addEventListener('click', () => {
+    if (rows > 1) setRows(rows - 1);
+  });
+  rowsPlus === null || rowsPlus === void 0 || rowsPlus.addEventListener('click', () => {
+    if (rows < MAX_DIM) setRows(rows + 1);
+  });
+  colsMinus === null || colsMinus === void 0 || colsMinus.addEventListener('click', () => {
+    if (cols > 1) setCols(cols - 1);
+  });
+  colsPlus === null || colsPlus === void 0 || colsPlus.addEventListener('click', () => {
+    if (cols < MAX_DIM) setCols(cols + 1);
+  });
+  const circleInp = document.getElementById('circleMode');
+  circleInp === null || circleInp === void 0 || circleInp.addEventListener('change', () => {
+    STATE.circleMode = circleInp.checked;
     updateCellColors();
   });
-
-  const offsetInp=document.getElementById('offsetRows');
-  offsetInp?.addEventListener('change',()=>{
-    STATE.offset=offsetInp.checked;
+  const offsetInp = document.getElementById('offsetRows');
+  offsetInp === null || offsetInp === void 0 || offsetInp.addEventListener('change', () => {
+    STATE.offset = offsetInp.checked;
     render();
   });
-
-  const gridInp=document.getElementById('showGrid');
-  gridInp?.addEventListener('change',()=>{
-    STATE.showGrid=gridInp.checked;
+  const gridInp = document.getElementById('showGrid');
+  gridInp === null || gridInp === void 0 || gridInp.addEventListener('change', () => {
+    STATE.showGrid = gridInp.checked;
     updateGridVisibility();
   });
-
-  colorCountInp?.addEventListener('input',()=>{
-    STATE.colorCount=clampInt(colorCountInp.value,1,colorInputs.length||MAX_COLORS);
+  colorCountInp === null || colorCountInp === void 0 || colorCountInp.addEventListener('input', () => {
+    STATE.colorCount = clampInt(colorCountInp.value, 1, colorInputs.length || MAX_COLORS);
     render();
   });
-
-  colorInputs.forEach((inp,idx)=>{
-    inp.addEventListener('input',()=>{
+  colorInputs.forEach((inp, idx) => {
+    inp.addEventListener('input', () => {
       modifiedColorIndexes.add(idx);
-      autoPaletteEnabled=modifiedColorIndexes.size===0;
-      ensureColors(Math.max(idx+1,STATE.colorCount));
-      STATE.colors[idx]=inp.value;
+      autoPaletteEnabled = modifiedColorIndexes.size === 0;
+      ensureColors(Math.max(idx + 1, STATE.colorCount));
+      STATE.colors[idx] = inp.value;
       updateCellColors();
     });
   });
-
-  addBtn?.addEventListener('click',()=>{
-    STATE.figures.push(createFigureState(`Figur ${STATE.figures.length+1}`,rows,cols,[]));
+  addBtn === null || addBtn === void 0 || addBtn.addEventListener('click', () => {
+    STATE.figures.push(createFigureState(`Figur ${STATE.figures.length + 1}`, rows, cols, []));
     render();
   });
-
-  function removeFigure(index){
-    if(!Array.isArray(STATE.figures) || STATE.figures.length<=1) return;
-    STATE.figures.splice(index,1);
+  function removeFigure(index) {
+    if (!Array.isArray(STATE.figures) || STATE.figures.length <= 1) return;
+    STATE.figures.splice(index, 1);
     render();
   }
-
-  const btnSvg=document.getElementById('btnSvg');
-  const btnPng=document.getElementById('btnPng');
-  const resetBtn=document.getElementById('resetBtn');
-
-  function svgToString(svgEl){
-    const clone=svgEl.cloneNode(true);
-    clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
-    clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
-    return '<?xml version="1.0" encoding="UTF-8"?>\n'+new XMLSerializer().serializeToString(clone);
+  const btnSvg = document.getElementById('btnSvg');
+  const btnPng = document.getElementById('btnPng');
+  const resetBtn = document.getElementById('resetBtn');
+  function svgToString(svgEl) {
+    const clone = svgEl.cloneNode(true);
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
   }
-
-  function downloadSVG(svgEl,filename){
-    const data=svgToString(svgEl);
-    const blob=new Blob([data],{type:'image/svg+xml;charset=utf-8'});
-    const url=URL.createObjectURL(blob);
-    const a=document.createElement('a');
-    a.href=url;
-    a.download=filename.endsWith('.svg')?filename:filename+'.svg';
-    document.body.appendChild(a); a.click(); a.remove();
-    setTimeout(()=>URL.revokeObjectURL(url),1000);
+  function downloadSVG(svgEl, filename) {
+    const data = svgToString(svgEl);
+    const blob = new Blob([data], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename.endsWith('.svg') ? filename : filename + '.svg';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
-
-  function downloadPNG(svgEl,filename,scale=2,bg='#fff'){
-    const vb=svgEl.viewBox.baseVal;
-    const w=vb?.width||svgEl.clientWidth||cols*40;
-    const h=vb?.height||svgEl.clientHeight||rows*40;
-    const data=svgToString(svgEl);
-    const blob=new Blob([data],{type:'image/svg+xml;charset=utf-8'});
-    const url=URL.createObjectURL(blob);
-    const img=new Image();
-    img.onload=()=>{
-      const canvas=document.createElement('canvas');
-      canvas.width=Math.round(w*scale);
-      canvas.height=Math.round(h*scale);
-      const ctx=canvas.getContext('2d');
-      ctx.fillStyle=bg;
-      ctx.fillRect(0,0,canvas.width,canvas.height);
-      ctx.drawImage(img,0,0,canvas.width,canvas.height);
+  function downloadPNG(svgEl, filename, scale = 2, bg = '#fff') {
+    const vb = svgEl.viewBox.baseVal;
+    const w = (vb === null || vb === void 0 ? void 0 : vb.width) || svgEl.clientWidth || cols * 40;
+    const h = (vb === null || vb === void 0 ? void 0 : vb.height) || svgEl.clientHeight || rows * 40;
+    const data = svgToString(svgEl);
+    const blob = new Blob([data], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.round(w * scale);
+      canvas.height = Math.round(h * scale);
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = bg;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
       URL.revokeObjectURL(url);
-      canvas.toBlob(blob=>{
-        const urlPng=URL.createObjectURL(blob);
-        const a=document.createElement('a');
-        a.href=urlPng;
-        a.download=filename.endsWith('.png')?filename:filename+'.png';
-        document.body.appendChild(a); a.click(); a.remove();
-        setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
-      },'image/png');
+      canvas.toBlob(blob => {
+        const urlPng = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = urlPng;
+        a.download = filename.endsWith('.png') ? filename : filename + '.png';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(urlPng), 1000);
+      }, 'image/png');
     };
-    img.src=url;
+    img.src = url;
   }
-
-  function buildExportSvg(){
-    const colors=getColors();
-    const cellSize=40;
-    const figW=cols*cellSize + (STATE.offset? cellSize/2 : 0);
-    const figH=rows*cellSize;
-    const nameH=24;
-    const gap=20;
-    const figCount=boxes.length;
-    const totalW=figCount>0 ? figCount*figW + gap*(figCount-1) : figW;
-    const totalH=figH + nameH;
-    const svg=document.createElementNS('http://www.w3.org/2000/svg','svg');
-    svg.setAttribute('viewBox',`0 0 ${totalW} ${totalH}`);
-    svg.setAttribute('width',totalW);
-    svg.setAttribute('height',totalH);
-    let xOffset=0;
-    boxes.forEach(box=>{
-      const panel=box.closest('.figurePanel');
-      const name=panel.querySelector('.nameInput')?.value||'';
-      const g=document.createElementNS('http://www.w3.org/2000/svg','g');
-      g.setAttribute('transform',`translate(${xOffset},0)`);
-      box.querySelectorAll('.row').forEach((rowEl,r)=>{
-        rowEl.querySelectorAll('.cell').forEach((cellEl,c)=>{
-          const idx=parseInt(cellEl.dataset.color,10)||0;
-          const x=c*cellSize + (STATE.offset && r%2===1 ? cellSize/2 : 0);
-          const yPos=r*cellSize;
-          const base=document.createElementNS('http://www.w3.org/2000/svg','rect');
-          base.setAttribute('x',x);
-          base.setAttribute('y',yPos);
-          base.setAttribute('width',cellSize);
-          base.setAttribute('height',cellSize);
-          base.setAttribute('fill','#fff');
-          if(STATE.showGrid){
-            base.setAttribute('stroke','#d1d5db');
-            base.setAttribute('stroke-width','1');
+  function buildExportSvg() {
+    const colors = getColors();
+    const cellSize = 40;
+    const figW = cols * cellSize + (STATE.offset ? cellSize / 2 : 0);
+    const figH = rows * cellSize;
+    const nameH = 24;
+    const gap = 20;
+    const figCount = boxes.length;
+    const totalW = figCount > 0 ? figCount * figW + gap * (figCount - 1) : figW;
+    const totalH = figH + nameH;
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', `0 0 ${totalW} ${totalH}`);
+    svg.setAttribute('width', totalW);
+    svg.setAttribute('height', totalH);
+    let xOffset = 0;
+    boxes.forEach(box => {
+      var _panel$querySelector;
+      const panel = box.closest('.figurePanel');
+      const name = ((_panel$querySelector = panel.querySelector('.nameInput')) === null || _panel$querySelector === void 0 ? void 0 : _panel$querySelector.value) || '';
+      const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      g.setAttribute('transform', `translate(${xOffset},0)`);
+      box.querySelectorAll('.row').forEach((rowEl, r) => {
+        rowEl.querySelectorAll('.cell').forEach((cellEl, c) => {
+          const idx = parseInt(cellEl.dataset.color, 10) || 0;
+          const x = c * cellSize + (STATE.offset && r % 2 === 1 ? cellSize / 2 : 0);
+          const yPos = r * cellSize;
+          const base = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+          base.setAttribute('x', x);
+          base.setAttribute('y', yPos);
+          base.setAttribute('width', cellSize);
+          base.setAttribute('height', cellSize);
+          base.setAttribute('fill', '#fff');
+          if (STATE.showGrid) {
+            base.setAttribute('stroke', '#d1d5db');
+            base.setAttribute('stroke-width', '1');
           }
           g.appendChild(base);
-          if(idx>0){
-            if(STATE.circleMode){
-              const circ=document.createElementNS('http://www.w3.org/2000/svg','circle');
-              circ.setAttribute('cx',x+cellSize/2);
-              circ.setAttribute('cy',yPos+cellSize/2);
-              circ.setAttribute('r',cellSize/2);
-              circ.setAttribute('fill',colors[idx-1]);
+          if (idx > 0) {
+            if (STATE.circleMode) {
+              const circ = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+              circ.setAttribute('cx', x + cellSize / 2);
+              circ.setAttribute('cy', yPos + cellSize / 2);
+              circ.setAttribute('r', cellSize / 2);
+              circ.setAttribute('fill', colors[idx - 1]);
               g.appendChild(circ);
-            }else{
-              const rect=document.createElementNS('http://www.w3.org/2000/svg','rect');
-              rect.setAttribute('x',x);
-              rect.setAttribute('y',yPos);
-              rect.setAttribute('width',cellSize);
-              rect.setAttribute('height',cellSize);
-              rect.setAttribute('fill',colors[idx-1]);
-              if(STATE.showGrid){
-                rect.setAttribute('stroke','#d1d5db');
-                rect.setAttribute('stroke-width','1');
+            } else {
+              const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+              rect.setAttribute('x', x);
+              rect.setAttribute('y', yPos);
+              rect.setAttribute('width', cellSize);
+              rect.setAttribute('height', cellSize);
+              rect.setAttribute('fill', colors[idx - 1]);
+              if (STATE.showGrid) {
+                rect.setAttribute('stroke', '#d1d5db');
+                rect.setAttribute('stroke-width', '1');
               }
               g.appendChild(rect);
             }
           }
         });
       });
-      if(name){
-        const text=document.createElementNS('http://www.w3.org/2000/svg','text');
-        text.setAttribute('x',figW/2);
-        text.setAttribute('y',figH+16);
-        text.setAttribute('text-anchor','middle');
-        text.setAttribute('font-size','16');
-        text.setAttribute('font-family','system-ui, sans-serif');
-        text.textContent=name;
+      if (name) {
+        const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        text.setAttribute('x', figW / 2);
+        text.setAttribute('y', figH + 16);
+        text.setAttribute('text-anchor', 'middle');
+        text.setAttribute('font-size', '16');
+        text.setAttribute('font-family', 'system-ui, sans-serif');
+        text.textContent = name;
         g.appendChild(text);
       }
       svg.appendChild(g);
-      xOffset+=figW+gap;
+      xOffset += figW + gap;
     });
     return svg;
   }
-
-  btnSvg?.addEventListener('click',()=>{
-    const svg=buildExportSvg();
-    downloadSVG(svg,'figurtall.svg');
+  btnSvg === null || btnSvg === void 0 || btnSvg.addEventListener('click', () => {
+    const svg = buildExportSvg();
+    downloadSVG(svg, 'figurtall.svg');
   });
-  btnPng?.addEventListener('click',()=>{
-    const svg=buildExportSvg();
-    downloadPNG(svg,'figurtall.png',2);
+  btnPng === null || btnPng === void 0 || btnPng.addEventListener('click', () => {
+    const svg = buildExportSvg();
+    downloadPNG(svg, 'figurtall.png', 2);
   });
-
-  function resetState(){
-    STATE.rows=3;
-    STATE.cols=3;
-    STATE.circleMode=true;
-    STATE.offset=true;
-    STATE.showGrid=true;
-    STATE.colorCount=1;
-    STATE.colors=[];
+  function resetState() {
+    STATE.rows = 3;
+    STATE.cols = 3;
+    STATE.circleMode = true;
+    STATE.offset = true;
+    STATE.showGrid = true;
+    STATE.colorCount = 1;
+    STATE.colors = [];
     modifiedColorIndexes.clear();
-    autoPaletteEnabled=true;
-    lastAppliedPaletteSize=null;
+    autoPaletteEnabled = true;
+    lastAppliedPaletteSize = null;
     ensureColors(STATE.colorCount);
-    STATE.figures=[];
+    STATE.figures = [];
   }
-
-  function render(){
+  function render() {
     sanitizeState();
     applyStateToControls();
     rebuildFigurePanels();
   }
-
-  resetBtn?.addEventListener('click',()=>{
+  resetBtn === null || resetBtn === void 0 || resetBtn.addEventListener('click', () => {
     resetState();
     render();
   });
-
   render();
   updateFigureLayout();
-  window.render=render;
+  window.render = render;
 })();
-

--- a/graftegner.js
+++ b/graftegner.js
@@ -12,15 +12,23 @@
 
 /* ======================= URL-baserte innstillinger ======================= */
 const params = new URLSearchParams(location.search);
-function paramStr(id, def=''){ const v=params.get(id); return v==null?def:v; }
-function paramBool(id){ return params.get(id)==='1'; }
-function paramNumber(id, def=null){
+function paramStr(id, def = '') {
   const v = params.get(id);
-  if(v == null) return def;
+  return v == null ? def : v;
+}
+function paramBool(id) {
+  return params.get(id) === '1';
+}
+function paramNumber(id, def = null) {
+  const v = params.get(id);
+  if (v == null) return def;
   const n = Number.parseFloat(String(v).replace(',', '.'));
   return Number.isFinite(n) ? n : def;
 }
-const FONT_LIMITS = { min: 6, max: 72 };
+const FONT_LIMITS = {
+  min: 6,
+  max: 72
+};
 const FONT_DEFAULTS = {
   ticks: 16,
   axis: 20,
@@ -28,89 +36,111 @@ const FONT_DEFAULTS = {
 };
 const SHOW_CURVE_NAMES = params.has('showNames') ? paramBool('showNames') : true;
 const SHOW_CURVE_EXPRESSIONS = params.has('showExpr') ? paramBool('showExpr') : false;
-function clampFontSize(val){
-  if(!Number.isFinite(val)) return null;
-  if(val < FONT_LIMITS.min) return FONT_LIMITS.min;
-  if(val > FONT_LIMITS.max) return FONT_LIMITS.max;
+function clampFontSize(val) {
+  if (!Number.isFinite(val)) return null;
+  if (val < FONT_LIMITS.min) return FONT_LIMITS.min;
+  if (val > FONT_LIMITS.max) return FONT_LIMITS.max;
   return val;
 }
-function sanitizeFontSize(val, fallback){
+function sanitizeFontSize(val, fallback) {
   const clamped = clampFontSize(val);
   return clamped == null ? fallback : clamped;
 }
-function parseScreen(str){
-  if(!str) return null;
+function parseScreen(str) {
+  if (!str) return null;
   const cleaned = str.replace(/^[\s\[]+|[\]\s]+$/g, '');
-  const parts = cleaned.split(',').map(s=>+s.trim());
-  return parts.length===4 && parts.every(Number.isFinite) ? parts : null;
+  const parts = cleaned.split(',').map(s => +s.trim());
+  return parts.length === 4 && parts.every(Number.isFinite) ? parts : null;
 }
-function buildSimple(){
+function buildSimple() {
   const lines = [];
   let i = 1;
-  while(true){
+  while (true) {
     const key = `fun${i}`;
     const fun = paramStr(key, i === 1 ? 'f(x)=x^2-2' : '').trim();
     const dom = paramStr(`dom${i}`, '').trim();
-    if(i === 1 || params.has(key)){
-      if(fun){ lines.push(dom ? `${fun}, x in ${dom}` : fun); }
+    if (i === 1 || params.has(key)) {
+      if (fun) {
+        lines.push(dom ? `${fun}, x in ${dom}` : fun);
+      }
       i++;
     } else {
       break;
     }
   }
-  const pts = paramStr('points','0').trim();
-  if(pts){ lines.push(`points=${pts}`); }
-  const startx = paramStr('startx','').trim();
-  if(startx){ lines.push(`startx=${startx}`); }
-  const coords = paramStr('coords','').trim();
-  if(coords){ lines.push(`coords=${coords}`); }
+  const pts = paramStr('points', '0').trim();
+  if (pts) {
+    lines.push(`points=${pts}`);
+  }
+  const startx = paramStr('startx', '').trim();
+  if (startx) {
+    lines.push(`startx=${startx}`);
+  }
+  const coords = paramStr('coords', '').trim();
+  if (coords) {
+    lines.push(`coords=${coords}`);
+  }
   return lines.join('\n');
 }
-let SIMPLE = (typeof window !== 'undefined' && typeof window.SIMPLE !== 'undefined')
-  ? window.SIMPLE
-  : buildSimple();
-if(typeof window !== 'undefined'){ window.SIMPLE = SIMPLE; }
+let SIMPLE = typeof window !== 'undefined' && typeof window.SIMPLE !== 'undefined' ? window.SIMPLE : buildSimple();
+if (typeof window !== 'undefined') {
+  window.SIMPLE = SIMPLE;
+}
 
 /* ====================== AVANSERT KONFIG ===================== */
 const ADV = {
   axis: {
     labels: {
-      x: paramStr('xName','x'),
-      y: paramStr('yName','y'),
+      x: paramStr('xName', 'x'),
+      y: paramStr('yName', 'y'),
       fontSize: sanitizeFontSize(paramNumber('axisFont', FONT_DEFAULTS.axis), FONT_DEFAULTS.axis)
     },
-    style:  { stroke: '#111827', width: 2 },
-    grid:   {
+    style: {
+      stroke: '#111827',
+      width: 2
+    },
+    grid: {
       majorX: 1,
       majorY: 1,
       labelPrecision: 0,
       fontSize: sanitizeFontSize(paramNumber('tickFont', FONT_DEFAULTS.ticks), FONT_DEFAULTS.ticks)
     }
   },
-  screen: parseScreen(paramStr('screen','')),
+  screen: parseScreen(paramStr('screen', '')),
   lockAspect: params.has('lock') ? paramBool('lock') : true,
   firstQuadrant: paramBool('q1'),
-
   interactions: {
-    pan:  { enabled: paramBool('pan'),  needShift: false },
-    zoom: { enabled: true,  wheel: true, needShift: false, factorX: 1.2, factorY: 1.2 }
-  },
-
-  /* Brukes i punkts-modus og for glidere i funksjons-modus */
-  points: {
-    start:  [ [-3, 1], [ 1, 3] ],   // to punkt i linje-modus
-    startX: [  1 ],                 // start-X for glidere (kan overstyres i SIMPLE)
-    showCoordsOnHover: true,
-    decimals: 2,
-    guideArrows: true,   // bare i funksjons-modus
-    snap: {
-      enabled: params.has('snap') ? paramBool('snap') : true,
-      mode: 'up',        // 'drag' | 'up'
-      stepX: null,       // null => bruk axis.grid.majorX
-      stepY: null        // null => bruk axis.grid.majorY
+    pan: {
+      enabled: paramBool('pan'),
+      needShift: false
+    },
+    zoom: {
+      enabled: true,
+      wheel: true,
+      needShift: false,
+      factorX: 1.2,
+      factorY: 1.2
     }
   },
-
+  /* Brukes i punkts-modus og for glidere i funksjons-modus */
+  points: {
+    start: [[-3, 1], [1, 3]],
+    // to punkt i linje-modus
+    startX: [1],
+    // start-X for glidere (kan overstyres i SIMPLE)
+    showCoordsOnHover: true,
+    decimals: 2,
+    guideArrows: true,
+    // bare i funksjons-modus
+    snap: {
+      enabled: params.has('snap') ? paramBool('snap') : true,
+      mode: 'up',
+      // 'drag' | 'up'
+      stepX: null,
+      // null => bruk axis.grid.majorX
+      stepY: null // null => bruk axis.grid.majorY
+    }
+  },
   // Grafnavn
   curveName: {
     show: SHOW_CURVE_NAMES || SHOW_CURVE_EXPRESSIONS,
@@ -120,11 +150,15 @@ const ADV = {
     layer: 30,
     fractions: [0.2, 0.8, 0.6, 0.4],
     gapPx: 30,
-    plate: { paddingPx: 4, fill: '#fff', opacity: 0.6, radiusPx: 4 },
+    plate: {
+      paddingPx: 4,
+      fill: '#fff',
+      opacity: 0.6,
+      radiusPx: 4
+    },
     marginFracX: 0.04,
     marginFracY: 0.04
   },
-
   // Domenemarkører (brackets)
   domainMarkers: {
     show: true,
@@ -134,7 +168,6 @@ const ADV = {
     width: 3,
     layer: 8
   },
-
   // Asymptoter
   asymptote: {
     detect: true,
@@ -142,7 +175,6 @@ const ADV = {
     hugeY: 30,
     trimY: 8
   },
-
   // Fasit-sjekk (linje-modus)
   check: {
     slopeTol: 1e-3,
@@ -151,100 +183,105 @@ const ADV = {
 };
 
 /* ======================= Parser / modus ======================= */
-function parseSimple(txt){
-  const lines = (txt||'').split('\n').map(s=>s.trim()).filter(Boolean);
-  const out = { funcs:[], pointsCount:0, startX:[], extraPoints:[], answer:null, raw:txt };
-
-  const parseDomain = dom => {
-    if(!dom) return null;
-    const cleaned = dom.trim();
-    if(!cleaned) return null;
-    if(/^r$/i.test(cleaned) || /^ℝ$/i.test(cleaned)) return null;
-    const dm = cleaned.match(/^\[\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*\]$/i);
-    return dm ? [ +dm[1], +dm[2] ] : null;
+function parseSimple(txt) {
+  const lines = (txt || '').split('\n').map(s => s.trim()).filter(Boolean);
+  const out = {
+    funcs: [],
+    pointsCount: 0,
+    startX: [],
+    extraPoints: [],
+    answer: null,
+    raw: txt
   };
-
+  const parseDomain = dom => {
+    if (!dom) return null;
+    const cleaned = dom.trim();
+    if (!cleaned) return null;
+    if (/^r$/i.test(cleaned) || /^ℝ$/i.test(cleaned)) return null;
+    const dm = cleaned.match(/^\[\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*\]$/i);
+    return dm ? [+dm[1], +dm[2]] : null;
+  };
   const parseFunctionLine = line => {
     const eqIdx = line.indexOf('=');
-    if(eqIdx < 0) return null;
-
+    if (eqIdx < 0) return null;
     const lhsRaw = line.slice(0, eqIdx).trim();
     const rhsWithDom = line.slice(eqIdx + 1).trim();
-    if(!lhsRaw || !rhsWithDom) return null;
-
+    if (!lhsRaw || !rhsWithDom) return null;
     let name = null;
     let label = null;
-
     const lhsFn = lhsRaw.match(/^([a-zA-Z]\w*)\s*\(\s*x\s*\)$/i);
-    if(lhsFn){
+    if (lhsFn) {
       name = lhsFn[1];
       label = `${lhsFn[1]}(x)`;
-    }else{
+    } else {
       const lhsVar = lhsRaw.match(/^([a-zA-Z]\w*)$/i);
-      if(!lhsVar) return null;
-      if(lhsVar[1].toLowerCase() !== 'y') return null;
+      if (!lhsVar) return null;
+      if (lhsVar[1].toLowerCase() !== 'y') return null;
       name = lhsVar[1];
       label = lhsVar[1];
     }
-
     let rhs = rhsWithDom;
     let domain = null;
     const domMatch = /,\s*x\s*(?:in|∈)\s*(.+)$/i.exec(rhsWithDom);
-    if(domMatch){
+    if (domMatch) {
       rhs = rhsWithDom.slice(0, domMatch.index).trim();
       domain = parseDomain(domMatch[1]);
     }
-
     rhs = rhs.trim();
-    if(!rhs) return null;
-
-    return { name, rhs, domain, label };
+    if (!rhs) return null;
+    return {
+      name,
+      rhs,
+      domain,
+      label
+    };
   };
-
-  for(const L of lines){
+  for (const L of lines) {
     const fun = parseFunctionLine(L);
-    if(fun){ out.funcs.push(fun); continue; }
-    const pm = L.match(/^points\s*=\s*(\d+)/i);
-    if(pm){ out.pointsCount = +pm[1]; continue; }
-
-    const cm = L.match(/^coords\s*=\s*(.+)$/i);
-    if(cm){
-      const pts = cm[1]
-        .split(';')
-        .map(s=>s.trim().replace(/^\(|\)$/g,''))
-        .filter(Boolean)
-        .map(p=>p.split(',').map(t=>+t.trim()).filter(Number.isFinite));
-      for(const pt of pts){ if(pt.length===2) out.extraPoints.push(pt); }
+    if (fun) {
+      out.funcs.push(fun);
       continue;
     }
-
+    const pm = L.match(/^points\s*=\s*(\d+)/i);
+    if (pm) {
+      out.pointsCount = +pm[1];
+      continue;
+    }
+    const cm = L.match(/^coords\s*=\s*(.+)$/i);
+    if (cm) {
+      const pts = cm[1].split(';').map(s => s.trim().replace(/^\(|\)$/g, '')).filter(Boolean).map(p => p.split(',').map(t => +t.trim()).filter(Number.isFinite));
+      for (const pt of pts) {
+        if (pt.length === 2) out.extraPoints.push(pt);
+      }
+      continue;
+    }
     const sm = L.match(/^startx\s*=\s*(.+)$/i);
-    if(sm){ out.startX = sm[1].split(',').map(s=>+s.trim()).filter(Number.isFinite); continue; }
-
+    if (sm) {
+      out.startX = sm[1].split(',').map(s => +s.trim()).filter(Number.isFinite);
+      continue;
+    }
     const am = L.match(/^riktig\s*:\s*(.+)$/i);
-    if(am){ out.answer = am[1].trim(); continue; }
+    if (am) {
+      out.answer = am[1].trim();
+      continue;
+    }
   }
   return out;
 }
 let SIMPLE_PARSED = parseSimple(SIMPLE);
-
-const ALLOWED_NAMES = [
-  'sin','cos','tan','asin','acos','atan','sinh','cosh','tanh',
-  'log','ln','sqrt','exp','abs','min','max','floor','ceil','round','pow'
-];
-function isExplicitRHS(rhs){
+const ALLOWED_NAMES = ['sin', 'cos', 'tan', 'asin', 'acos', 'atan', 'sinh', 'cosh', 'tanh', 'log', 'ln', 'sqrt', 'exp', 'abs', 'min', 'max', 'floor', 'ceil', 'round', 'pow'];
+function isExplicitRHS(rhs) {
   let s = rhs.toLowerCase();
-  for(const k of ALLOWED_NAMES) s = s.replace(new RegExp(`\\b${k}\\b`,'g'),'');
-  s = s.replace(/\bpi\b/g,'').replace(/\be\b/g,'').replace(/x/g,'');
-  s = s.replace(/[0-9.+\-*/^()%\s]/g,'');
-  return s.length===0;
+  for (const k of ALLOWED_NAMES) s = s.replace(new RegExp(`\\b${k}\\b`, 'g'), '');
+  s = s.replace(/\bpi\b/g, '').replace(/\be\b/g, '').replace(/x/g, '');
+  s = s.replace(/[0-9.+\-*/^()%\s]/g, '');
+  return s.length === 0;
 }
-function decideMode(parsed){
+function decideMode(parsed) {
   const anyPlaceholder = parsed.funcs.some(f => !isExplicitRHS(f.rhs));
   return anyPlaceholder ? 'points' : 'functions';
 }
 let MODE = decideMode(SIMPLE_PARSED);
-
 let START_SCREEN = null;
 let brd = null;
 let axX = null;
@@ -259,151 +296,214 @@ let B = null;
 let moving = [];
 
 /* =============== uttrykk → funksjon ================= */
-function parseFunctionSpec(spec){
-  let rhs = (spec||'').toString().trim();
+function parseFunctionSpec(spec) {
+  let rhs = (spec || '').toString().trim();
   const m = rhs.match(/^([a-zA-Z]\w*)\s*\(\s*x\s*\)\s*=\s*(.+)$/);
-  if(m){ rhs=m[2]; }
-  rhs = rhs
-    .replace(/(^|[=+\-*/])\s*([+-])\s*([a-zA-Z0-9._()]+)\s*\^/g, (m,p,s,b) => p+'0'+s+'('+b+')^')
-    .replace(/\^/g,'**')
-    .replace(/(\d)([a-zA-Z(])/g,'$1*$2')
-    .replace(/([x\)])\(/g,'$1*(')
-    .replace(/x(\d)/g,'x*$1')
-    .replace(/\bln\(/gi,'log(')
-    .replace(/\bpi\b/gi,'PI')
-    .replace(/\be\b/gi,'E')
-    .replace(/\btau\b/gi,'(2*PI)');
-
+  if (m) {
+    rhs = m[2];
+  }
+  rhs = rhs.replace(/(^|[=+\-*/])\s*([+-])\s*([a-zA-Z0-9._()]+)\s*\^/g, (m, p, s, b) => p + '0' + s + '(' + b + ')^').replace(/\^/g, '**').replace(/(\d)([a-zA-Z(])/g, '$1*$2').replace(/([x\)])\(/g, '$1*(').replace(/x(\d)/g, 'x*$1').replace(/\bln\(/gi, 'log(').replace(/\bpi\b/gi, 'PI').replace(/\be\b/gi, 'E').replace(/\btau\b/gi, '(2*PI)');
   let fn;
-  try{
+  try {
     // eslint-disable-next-line no-new-func
-    fn = new Function('x','with(Math){return '+rhs+';}');
-  }catch(_){
-    fn = x=>NaN;
+    fn = new Function('x', 'with(Math){return ' + rhs + ';}');
+  } catch (_) {
+    fn = x => NaN;
   }
   return fn;
 }
 
 /* ============ Hjelpere for brøk/format & snap (linje-modus) ======== */
-function stepX(){ return (ADV.points.snap.stepX!=null ? ADV.points.snap.stepX : +ADV.axis.grid.majorX) || 1; }
-function stepY(){ return (ADV.points.snap.stepY!=null ? ADV.points.snap.stepY : +ADV.axis.grid.majorY) || 1; }
-function nearestMultiple(val, step){ return Math.round(val/step)*step; }
-function isNearMultiple(val, step){
-  const eps = Math.max(1e-9, Math.abs(step)*1e-6);
-  return Math.abs(val - nearestMultiple(val,step)) <= eps;
+function stepX() {
+  return (ADV.points.snap.stepX != null ? ADV.points.snap.stepX : +ADV.axis.grid.majorX) || 1;
 }
-function decimalsForStep(step){
-  if (!Number.isFinite(step) || step<=0) return 0;
+function stepY() {
+  return (ADV.points.snap.stepY != null ? ADV.points.snap.stepY : +ADV.axis.grid.majorY) || 1;
+}
+function nearestMultiple(val, step) {
+  return Math.round(val / step) * step;
+}
+function isNearMultiple(val, step) {
+  const eps = Math.max(1e-9, Math.abs(step) * 1e-6);
+  return Math.abs(val - nearestMultiple(val, step)) <= eps;
+}
+function decimalsForStep(step) {
+  if (!Number.isFinite(step) || step <= 0) return 0;
   if (Math.abs(step - Math.round(step)) < 1e-12) return 0;
   const s = step.toString();
-  if (s.includes('e')) { const m = Math.abs(Math.log10(step)); return Math.min(6, Math.ceil(m)); }
-  return Math.min(6, (s.split('.')[1]||'').length);
+  if (s.includes('e')) {
+    const m = Math.abs(Math.log10(step));
+    return Math.min(6, Math.ceil(m));
+  }
+  return Math.min(6, (s.split('.')[1] || '').length);
 }
-function toFixedTrim(n, d){
-  return (+n).toFixed(d).replace(/(\.\d*?)0+$/,'$1').replace(/\.$/,'');
+function toFixedTrim(n, d) {
+  return (+n).toFixed(d).replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
 }
-function fmtSmartVal(val, step){
-  if(!ADV.points.snap.enabled){ return toFixedTrim(val, ADV.points.decimals); }
+function fmtSmartVal(val, step) {
+  if (!ADV.points.snap.enabled) {
+    return toFixedTrim(val, ADV.points.decimals);
+  }
   const m = nearestMultiple(val, step);
-  if(isNearMultiple(val, step)){
+  if (isNearMultiple(val, step)) {
     const digs = decimalsForStep(step);
     return toFixedTrim(m, digs);
-  }else{
+  } else {
     return toFixedTrim(val, ADV.points.decimals);
   }
 }
-function fmtCoordsStatic(P){ return `(${fmtSmartVal(P.X(), stepX())}, ${fmtSmartVal(P.Y(), stepY())})`; }
-function fmtCoordsDrag(P){ const d=ADV.points.decimals; return `(${toFixedTrim(P.X(),d)}, ${toFixedTrim(P.Y(),d)})`; }
+function fmtCoordsStatic(P) {
+  return `(${fmtSmartVal(P.X(), stepX())}, ${fmtSmartVal(P.Y(), stepY())})`;
+}
+function fmtCoordsDrag(P) {
+  const d = ADV.points.decimals;
+  return `(${toFixedTrim(P.X(), d)}, ${toFixedTrim(P.Y(), d)})`;
+}
 
 /* ======= brøk for m & b (melding ved snap / “Riktig:”) ======= */
-function rationalApprox(x, maxDen=64){
-  let a0 = Math.floor(x), p0=1, q0=0, p1=a0, q1=1, frac = x - a0;
-  while(Math.abs(p1/q1 - x) > 1e-12 && q1 <= maxDen && frac){
-    const a = Math.floor(1/frac);
-    const p2 = a*p1 + p0, q2 = a*q1 + q0;
-    p0=p1; q0=q1; p1=p2; q1=q2; frac = 1/frac - a;
+function rationalApprox(x, maxDen = 64) {
+  let a0 = Math.floor(x),
+    p0 = 1,
+    q0 = 0,
+    p1 = a0,
+    q1 = 1,
+    frac = x - a0;
+  while (Math.abs(p1 / q1 - x) > 1e-12 && q1 <= maxDen && frac) {
+    const a = Math.floor(1 / frac);
+    const p2 = a * p1 + p0,
+      q2 = a * q1 + q0;
+    p0 = p1;
+    q0 = q1;
+    p1 = p2;
+    q1 = q2;
+    frac = 1 / frac - a;
   }
   return [p1, q1];
 }
-function fracStr(x){
-  const [n,d] = rationalApprox(x, 64);
-  return d===1 ? `${n}` : `${n}/${d}`;
+function fracStr(x) {
+  const [n, d] = rationalApprox(x, 64);
+  return d === 1 ? `${n}` : `${n}/${d}`;
 }
-function linearStr(m,b){
-  if(ADV.points.snap.enabled){
-    if(m===0) return `y = ${fracStr(b)}`;
-    const mS = m===1 ? 'x' : (m===-1 ? '-x' : `${fracStr(m)}x`);
-    const bS = b===0 ? '' : ` ${b>=0?'+':'-'} ${fracStr(Math.abs(b))}`;
+function linearStr(m, b) {
+  if (ADV.points.snap.enabled) {
+    if (m === 0) return `y = ${fracStr(b)}`;
+    const mS = m === 1 ? 'x' : m === -1 ? '-x' : `${fracStr(m)}x`;
+    const bS = b === 0 ? '' : ` ${b >= 0 ? '+' : '-'} ${fracStr(Math.abs(b))}`;
     return `y = ${mS}${bS}`;
-  }else{
+  } else {
     const f = v => toFixedTrim(v, 3);
-    if(m===0) return `y = ${f(b)}`;
-    const mS = m===1 ? 'x' : (m===-1 ? '-x' : `${f(m)}x`);
-    const bS = b===0 ? '' : ` ${b>=0?'+':'-'} ${f(Math.abs(b))}`;
+    if (m === 0) return `y = ${f(b)}`;
+    const mS = m === 1 ? 'x' : m === -1 ? '-x' : `${f(m)}x`;
+    const bS = b === 0 ? '' : ` ${b >= 0 ? '+' : '-'} ${f(Math.abs(b))}`;
     return `y = ${mS}${bS}`;
   }
 }
 
 /* ===================== Asymptoter ===================== */
-function detectVerticalAsymptotes(fn, A, B, N=1000, huge=ADV.asymptote.hugeY){
-  const xs=[], ys=[];
-  for(let i=0;i<=N;i++){ const x=A+(i*(B-A))/N; let y; try{y=fn(x);}catch(_){y=NaN;} xs.push(x); ys.push(y); }
-  const midBlow=(xL,xR)=>{ const m=0.5*(xL+xR); let y; try{y=fn(m);}catch(_){y=NaN;} return !Number.isFinite(y)||Math.abs(y)>(huge*2); };
-  const cand=[];
-  for(let i=1;i<ys.length;i++){
-    const xL=xs[i-1], xR=xs[i], y0=ys[i-1], y1=ys[i];
-    const b0=!Number.isFinite(y0)||Math.abs(y0)>huge;
-    const b1=!Number.isFinite(y1)||Math.abs(y1)>huge;
-    const opp=(Number.isFinite(y0)&&Number.isFinite(y1))?Math.sign(y0)!==Math.sign(y1):false;
-    if((b0&&b1&&opp) || ((b0^b1)&&midBlow(xL,xR))) cand.push(0.5*(xL+xR));
+function detectVerticalAsymptotes(fn, A, B, N = 1000, huge = ADV.asymptote.hugeY) {
+  const xs = [],
+    ys = [];
+  for (let i = 0; i <= N; i++) {
+    const x = A + i * (B - A) / N;
+    let y;
+    try {
+      y = fn(x);
+    } catch (_) {
+      y = NaN;
+    }
+    xs.push(x);
+    ys.push(y);
   }
-  const merged=[], tol=(B-A)/N*4;
-  cand.sort((a,b)=>a-b).forEach(x=>{ if(merged.length===0||Math.abs(x-merged[merged.length-1])>tol) merged.push(x); });
+  const midBlow = (xL, xR) => {
+    const m = 0.5 * (xL + xR);
+    let y;
+    try {
+      y = fn(m);
+    } catch (_) {
+      y = NaN;
+    }
+    return !Number.isFinite(y) || Math.abs(y) > huge * 2;
+  };
+  const cand = [];
+  for (let i = 1; i < ys.length; i++) {
+    const xL = xs[i - 1],
+      xR = xs[i],
+      y0 = ys[i - 1],
+      y1 = ys[i];
+    const b0 = !Number.isFinite(y0) || Math.abs(y0) > huge;
+    const b1 = !Number.isFinite(y1) || Math.abs(y1) > huge;
+    const opp = Number.isFinite(y0) && Number.isFinite(y1) ? Math.sign(y0) !== Math.sign(y1) : false;
+    if (b0 && b1 && opp || b0 ^ b1 && midBlow(xL, xR)) cand.push(0.5 * (xL + xR));
+  }
+  const merged = [],
+    tol = (B - A) / N * 4;
+  cand.sort((a, b) => a - b).forEach(x => {
+    if (merged.length === 0 || Math.abs(x - merged[merged.length - 1]) > tol) merged.push(x);
+  });
   return merged;
 }
-function detectHorizontalAsymptoteInRange(fn, a, b, winFrac=0.12, N=600){
-  if(!(b>a)) return null;
-  const TRIM = ADV.asymptote.trimY ?? 8;
-  const win = Math.max((b-a)*winFrac, (b-a)/N*10);
-  const mean = (L,R,steps=120)=>{
-    let s=0,c=0;
-    for(let i=0;i<=steps;i++){
-      const x=L + (i*(R-L))/steps;
-      let y; try{ y=fn(x);}catch(_){ y=NaN; }
-      if(Number.isFinite(y)){
+function detectHorizontalAsymptoteInRange(fn, a, b, winFrac = 0.12, N = 600) {
+  var _ADV$asymptote$trimY;
+  if (!(b > a)) return null;
+  const TRIM = (_ADV$asymptote$trimY = ADV.asymptote.trimY) !== null && _ADV$asymptote$trimY !== void 0 ? _ADV$asymptote$trimY : 8;
+  const win = Math.max((b - a) * winFrac, (b - a) / N * 10);
+  const mean = (L, R, steps = 120) => {
+    let s = 0,
+      c = 0;
+    for (let i = 0; i <= steps; i++) {
+      const x = L + i * (R - L) / steps;
+      let y;
+      try {
+        y = fn(x);
+      } catch (_) {
+        y = NaN;
+      }
+      if (Number.isFinite(y)) {
         y = Math.max(-TRIM, Math.min(TRIM, y));
-        s+=y; c++;
+        s += y;
+        c++;
       }
     }
-    return c? s/c : NaN;
+    return c ? s / c : NaN;
   };
-  const yL = mean(a, Math.min(a+win, b));
-  const yR = mean(Math.max(b-win, a), b);
-  if(!Number.isFinite(yL) || !Number.isFinite(yR)) return null;
-  const y = 0.5*(yL+yR);
+  const yL = mean(a, Math.min(a + win, b));
+  const yR = mean(Math.max(b - win, a), b);
+  if (!Number.isFinite(yL) || !Number.isFinite(yR)) return null;
+  const y = 0.5 * (yL + yR);
   const tol = 0.05 * Math.max(1, Math.abs(y));
-  return (Math.abs(yL - y) <= tol && Math.abs(yR - y) <= tol) ? y : null;
+  return Math.abs(yL - y) <= tol && Math.abs(yR - y) <= tol ? y : null;
 }
 
 /* ===================== Sample features ===================== */
-function sampleFeatures(fn, a, b, opts={}){
-  const { includeEndVals=false, detectAsymptotes=true, N=1000 } = opts;
-  const TRIM = ADV.asymptote?.trimY ?? 8;
-
-  const xs = [], ysRaw = [], ysTrim = [];
+function sampleFeatures(fn, a, b, opts = {}) {
+  var _ADV$asymptote$trimY2, _ADV$asymptote;
+  const {
+    includeEndVals = false,
+    detectAsymptotes = true,
+    N = 1000
+  } = opts;
+  const TRIM = (_ADV$asymptote$trimY2 = (_ADV$asymptote = ADV.asymptote) === null || _ADV$asymptote === void 0 ? void 0 : _ADV$asymptote.trimY) !== null && _ADV$asymptote$trimY2 !== void 0 ? _ADV$asymptote$trimY2 : 8;
+  const xs = [],
+    ysRaw = [],
+    ysTrim = [];
   for (let i = 0; i <= N; i++) {
-    const x = a + (i * (b - a)) / N;
-    let y; try { y = fn(x); } catch (_) { y = NaN; }
+    const x = a + i * (b - a) / N;
+    let y;
+    try {
+      y = fn(x);
+    } catch (_) {
+      y = NaN;
+    }
     xs.push(x);
     ysRaw.push(Number.isFinite(y) ? y : NaN);
-    if (Number.isFinite(y)) ysTrim.push(Math.max(-TRIM, Math.min(TRIM, y)));
-    else                    ysTrim.push(NaN);
+    if (Number.isFinite(y)) ysTrim.push(Math.max(-TRIM, Math.min(TRIM, y)));else ysTrim.push(NaN);
   }
 
   // røtter
   const roots = [];
   for (let i = 1; i < ysTrim.length; i++) {
-    const y0 = ysTrim[i - 1], y1 = ysTrim[i];
+    const y0 = ysTrim[i - 1],
+      y1 = ysTrim[i];
     if (!Number.isFinite(y0) || !Number.isFinite(y1)) continue;
     if (y0 === 0) roots.push(xs[i - 1]);
     if (y0 * y1 < 0) {
@@ -415,85 +515,134 @@ function sampleFeatures(fn, a, b, opts={}){
   // y-skjæring
   let yIntercept = null;
   if (0 >= a && 0 <= b) {
-    try{ const y0 = fn(0); if(Number.isFinite(y0)) yIntercept = y0; }catch(_){}
+    try {
+      const y0 = fn(0);
+      if (Number.isFinite(y0)) yIntercept = y0;
+    } catch (_) {}
   }
 
   // ekstremal
   const extrema = [];
   for (let i = 1; i < ysRaw.length - 1; i++) {
-    const y0 = ysRaw[i - 1], y1 = ysRaw[i], y2 = ysRaw[i + 1];
+    const y0 = ysRaw[i - 1],
+      y1 = ysRaw[i],
+      y2 = ysRaw[i + 1];
     if (!Number.isFinite(y0) || !Number.isFinite(y1) || !Number.isFinite(y2)) continue;
-    const d1 = y1 - y0, d2 = y2 - y1;
+    const d1 = y1 - y0,
+      d2 = y2 - y1;
     if (d1 * d2 <= 0) {
-      const x0 = xs[i - 1], x1 = xs[i];
-      const denom = (y0 - 2 * y1 + y2);
+      const x0 = xs[i - 1],
+        x1 = xs[i];
+      const denom = y0 - 2 * y1 + y2;
       let xv;
-      if (Math.abs(denom) < 1e-12) xv = x1;
-      else {
+      if (Math.abs(denom) < 1e-12) xv = x1;else {
         const h = x1 - x0;
-        xv = x1 - (h * (y2 - y0)) / (2 * denom);
+        xv = x1 - h * (y2 - y0) / (2 * denom);
       }
-      let yv; try { yv = fn(xv); } catch (_) { yv = NaN; }
-      if (Number.isFinite(yv)) extrema.push({ x: xv, y: yv });
+      let yv;
+      try {
+        yv = fn(xv);
+      } catch (_) {
+        yv = NaN;
+      }
+      if (Number.isFinite(yv)) extrema.push({
+        x: xv,
+        y: yv
+      });
     }
   }
 
   // endepunkter
   let endVals = [];
-  if(includeEndVals){
-    try{ const ya = fn(a); if(Number.isFinite(ya)) endVals.push({x:a,y:ya}); }catch(_){}
-    try{ const yb = fn(b); if(Number.isFinite(yb)) endVals.push({x:b,y:yb}); }catch(_){}
+  if (includeEndVals) {
+    try {
+      const ya = fn(a);
+      if (Number.isFinite(ya)) endVals.push({
+        x: a,
+        y: ya
+      });
+    } catch (_) {}
+    try {
+      const yb = fn(b);
+      if (Number.isFinite(yb)) endVals.push({
+        x: b,
+        y: yb
+      });
+    } catch (_) {}
   }
 
   // robuste y-grenser via kvantiler
   let yVals = ysTrim.filter(Number.isFinite);
-  let ymin = -5, ymax = 5;
+  let ymin = -5,
+    ymax = 5;
   if (yVals.length) {
-    yVals.sort((u,v)=>u-v);
-    const lo = yVals[Math.floor(0.02*(yVals.length-1))];
-    const hi = yVals[Math.floor(0.98*(yVals.length-1))];
-    ymin = lo; ymax = hi;
+    yVals.sort((u, v) => u - v);
+    const lo = yVals[Math.floor(0.02 * (yVals.length - 1))];
+    const hi = yVals[Math.floor(0.98 * (yVals.length - 1))];
+    ymin = lo;
+    ymax = hi;
   }
 
   // asymptoter
-  const vas = (detectAsymptotes && ADV.asymptote.detect && ADV.asymptote.showVertical)
-    ? detectVerticalAsymptotes(fn, a, b, 1000, ADV.asymptote.hugeY) : [];
-
+  const vas = detectAsymptotes && ADV.asymptote.detect && ADV.asymptote.showVertical ? detectVerticalAsymptotes(fn, a, b, 1000, ADV.asymptote.hugeY) : [];
   const haGuess = detectHorizontalAsymptoteInRange(fn, a, b);
-
-  return { roots, extrema, yIntercept, endVals, ymin, ymax, vas, ha: haGuess };
+  return {
+    roots,
+    extrema,
+    yIntercept,
+    endVals,
+    ymin,
+    ymax,
+    vas,
+    ha: haGuess
+  };
 }
 
 /* ===================== Autozoom ===================== */
-function computeAutoScreenFunctions(){
+function computeAutoScreenFunctions() {
   const allUnbounded = SIMPLE_PARSED.funcs.every(f => !f.domain);
 
   // samle features
   const feats = [];
-  let domMin=Infinity, domMax=-Infinity, anyDom=false;
-
-  for(const f of SIMPLE_PARSED.funcs){
+  let domMin = Infinity,
+    domMax = -Infinity,
+    anyDom = false;
+  for (const f of SIMPLE_PARSED.funcs) {
     const fn = parseFunctionSpec(`${f.name}(x)=${f.rhs}`);
-    if(f.domain){
+    if (f.domain) {
       anyDom = true;
       domMin = Math.min(domMin, f.domain[0]);
       domMax = Math.max(domMax, f.domain[1]);
-      feats.push({ hasDom:true, fn, a:f.domain[0], b:f.domain[1],
-                   ...sampleFeatures(fn, f.domain[0], f.domain[1], { includeEndVals:true }) });
-    }else{
-      feats.push({ hasDom:false, fn, a:-5, b: 5,
-                   ...sampleFeatures(fn, -5, 5, { includeEndVals:false }) });
+      feats.push({
+        hasDom: true,
+        fn,
+        a: f.domain[0],
+        b: f.domain[1],
+        ...sampleFeatures(fn, f.domain[0], f.domain[1], {
+          includeEndVals: true
+        })
+      });
+    } else {
+      feats.push({
+        hasDom: false,
+        fn,
+        a: -5,
+        b: 5,
+        ...sampleFeatures(fn, -5, 5, {
+          includeEndVals: false
+        })
+      });
     }
   }
-
   let xmin, xmax, ymin, ymax;
-
-  if(allUnbounded){
+  if (allUnbounded) {
     // behold [-5,5] så lenge sentrale punkter ikke faller utenfor
-    xmin = -5; xmax = 5; ymin = -5; ymax = 5;
-
-    for(const F of feats){
-      if(Number.isFinite(F.yIntercept)){
+    xmin = -5;
+    xmax = 5;
+    ymin = -5;
+    ymax = 5;
+    for (const F of feats) {
+      if (Number.isFinite(F.yIntercept)) {
         ymin = Math.min(ymin, F.yIntercept);
         ymax = Math.max(ymax, F.yIntercept);
       }
@@ -501,70 +650,100 @@ function computeAutoScreenFunctions(){
         ymin = Math.min(ymin, e.y);
         ymax = Math.max(ymax, e.y);
       });
-      if(Number.isFinite(F.ha)){
+      if (Number.isFinite(F.ha)) {
         ymin = Math.min(ymin, F.ha);
         ymax = Math.max(ymax, F.ha);
       }
     }
-  }else{
+  } else {
     // minst én avgrenset → vis hele domenet + sentrale punkter
-    xmin = domMin; xmax = domMax;
-
-    let ylo = [], yhi = [];
-    feats.forEach(F => { ylo.push(F.ymin); yhi.push(F.ymax); });
+    xmin = domMin;
+    xmax = domMax;
+    let ylo = [],
+      yhi = [];
+    feats.forEach(F => {
+      ylo.push(F.ymin);
+      yhi.push(F.ymax);
+    });
     ymin = Math.min(...ylo, -5);
-    ymax = Math.max(...yhi,  5);
-
-    for(const F of feats){
-      F.roots.forEach(r => { xmin = Math.min(xmin, r); xmax = Math.max(xmax, r); });
-      if(Number.isFinite(F.yIntercept)){ ymin = Math.min(ymin, F.yIntercept); ymax = Math.max(ymax, F.yIntercept); }
+    ymax = Math.max(...yhi, 5);
+    for (const F of feats) {
+      F.roots.forEach(r => {
+        xmin = Math.min(xmin, r);
+        xmax = Math.max(xmax, r);
+      });
+      if (Number.isFinite(F.yIntercept)) {
+        ymin = Math.min(ymin, F.yIntercept);
+        ymax = Math.max(ymax, F.yIntercept);
+      }
       F.extrema.forEach(e => {
-        xmin = Math.min(xmin, e.x); xmax = Math.max(xmax, e.x);
-        ymin = Math.min(ymin, e.y); ymax = Math.max(ymax, e.y);
+        xmin = Math.min(xmin, e.x);
+        xmax = Math.max(xmax, e.x);
+        ymin = Math.min(ymin, e.y);
+        ymax = Math.max(ymax, e.y);
       });
-      (F.endVals||[]).forEach(ev=>{
-        xmin = Math.min(xmin, ev.x); xmax = Math.max(xmax, ev.x);
-        ymin = Math.min(ymin, ev.y); ymax = Math.max(ymax, ev.y);
+      (F.endVals || []).forEach(ev => {
+        xmin = Math.min(xmin, ev.x);
+        xmax = Math.max(xmax, ev.x);
+        ymin = Math.min(ymin, ev.y);
+        ymax = Math.max(ymax, ev.y);
       });
-      if(F.vas && F.vas.length){ for(const a of F.vas){ xmin = Math.min(xmin, a); xmax = Math.max(xmax, a); } }
-      if(Number.isFinite(F.ha)){ ymin = Math.min(ymin, F.ha); ymax = Math.max(ymax, F.ha); }
+      if (F.vas && F.vas.length) {
+        for (const a of F.vas) {
+          xmin = Math.min(xmin, a);
+          xmax = Math.max(xmax, a);
+        }
+      }
+      if (Number.isFinite(F.ha)) {
+        ymin = Math.min(ymin, F.ha);
+        ymax = Math.max(ymax, F.ha);
+      }
     }
   }
 
   // Aksene alltid med
-  xmin = Math.min(xmin, 0); xmax = Math.max(xmax, 0);
-  ymin = Math.min(ymin, 0); ymax = Math.max(ymax, 0);
+  xmin = Math.min(xmin, 0);
+  xmax = Math.max(xmax, 0);
+  ymin = Math.min(ymin, 0);
+  ymax = Math.max(ymax, 0);
 
   // padding (og ev. kvadrat)
-  const padX = 0.08*(xmax - xmin || 10);
-  const padY = 0.08*(ymax - ymin || 10);
-  xmin -= padX; xmax += padX; ymin -= padY; ymax += padY;
-  if(shouldLockAspect()){
-    const cx=(xmin+xmax)/2, cy=(ymin+ymax)/2;
-    const span=Math.max(xmax-xmin, ymax-ymin);
-    const half=span/2;
-    return [cx-half, cx+half, cy-half, cy+half];
+  const padX = 0.08 * (xmax - xmin || 10);
+  const padY = 0.08 * (ymax - ymin || 10);
+  xmin -= padX;
+  xmax += padX;
+  ymin -= padY;
+  ymax += padY;
+  if (shouldLockAspect()) {
+    const cx = (xmin + xmax) / 2,
+      cy = (ymin + ymax) / 2;
+    const span = Math.max(xmax - xmin, ymax - ymin);
+    const half = span / 2;
+    return [cx - half, cx + half, cy - half, cy + half];
   }
   return [xmin, xmax, ymin, ymax];
 }
-
-function computeAutoScreenPoints(){
-  const pts = ADV.points.start.slice(0,2);
-  const xs = pts.map(p=>p[0]), ys = pts.map(p=>p[1]);
-  let xmin = Math.min(-5, ...xs), xmax = Math.max( 5, ...xs);
-  let ymin = Math.min(-5, ...ys), ymax = Math.max( 5, ...ys);
-
-  xmin = Math.min(xmin, 0); xmax = Math.max(xmax, 0);
-  ymin = Math.min(ymin, 0); ymax = Math.max(ymax, 0);
-
-  const cx = (xmin + xmax) / 2, cy = (ymin + ymax) / 2;
+function computeAutoScreenPoints() {
+  const pts = ADV.points.start.slice(0, 2);
+  const xs = pts.map(p => p[0]),
+    ys = pts.map(p => p[1]);
+  let xmin = Math.min(-5, ...xs),
+    xmax = Math.max(5, ...xs);
+  let ymin = Math.min(-5, ...ys),
+    ymax = Math.max(5, ...ys);
+  xmin = Math.min(xmin, 0);
+  xmax = Math.max(xmax, 0);
+  ymin = Math.min(ymin, 0);
+  ymax = Math.max(ymax, 0);
+  const cx = (xmin + xmax) / 2,
+    cy = (ymin + ymax) / 2;
   let halfX = Math.max(xmax - xmin, 10) / 2 * 1.1;
   let halfY = Math.max(ymax - ymin, 10) / 2 * 1.1;
-  if(shouldLockAspect()){
+  if (shouldLockAspect()) {
     const half = Math.max(halfX, halfY);
     halfX = halfY = half;
   }
-  return [cx-halfX, cx+halfX, cy-halfY, cy+halfY];
+  return [cx - halfX, cx + halfX, cy - halfY, cy + halfY];
 }
 const toBB = scr => [scr[0], scr[3], scr[1], scr[2]];
 
@@ -572,27 +751,31 @@ const toBB = scr => [scr[0], scr[3], scr[1], scr[2]];
 JXG.Options.showCopyright = false;
 JXG.Options.showNavigation = false;
 JXG.Options.text.display = 'internal';
-function initialScreen(){
-  let scr = ADV.screen ?? (MODE==='functions' ? computeAutoScreenFunctions()
-                                              : computeAutoScreenPoints());
-  if(ADV.firstQuadrant){
-    if(scr[0] < 0) scr[0] = 0;
-    if(scr[2] < 0) scr[2] = 0;
+function initialScreen() {
+  var _ADV$screen;
+  let scr = (_ADV$screen = ADV.screen) !== null && _ADV$screen !== void 0 ? _ADV$screen : MODE === 'functions' ? computeAutoScreenFunctions() : computeAutoScreenPoints();
+  if (ADV.firstQuadrant) {
+    if (scr[0] < 0) scr[0] = 0;
+    if (scr[2] < 0) scr[2] = 0;
   }
   return scr;
 }
-function syncSimpleFromWindow(){
-  if(typeof window !== 'undefined' && typeof window.SIMPLE !== 'undefined'){
+function syncSimpleFromWindow() {
+  if (typeof window !== 'undefined' && typeof window.SIMPLE !== 'undefined') {
     SIMPLE = window.SIMPLE;
-  }else if(typeof window !== 'undefined'){
+  } else if (typeof window !== 'undefined') {
     window.SIMPLE = SIMPLE;
   }
 }
-
-function destroyBoard(){
-  if(brd){
-    try{ brd.off?.('boundingbox', updateAfterViewChange); }catch(_){ }
-    try{ JXG.JSXGraph.freeBoard(brd); }catch(_){ }
+function destroyBoard() {
+  if (brd) {
+    try {
+      var _brd$off, _brd;
+      (_brd$off = (_brd = brd).off) === null || _brd$off === void 0 || _brd$off.call(_brd, 'boundingbox', updateAfterViewChange);
+    } catch (_) {}
+    try {
+      JXG.JSXGraph.freeBoard(brd);
+    } catch (_) {}
   }
   brd = null;
   axX = null;
@@ -606,50 +789,71 @@ function destroyBoard(){
   B = null;
   moving = [];
 }
-
-function applyAxisStyles(){
-  if(!brd) return;
-  ['x','y'].forEach(ax=>{
+function applyAxisStyles() {
+  if (!brd) return;
+  ['x', 'y'].forEach(ax => {
     brd.defaultAxes[ax].setAttribute({
-      withLabel:false,
-      strokeColor:ADV.axis.style.stroke,
-      strokeWidth:ADV.axis.style.width,
-      firstArrow:false,
-      lastArrow:true
+      withLabel: false,
+      strokeColor: ADV.axis.style.stroke,
+      strokeWidth: ADV.axis.style.width,
+      firstArrow: false,
+      lastArrow: true
     });
   });
 }
-
-function applyTickSettings(){
-  if(!axX || !axY) return;
-  const tickBase = { drawLabels:true, precision: ADV.axis.grid.labelPrecision };
-  const labelBase = { fontSize: ADV.axis.grid.fontSize };
+function applyTickSettings() {
+  if (!axX || !axY) return;
+  const tickBase = {
+    drawLabels: true,
+    precision: ADV.axis.grid.labelPrecision
+  };
+  const labelBase = {
+    fontSize: ADV.axis.grid.fontSize
+  };
   axX.defaultTicks.setAttribute({
     ...tickBase,
     ticksDistance: +ADV.axis.grid.majorX || 1,
     minorTicks: 0,
-    label: { ...labelBase, display:'internal', anchorX:'middle', anchorY:'top', offset:[0,-8] }
+    label: {
+      ...labelBase,
+      display: 'internal',
+      anchorX: 'middle',
+      anchorY: 'top',
+      offset: [0, -8]
+    }
   });
   axY.defaultTicks.setAttribute({
     ...tickBase,
     ticksDistance: +ADV.axis.grid.majorY || 1,
     minorTicks: 0,
-    label: { ...labelBase, display:'internal', anchorX:'right', anchorY:'middle', offset:[-8,0] }
+    label: {
+      ...labelBase,
+      display: 'internal',
+      anchorX: 'right',
+      anchorY: 'middle',
+      offset: [-8, 0]
+    }
   });
 }
-
-function initBoard(){
+function initBoard() {
   START_SCREEN = initialScreen();
-  brd = JXG.JSXGraph.initBoard('board',{
+  brd = JXG.JSXGraph.initBoard('board', {
     boundingbox: toBB(START_SCREEN),
     axis: true,
     grid: false,
     showNavigation: false,
     showCopyright: false,
-    pan:  { enabled: ADV.interactions.pan.enabled,  needShift: false },
-    zoom: { enabled: ADV.interactions.zoom.enabled, wheel: true,
-            needShift: false, factorX: ADV.interactions.zoom.factorX,
-            factorY: ADV.interactions.zoom.factorY }
+    pan: {
+      enabled: ADV.interactions.pan.enabled,
+      needShift: false
+    },
+    zoom: {
+      enabled: ADV.interactions.zoom.enabled,
+      wheel: true,
+      needShift: false,
+      factorX: ADV.interactions.zoom.factorX,
+      factorY: ADV.interactions.zoom.factorY
+    }
   });
   axX = brd.defaultAxes.x;
   axY = brd.defaultAxes.y;
@@ -663,201 +867,288 @@ function initBoard(){
 }
 
 /* ---------- akser og navn ---------- */
-function placeAxisNames(){
-  if(!brd) return;
-  const [xmin,ymax,xmax,ymin]=brd.getBoundingBox();
-  const rx=xmax-xmin, ry=ymax-ymin, off=0.04;
+function placeAxisNames() {
+  if (!brd) return;
+  const [xmin, ymax, xmax, ymin] = brd.getBoundingBox();
+  const rx = xmax - xmin,
+    ry = ymax - ymin,
+    off = 0.04;
   const axisFont = ADV.axis.labels.fontSize;
   const axisColor = ADV.axis.style.stroke;
-  if(!xName){
-    xName = brd.create('text',[0,0,()=>ADV.axis.labels.x||'x'],
-      {display:'internal',anchorX:'right',anchorY:'top',fixed:true,fontSize:axisFont, layer:40,
-       color:axisColor, cssStyle:'pointer-events:none;user-select:none;'});
-  }else{
-    xName.setAttribute({ fontSize: axisFont, color: axisColor });
+  if (!xName) {
+    xName = brd.create('text', [0, 0, () => ADV.axis.labels.x || 'x'], {
+      display: 'internal',
+      anchorX: 'right',
+      anchorY: 'top',
+      fixed: true,
+      fontSize: axisFont,
+      layer: 40,
+      color: axisColor,
+      cssStyle: 'pointer-events:none;user-select:none;'
+    });
+  } else {
+    xName.setAttribute({
+      fontSize: axisFont,
+      color: axisColor
+    });
   }
-  if(!yName){
-    yName = brd.create('text',[0,0,()=>ADV.axis.labels.y||'y'],
-      {display:'internal',anchorX:'right',anchorY:'top',fixed:true,fontSize:axisFont, layer:40,
-       color:axisColor, cssStyle:'pointer-events:none;user-select:none;'});
-  }else{
-    yName.setAttribute({ fontSize: axisFont, color: axisColor });
+  if (!yName) {
+    yName = brd.create('text', [0, 0, () => ADV.axis.labels.y || 'y'], {
+      display: 'internal',
+      anchorX: 'right',
+      anchorY: 'top',
+      fixed: true,
+      fontSize: axisFont,
+      layer: 40,
+      color: axisColor,
+      cssStyle: 'pointer-events:none;user-select:none;'
+    });
+  } else {
+    yName.setAttribute({
+      fontSize: axisFont,
+      color: axisColor
+    });
   }
-  xName.moveTo([xmax-off*rx, 0-off*ry]);
-  yName.moveTo([0-off*rx, ymax-off*ry]);
+  xName.moveTo([xmax - off * rx, 0 - off * ry]);
+  yName.moveTo([0 - off * rx, ymax - off * ry]);
 }
 
 /* ====== Lås 1:1 når lockAspect===true,
    eller når lockAspect er null og majorX===majorY ====== */
-function shouldLockAspect(){
+function shouldLockAspect() {
   if (ADV.lockAspect === true) return true;
   if (ADV.lockAspect === false) return false;
   const sx = +ADV.axis.grid.majorX || 1;
   const sy = +ADV.axis.grid.majorY || 1;
   return Math.abs(sx - sy) < 1e-12;
 }
-
-let enforcing=false;
-function enforceAspectStrict(){
-  if(!brd || !shouldLockAspect() || enforcing) return;
-  enforcing=true;
-  try{
-    const [xmin,ymax,xmax,ymin]=brd.getBoundingBox();
-    const W=xmax-xmin, H=ymax-ymin;
+let enforcing = false;
+function enforceAspectStrict() {
+  if (!brd || !shouldLockAspect() || enforcing) return;
+  enforcing = true;
+  try {
+    const [xmin, ymax, xmax, ymin] = brd.getBoundingBox();
+    const W = xmax - xmin,
+      H = ymax - ymin;
     const pixAR = brd.canvasWidth / brd.canvasHeight;
-    const worldAR = W/H;
-    if(Math.abs(worldAR-pixAR)<1e-9) return;
-    let newW=W, newH=H;
-    if(worldAR>pixAR){ newH=W/pixAR; } else { newW=H*pixAR; }
-    const cx=(xmax+xmin)/2, cy=(ymax+ymin)/2;
-    brd.setBoundingBox([cx-newW/2, cy+newH/2, cx+newW/2, cy-newH/2], false);
-  } finally { enforcing=false; }
+    const worldAR = W / H;
+    if (Math.abs(worldAR - pixAR) < 1e-9) return;
+    let newW = W,
+      newH = H;
+    if (worldAR > pixAR) {
+      newH = W / pixAR;
+    } else {
+      newW = H * pixAR;
+    }
+    const cx = (xmax + xmin) / 2,
+      cy = (ymax + ymin) / 2;
+    brd.setBoundingBox([cx - newW / 2, cy + newH / 2, cx + newW / 2, cy - newH / 2], false);
+  } finally {
+    enforcing = false;
+  }
 }
 
 /* ---------- GRID (statisk) ---------- */
-function rebuildGrid(){
-  if(!brd) return;
-  for(const L of gridV){ try{ brd.removeObject(L); }catch(_){ } }
-  for(const L of gridH){ try{ brd.removeObject(L); }catch(_){ } }
-  gridV=[];
-  gridH=[];
-
+function rebuildGrid() {
+  if (!brd) return;
+  for (const L of gridV) {
+    try {
+      brd.removeObject(L);
+    } catch (_) {}
+  }
+  for (const L of gridH) {
+    try {
+      brd.removeObject(L);
+    } catch (_) {}
+  }
+  gridV = [];
+  gridH = [];
   enforceAspectStrict();
-
-  const [xmin,ymax,xmax,ymin]=brd.getBoundingBox();
-  const sx=(+ADV.axis.grid.majorX>1e-9?+ADV.axis.grid.majorX:1);
-  const sy=(+ADV.axis.grid.majorY>1e-9?+ADV.axis.grid.majorY:1);
-  const x0=Math.ceil(xmin/sx)*sx, y0=Math.ceil(ymin/sy)*sy;
-
-  const attrs = { straightFirst:false, straightLast:false, strokeColor:'#e5e7eb',
-                  strokeWidth:1, fixed:true, layer:0, highlight:false, cssStyle:'pointer-events:none;' };
-
-  for(let x=x0; x<=xmax+1e-9; x+=sx) gridV.push(brd.create('line', [[x,ymin],[x,ymax]], attrs));
-  for(let y=y0; y<=ymax+1e-9; y+=sy) gridH.push(brd.create('line', [[xmin,y],[xmax,y]], attrs));
+  const [xmin, ymax, xmax, ymin] = brd.getBoundingBox();
+  const sx = +ADV.axis.grid.majorX > 1e-9 ? +ADV.axis.grid.majorX : 1;
+  const sy = +ADV.axis.grid.majorY > 1e-9 ? +ADV.axis.grid.majorY : 1;
+  const x0 = Math.ceil(xmin / sx) * sx,
+    y0 = Math.ceil(ymin / sy) * sy;
+  const attrs = {
+    straightFirst: false,
+    straightLast: false,
+    strokeColor: '#e5e7eb',
+    strokeWidth: 1,
+    fixed: true,
+    layer: 0,
+    highlight: false,
+    cssStyle: 'pointer-events:none;'
+  };
+  for (let x = x0; x <= xmax + 1e-9; x += sx) gridV.push(brd.create('line', [[x, ymin], [x, ymax]], attrs));
+  for (let y = y0; y <= ymax + 1e-9; y += sy) gridH.push(brd.create('line', [[xmin, y], [xmax, y]], attrs));
 }
 
 /* =================== Grafnavn-bakplate =================== */
-function measureTextPx(label){
+function measureTextPx(label) {
   const tryBBox = node => {
-    if(!node) return null;
-    try{
-      if(typeof node.getBBox === 'function'){
+    if (!node) return null;
+    try {
+      if (typeof node.getBBox === 'function') {
         const bb = node.getBBox();
-        if(bb && Number.isFinite(bb.width) && Number.isFinite(bb.height)){
-          return { w: bb.width, h: bb.height };
+        if (bb && Number.isFinite(bb.width) && Number.isFinite(bb.height)) {
+          return {
+            w: bb.width,
+            h: bb.height
+          };
         }
       }
-    }catch(_){ }
+    } catch (_) {}
     return null;
   };
   const tryRect = node => {
-    if(!node) return null;
-    try{
-      if(typeof node.getBoundingClientRect === 'function'){
+    if (!node) return null;
+    try {
+      if (typeof node.getBoundingClientRect === 'function') {
         const rect = node.getBoundingClientRect();
-        if(rect && Number.isFinite(rect.width) && Number.isFinite(rect.height)){
-          return { w: rect.width, h: rect.height };
+        if (rect && Number.isFinite(rect.width) && Number.isFinite(rect.height)) {
+          return {
+            w: rect.width,
+            h: rect.height
+          };
         }
       }
-    }catch(_){ }
+    } catch (_) {}
     return null;
   };
-
-  const nodes = [
-    label && label.rendNode,
-    label && label.rendNodeText && label.rendNodeText.parentNode,
-    label && label.rendNodeText
-  ];
-  for(const node of nodes){
+  const nodes = [label && label.rendNode, label && label.rendNodeText && label.rendNodeText.parentNode, label && label.rendNodeText];
+  for (const node of nodes) {
     const res = tryBBox(node);
-    if(res) return res;
+    if (res) return res;
   }
-  for(const node of nodes){
+  for (const node of nodes) {
     const res = tryRect(node);
-    if(res) return res;
+    if (res) return res;
   }
-
-  const text = (label && label.plaintext) || 'f(x)';
-  const f = (label && label.visProp && label.visProp.fontsize) || ADV.curveName.fontSize;
-  return { w: text.length * f * 0.6, h: f * 1.1 };
+  const text = label && label.plaintext || 'f(x)';
+  const f = label && label.visProp && label.visProp.fontsize || ADV.curveName.fontSize;
+  return {
+    w: text.length * f * 0.6,
+    h: f * 1.1
+  };
 }
-function ensurePlateFor(label){
-  if(label._plate) return;
-  const mkPt = (x,y)=> brd.create('point',[x,y],{visible:false,fixed:true,layer:ADV.curveName.layer-1});
-  const p1=mkPt(0,0),p2=mkPt(0,0),p3=mkPt(0,0),p4=mkPt(0,0);
-  brd.create('polygon',[p1,p2,p3,p4],{
-    fillColor:ADV.curveName.plate.fill, fillOpacity:ADV.curveName.plate.opacity,
-    borders:{visible:false}, fixed:true, highlight:false, layer:ADV.curveName.layer-1,
-    cssStyle:'pointer-events:none;stroke-linejoin:round;'
+function ensurePlateFor(label) {
+  if (label._plate) return;
+  const mkPt = (x, y) => brd.create('point', [x, y], {
+    visible: false,
+    fixed: true,
+    layer: ADV.curveName.layer - 1
   });
-  label._plate={p1,p2,p3,p4};
+  const p1 = mkPt(0, 0),
+    p2 = mkPt(0, 0),
+    p3 = mkPt(0, 0),
+    p4 = mkPt(0, 0);
+  brd.create('polygon', [p1, p2, p3, p4], {
+    fillColor: ADV.curveName.plate.fill,
+    fillOpacity: ADV.curveName.plate.opacity,
+    borders: {
+      visible: false
+    },
+    fixed: true,
+    highlight: false,
+    layer: ADV.curveName.layer - 1,
+    cssStyle: 'pointer-events:none;stroke-linejoin:round;'
+  });
+  label._plate = {
+    p1,
+    p2,
+    p3,
+    p4
+  };
 }
-function ensureLabelFront(label){
+function ensureLabelFront(label) {
   const node = label && label.rendNode;
-  if(node && node.parentNode){ node.parentNode.appendChild(node); }
+  if (node && node.parentNode) {
+    node.parentNode.appendChild(node);
+  }
 }
-function updatePlate(label){
-  if(!label._plate) return;
-  const [xmin,ymax,xmax,ymin]=brd.getBoundingBox();
-  const ux=(xmax-xmin)/brd.canvasWidth, uy=(ymax-ymin)/brd.canvasHeight;
-  const {w,h}=measureTextPx(label), pad=ADV.curveName.plate.paddingPx;
-  const tx=label.X(), ty=label.Y();
-  const ax=(label.visProp&&label.visProp.anchorx)||'left';
-  const ay=(label.visProp&&label.visProp.anchory)||'middle';
-  let L,R,T,B;
-  if(ax==='left'){L=tx-pad*ux; R=tx+(w+pad)*ux;}
-  else if(ax==='right'){L=tx-(w+pad)*ux; R=tx+pad*ux;}
-  else{L=tx-(w/2+pad)*ux; R=tx+(w/2+pad)*ux;}
-  if(ay==='top'){T=ty+pad*uy; B=ty-(h+pad)*uy;}
-  else if(ay==='bottom'){T=ty+(h+pad)*uy; B=ty-pad*uy;}
-  else{T=ty+(h/2+pad)*uy; B=ty-(h/2+pad)*uy;}
-  const P=label._plate; P.p1.moveTo([L,T]); P.p2.moveTo([R,T]); P.p3.moveTo([R,B]); P.p4.moveTo([L,B]);
+function updatePlate(label) {
+  if (!label._plate) return;
+  const [xmin, ymax, xmax, ymin] = brd.getBoundingBox();
+  const ux = (xmax - xmin) / brd.canvasWidth,
+    uy = (ymax - ymin) / brd.canvasHeight;
+  const {
+      w,
+      h
+    } = measureTextPx(label),
+    pad = ADV.curveName.plate.paddingPx;
+  const tx = label.X(),
+    ty = label.Y();
+  const ax = label.visProp && label.visProp.anchorx || 'left';
+  const ay = label.visProp && label.visProp.anchory || 'middle';
+  let L, R, T, B;
+  if (ax === 'left') {
+    L = tx - pad * ux;
+    R = tx + (w + pad) * ux;
+  } else if (ax === 'right') {
+    L = tx - (w + pad) * ux;
+    R = tx + pad * ux;
+  } else {
+    L = tx - (w / 2 + pad) * ux;
+    R = tx + (w / 2 + pad) * ux;
+  }
+  if (ay === 'top') {
+    T = ty + pad * uy;
+    B = ty - (h + pad) * uy;
+  } else if (ay === 'bottom') {
+    T = ty + (h + pad) * uy;
+    B = ty - pad * uy;
+  } else {
+    T = ty + (h / 2 + pad) * uy;
+    B = ty - (h / 2 + pad) * uy;
+  }
+  const P = label._plate;
+  P.p1.moveTo([L, T]);
+  P.p2.moveTo([R, T]);
+  P.p3.moveTo([R, B]);
+  P.p4.moveTo([L, B]);
 }
-
-function clampLabelToView(label){
-  if(!label) return;
+function clampLabelToView(label) {
+  if (!label) return;
   const bb = brd.getBoundingBox();
-  const xmin = bb[0], xmax = bb[2], ymin = bb[3], ymax = bb[1];
+  const xmin = bb[0],
+    xmax = bb[2],
+    ymin = bb[3],
+    ymax = bb[1];
   const marginX = (xmax - xmin) * (ADV.curveName.marginFracX || 0);
   const marginY = (ymax - ymin) * (ADV.curveName.marginFracY || 0);
-  const x = label.X(), y = label.Y();
+  const x = label.X(),
+    y = label.Y();
   const xClamped = Math.min(xmax - marginX, Math.max(xmin + marginX, x));
   const yClamped = Math.min(ymax - marginY, Math.max(ymin + marginY, y));
-  if(Math.abs(xClamped - x) > 1e-12 || Math.abs(yClamped - y) > 1e-12){
+  if (Math.abs(xClamped - x) > 1e-12 || Math.abs(yClamped - y) > 1e-12) {
     label.moveTo([xClamped, yClamped]);
   }
 }
-
-function makeLabelDraggable(label, g, reposition){
-  if(!label) return;
-
+function makeLabelDraggable(label, g, reposition) {
+  if (!label) return;
   const setup = () => {
     const node = label.rendNode;
-    if(!node) return false;
-    if(node._dragSetup) return true;
+    if (!node) return false;
+    if (node._dragSetup) return true;
     node._dragSetup = true;
-
     node.style.pointerEvents = 'auto';
     node.style.cursor = 'move';
     node.style.touchAction = 'none';
-
     let dragging = false;
     let offset = [0, 0];
-
     const toCoords = ev => {
-      try{
+      try {
         const c = brd.getUsrCoordsOfMouse(ev);
-        if(Array.isArray(c) && c.length >= 2){
+        if (Array.isArray(c) && c.length >= 2) {
           return [c[0], c[1]];
         }
-      }catch(_){ }
+      } catch (_) {}
       return null;
     };
-
     const start = ev => {
-      if(ev.button != null && ev.button !== 0) return;
+      if (ev.button != null && ev.button !== 0) return;
       const coords = toCoords(ev);
-      if(!coords) return;
+      if (!coords) return;
       ev.preventDefault();
       ev.stopPropagation();
       dragging = true;
@@ -865,15 +1156,16 @@ function makeLabelDraggable(label, g, reposition){
       ensureLabelFront(label);
       clampLabelToView(label);
       offset = [label.X() - coords[0], label.Y() - coords[1]];
-      if(typeof node.setPointerCapture === 'function' && ev.pointerId != null){
-        try{ node.setPointerCapture(ev.pointerId); }catch(_){ }
+      if (typeof node.setPointerCapture === 'function' && ev.pointerId != null) {
+        try {
+          node.setPointerCapture(ev.pointerId);
+        } catch (_) {}
       }
     };
-
     const move = ev => {
-      if(!dragging) return;
+      if (!dragging) return;
       const coords = toCoords(ev);
-      if(!coords) return;
+      if (!coords) return;
       ev.preventDefault();
       const nx = coords[0] + offset[0];
       const ny = coords[1] + offset[1];
@@ -881,19 +1173,19 @@ function makeLabelDraggable(label, g, reposition){
       clampLabelToView(label);
       updatePlate(label);
     };
-
     const end = ev => {
-      if(!dragging) return;
+      if (!dragging) return;
       dragging = false;
       ev.preventDefault();
       ev.stopPropagation();
       clampLabelToView(label);
       updatePlate(label);
-      if(typeof node.releasePointerCapture === 'function' && ev.pointerId != null){
-        try{ node.releasePointerCapture(ev.pointerId); }catch(_){ }
+      if (typeof node.releasePointerCapture === 'function' && ev.pointerId != null) {
+        try {
+          node.releasePointerCapture(ev.pointerId);
+        } catch (_) {}
       }
     };
-
     node.addEventListener('pointerdown', start);
     node.addEventListener('pointermove', move);
     node.addEventListener('pointerup', end);
@@ -904,16 +1196,13 @@ function makeLabelDraggable(label, g, reposition){
       g._labelManual = false;
       reposition(true);
     });
-
     return true;
   };
-
-  if(setup()) return;
-
+  if (setup()) return;
   let attempts = 0;
   const retry = () => {
-    if(setup()) return;
-    if(attempts++ < 5){
+    if (setup()) return;
+    if (attempts++ < 5) {
       setTimeout(retry, 30);
     }
   };
@@ -921,98 +1210,149 @@ function makeLabelDraggable(label, g, reposition){
 }
 
 /* =================== FARGEPALETT =================== */
-function colorFor(i){ const def=['#9333ea','#475569','#ef4444','#0ea5e9','#10b981','#f59e0b']; return def[i%def.length]; }
+function colorFor(i) {
+  const def = ['#9333ea', '#475569', '#ef4444', '#0ea5e9', '#10b981', '#f59e0b'];
+  return def[i % def.length];
+}
 
 /* =================== SEGMENTERT TEGNING =================== */
-function removeSegments(g){ if(g.segs){ g.segs.forEach(s=>brd.removeObject(s)); g.segs=[]; } }
-function rebuildFunctionSegmentsFor(g){
+function removeSegments(g) {
+  if (g.segs) {
+    g.segs.forEach(s => brd.removeObject(s));
+    g.segs = [];
+  }
+}
+function rebuildFunctionSegmentsFor(g) {
   removeSegments(g);
   const bb = brd.getBoundingBox();
-  let L = bb[0], R = bb[2];
-
-  if(g.domain && g.domain.length===2){
+  let L = bb[0],
+    R = bb[2];
+  if (g.domain && g.domain.length === 2) {
     L = Math.max(L, g.domain[0]);
     R = Math.min(R, g.domain[1]);
   }
-  if(!(R>L)) return;
-
-  const vas = (ADV.asymptote.detect && ADV.asymptote.showVertical)
-    ? detectVerticalAsymptotes(g.fn, L, R, 1000, ADV.asymptote.hugeY)
-    : [];
-  const xs = [L, ...vas.filter(x=>x>L && x<R), R].sort((a,b)=>a-b);
-  const eps = (R-L)*1e-6;
-
-  const safe = x=>{ try{ const y=g.fn(x); return Number.isFinite(y)?y:NaN; }catch(_){ return NaN; } };
-
-  g.segs=[];
-  for(let i=0;i<xs.length-1;i++){
-    let a=xs[i], b=xs[i+1];
-    const leftOpen  = (i>0);
-    const rightOpen = (i<xs.length-2);
-    if(leftOpen)  a += eps;
-    if(rightOpen) b -= eps;
-    if(b<=a) continue;
-    const seg = brd.create('functiongraph', [safe, ()=>a, ()=>b],
-      { strokeColor:g.color, strokeWidth:4, fixed:true, highlight:false });
+  if (!(R > L)) return;
+  const vas = ADV.asymptote.detect && ADV.asymptote.showVertical ? detectVerticalAsymptotes(g.fn, L, R, 1000, ADV.asymptote.hugeY) : [];
+  const xs = [L, ...vas.filter(x => x > L && x < R), R].sort((a, b) => a - b);
+  const eps = (R - L) * 1e-6;
+  const safe = x => {
+    try {
+      const y = g.fn(x);
+      return Number.isFinite(y) ? y : NaN;
+    } catch (_) {
+      return NaN;
+    }
+  };
+  g.segs = [];
+  for (let i = 0; i < xs.length - 1; i++) {
+    let a = xs[i],
+      b = xs[i + 1];
+    const leftOpen = i > 0;
+    const rightOpen = i < xs.length - 2;
+    if (leftOpen) a += eps;
+    if (rightOpen) b -= eps;
+    if (b <= a) continue;
+    const seg = brd.create('functiongraph', [safe, () => a, () => b], {
+      strokeColor: g.color,
+      strokeWidth: 4,
+      fixed: true,
+      highlight: false
+    });
     g.segs.push(seg);
   }
 }
-function rebuildAllFunctionSegments(){ graphs.forEach(rebuildFunctionSegmentsFor); }
+function rebuildAllFunctionSegments() {
+  graphs.forEach(rebuildFunctionSegmentsFor);
+}
 
 /* =================== FUNKSJONER + BRACKETS =================== */
-function makeSmartCurveLabel(g, idx, text){
-  if(!ADV.curveName.show || !text) return;
-  const label = brd.create('text',[0,0,()=>text],{
-    color:g.color, fillColor:g.color, fontSize:ADV.curveName.fontSize,
-    fixed:true, highlight:false, layer:ADV.curveName.layer,
-    anchorX:'left', anchorY:'middle', display:'internal',
-    cssStyle:'user-select:none;cursor:move;touch-action:none;'
+function makeSmartCurveLabel(g, idx, text) {
+  if (!ADV.curveName.show || !text) return;
+  const label = brd.create('text', [0, 0, () => text], {
+    color: g.color,
+    fillColor: g.color,
+    fontSize: ADV.curveName.fontSize,
+    fixed: true,
+    highlight: false,
+    layer: ADV.curveName.layer,
+    anchorX: 'left',
+    anchorY: 'middle',
+    display: 'internal',
+    cssStyle: 'user-select:none;cursor:move;touch-action:none;'
   });
   ensurePlateFor(label);
   g._labelManual = false;
-
-  function finiteYAt(x){
-    let y=g.fn(x);
-    if(Number.isFinite(y)) return y;
-    const [xmin,ymax,xmax,ymin]=brd.getBoundingBox();
-    const span=xmax-xmin, step=span/60;
-    for(let k=1;k<=60;k++){
-      for(const s of [+1,-1]){
-        const xs=x+s*k*step/6; y=g.fn(xs);
-        if(Number.isFinite(y)) return y;
+  function finiteYAt(x) {
+    let y = g.fn(x);
+    if (Number.isFinite(y)) return y;
+    const [xmin, ymax, xmax, ymin] = brd.getBoundingBox();
+    const span = xmax - xmin,
+      step = span / 60;
+    for (let k = 1; k <= 60; k++) {
+      for (const s of [+1, -1]) {
+        const xs = x + s * k * step / 6;
+        y = g.fn(xs);
+        if (Number.isFinite(y)) return y;
       }
     }
     return 0;
   }
-  function position(force){
+  function position(force) {
     const forced = force === true;
-    if(g._labelManual && !forced){
+    if (g._labelManual && !forced) {
       clampLabelToView(label);
       updatePlate(label);
       ensureLabelFront(label);
       return;
     }
-    const bb=brd.getBoundingBox(), xmin=bb[0], xmax=bb[2], ymin=bb[3], ymax=bb[1];
-    const a=g.domain?g.domain[0]:xmin, b=g.domain?g.domain[1]:xmax;
-    const L=Math.max(a,xmin), R=Math.min(b,xmax);
-    if(!(R>L)) return;
-    const fr=ADV.curveName.fractions, pad=0.04*(R-L);
-    let best={pen:1e9,pos:[(xmin+xmax)/2,(ymin+ymax)/2],slope:0};
-    for(const f of fr){
-      let x=L+f*(R-L); x=Math.min(R-pad,Math.max(L+pad,x));
-      const y=finiteYAt(x);
-      const h=(xmax-xmin)/600; const y1=g.fn(x-h), y2=g.fn(x+h);
-      const m=(Number.isFinite(y1)&&Number.isFinite(y2))? (y2-y1)/(2*h) : 0;
-      let nx=-m, ny=1; const L2=Math.hypot(nx,ny)||1; nx/=L2; ny/=L2;
-      const rx=(xmax-xmin)/brd.canvasWidth, ry=(ymax-ymin)/brd.canvasHeight;
-      const off=ADV.curveName.gapPx; let X=x+nx*off*rx, Y=y+ny*off*ry;
-      const xCl=Math.min(xmax-(xmax-xmin)*ADV.curveName.marginFracX,Math.max(xmin+(xmax-xmin)*ADV.curveName.marginFracX,X));
-      const yCl=Math.min(ymax-(ymax-ymin)*ADV.curveName.marginFracY,Math.max(ymin+(ymax-ymin)*ADV.curveName.marginFracY,Y));
-      const pen=Math.abs(xCl-X)/rx+Math.abs(yCl-Y)/ry;
-      if(pen<best.pen) best={pen,pos:[xCl,yCl],slope:m};
+    const bb = brd.getBoundingBox(),
+      xmin = bb[0],
+      xmax = bb[2],
+      ymin = bb[3],
+      ymax = bb[1];
+    const a = g.domain ? g.domain[0] : xmin,
+      b = g.domain ? g.domain[1] : xmax;
+    const L = Math.max(a, xmin),
+      R = Math.min(b, xmax);
+    if (!(R > L)) return;
+    const fr = ADV.curveName.fractions,
+      pad = 0.04 * (R - L);
+    let best = {
+      pen: 1e9,
+      pos: [(xmin + xmax) / 2, (ymin + ymax) / 2],
+      slope: 0
+    };
+    for (const f of fr) {
+      let x = L + f * (R - L);
+      x = Math.min(R - pad, Math.max(L + pad, x));
+      const y = finiteYAt(x);
+      const h = (xmax - xmin) / 600;
+      const y1 = g.fn(x - h),
+        y2 = g.fn(x + h);
+      const m = Number.isFinite(y1) && Number.isFinite(y2) ? (y2 - y1) / (2 * h) : 0;
+      let nx = -m,
+        ny = 1;
+      const L2 = Math.hypot(nx, ny) || 1;
+      nx /= L2;
+      ny /= L2;
+      const rx = (xmax - xmin) / brd.canvasWidth,
+        ry = (ymax - ymin) / brd.canvasHeight;
+      const off = ADV.curveName.gapPx;
+      let X = x + nx * off * rx,
+        Y = y + ny * off * ry;
+      const xCl = Math.min(xmax - (xmax - xmin) * ADV.curveName.marginFracX, Math.max(xmin + (xmax - xmin) * ADV.curveName.marginFracX, X));
+      const yCl = Math.min(ymax - (ymax - ymin) * ADV.curveName.marginFracY, Math.max(ymin + (ymax - ymin) * ADV.curveName.marginFracY, Y));
+      const pen = Math.abs(xCl - X) / rx + Math.abs(yCl - Y) / ry;
+      if (pen < best.pen) best = {
+        pen,
+        pos: [xCl, yCl],
+        slope: m
+      };
     }
     label.moveTo(best.pos);
-    label.setAttribute({anchorX: best.slope>=0?'left':'right'});
+    label.setAttribute({
+      anchorX: best.slope >= 0 ? 'left' : 'right'
+    });
     clampLabelToView(label);
     updatePlate(label);
     ensureLabelFront(label);
@@ -1022,270 +1362,448 @@ function makeSmartCurveLabel(g, idx, text){
   brd.on('boundingbox', position);
   makeLabelDraggable(label, g, position);
 }
-
 function makeBracketAt(g, x0, side /* -1 = venstre (a), +1 = høyre (b) */) {
   g._br = g._br || {};
-  if (g._br[side]) { g._br[side].forEach(o => brd.removeObject(o)); g._br[side] = null; }
+  if (g._br[side]) {
+    g._br[side].forEach(o => brd.removeObject(o));
+    g._br[side] = null;
+  }
   if (!g.domain || !ADV.domainMarkers.show) return;
-
   const [xmin, ymax, xmax, ymin] = brd.getBoundingBox();
   const rx = (xmax - xmin) / brd.canvasWidth;
   const ry = (ymax - ymin) / brd.canvasHeight;
-  const baseH = Math.max((xmax - xmin)/200, 1e-4);
+  const baseH = Math.max((xmax - xmin) / 200, 1e-4);
 
   // Finn et punkt innover i domenet med finite y
-  let xS = x0, yS = g.fn(xS), tries = 0, inward = (side<0 ? +1 : -1);
-  while(!Number.isFinite(yS) && tries < 12){
-    xS = x0 + inward * (tries+1) * baseH;
-    try { yS = g.fn(xS); }catch(_){ yS = NaN; }
+  let xS = x0,
+    yS = g.fn(xS),
+    tries = 0,
+    inward = side < 0 ? +1 : -1;
+  while (!Number.isFinite(yS) && tries < 12) {
+    xS = x0 + inward * (tries + 1) * baseH;
+    try {
+      yS = g.fn(xS);
+    } catch (_) {
+      yS = NaN;
+    }
     tries++;
   }
-  if(!Number.isFinite(yS)) return;
+  if (!Number.isFinite(yS)) return;
 
   // tangent rundt xS
   let m = 0;
-  try{
-    const y1 = g.fn(xS + baseH), y2 = g.fn(xS - baseH);
+  try {
+    const y1 = g.fn(xS + baseH),
+      y2 = g.fn(xS - baseH);
     if (Number.isFinite(y1) && Number.isFinite(y2)) m = (y1 - y2) / (2 * baseH);
-  }catch(_){}
+  } catch (_) {}
 
   // enhets-tangent/-normal i px-rom
-  let tx = 1 / rx, ty = m / ry;
-  const tlen = Math.hypot(tx, ty) || 1; tx /= tlen; ty /= tlen;
-  let nx = -ty, ny = tx;
-
+  let tx = 1 / rx,
+    ty = m / ry;
+  const tlen = Math.hypot(tx, ty) || 1;
+  tx /= tlen;
+  ty /= tlen;
+  let nx = -ty,
+    ny = tx;
   const px2world = (vx, vy, Lpx) => [vx * Lpx * rx, vy * Lpx * ry];
   const LEN = ADV.domainMarkers.barPx;
-  const CAP = Math.max(4, LEN * (ADV.domainMarkers.tipFrac||0.2));
-
-  const [wx, wy] = px2world(nx, ny, LEN/2);
+  const CAP = Math.max(4, LEN * (ADV.domainMarkers.tipFrac || 0.2));
+  const [wx, wy] = px2world(nx, ny, LEN / 2);
   const A = [xS - wx, yS - wy];
   const B = [xS + wx, yS + wy];
-
   const style = {
-    strokeColor: ADV.domainMarkers.color, strokeWidth: ADV.domainMarkers.width,
-    fixed:true, highlight:false, layer: ADV.domainMarkers.layer
+    strokeColor: ADV.domainMarkers.color,
+    strokeWidth: ADV.domainMarkers.width,
+    fixed: true,
+    highlight: false,
+    layer: ADV.domainMarkers.layer
   };
   const back = brd.create('segment', [A, B], style);
 
   // caps peker innover: retning = -side * t
   const [ux, uy] = px2world(tx, ty, CAP);
   const dir = -side;
-  const cap1 = brd.create('segment', [A, [A[0] + dir*ux, A[1] + dir*uy]], style);
-  const cap2 = brd.create('segment', [B, [B[0] + dir*ux, B[1] + dir*uy]], style);
-
+  const cap1 = brd.create('segment', [A, [A[0] + dir * ux, A[1] + dir * uy]], style);
+  const cap2 = brd.create('segment', [B, [B[0] + dir * ux, B[1] + dir * uy]], style);
   g._br[side] = [back, cap1, cap2];
 }
-
-function updateAllBrackets(){
-  for(const g of graphs){
-    if(!g.domain) continue;
+function updateAllBrackets() {
+  for (const g of graphs) {
+    if (!g.domain) continue;
     makeBracketAt(g, g.domain[0], -1);
     makeBracketAt(g, g.domain[1], +1);
   }
 }
-
-function buildCurveLabelText(fun){
-  const showName = !!(ADV?.curveName?.showName);
-  const showExpr = !!(ADV?.curveName?.showExpression);
-  if(!showName && !showExpr) return '';
-  const nameText = typeof fun?.label === 'string' ? fun.label.trim() : '';
-  const exprText = typeof fun?.rhs === 'string' ? fun.rhs.trim() : '';
-  if(showName && showExpr){
-    if(nameText && exprText) return `${nameText} = ${exprText}`;
+function buildCurveLabelText(fun) {
+  var _ADV$curveName, _ADV$curveName2;
+  const showName = !!(ADV !== null && ADV !== void 0 && (_ADV$curveName = ADV.curveName) !== null && _ADV$curveName !== void 0 && _ADV$curveName.showName);
+  const showExpr = !!(ADV !== null && ADV !== void 0 && (_ADV$curveName2 = ADV.curveName) !== null && _ADV$curveName2 !== void 0 && _ADV$curveName2.showExpression);
+  if (!showName && !showExpr) return '';
+  const nameText = typeof (fun === null || fun === void 0 ? void 0 : fun.label) === 'string' ? fun.label.trim() : '';
+  const exprText = typeof (fun === null || fun === void 0 ? void 0 : fun.rhs) === 'string' ? fun.rhs.trim() : '';
+  if (showName && showExpr) {
+    if (nameText && exprText) return `${nameText} = ${exprText}`;
     return nameText || exprText;
   }
-  if(showName && nameText) return nameText;
-  if(showExpr && exprText) return exprText;
+  if (showName && nameText) return nameText;
+  if (showExpr && exprText) return exprText;
   return '';
 }
-
-function buildFunctions(){
+function buildFunctions() {
   graphs = [];
-  SIMPLE_PARSED.funcs.forEach((f,i)=>{
-    const color=colorFor(i);
-    const fn=parseFunctionSpec(`${f.name}(x)=${f.rhs}`);
+  SIMPLE_PARSED.funcs.forEach((f, i) => {
+    const color = colorFor(i);
+    const fn = parseFunctionSpec(`${f.name}(x)=${f.rhs}`);
     const label = buildCurveLabelText(f);
-    const g = { name:f.name, color, domain:f.domain||null, label, expression:f.rhs };
-    g.fn = x => { try{ const y=fn(x); return Number.isFinite(y)?y:NaN; }catch(_){ return NaN; } };
+    const g = {
+      name: f.name,
+      color,
+      domain: f.domain || null,
+      label,
+      expression: f.rhs
+    };
+    g.fn = x => {
+      try {
+        const y = fn(x);
+        return Number.isFinite(y) ? y : NaN;
+      } catch (_) {
+        return NaN;
+      }
+    };
     g.segs = [];
 
     // usynlig "carrier" for glidere – VIKTIG: STRAMT TIL DOMENET
-    const xMinCarrier = g.domain ? g.domain[0] : ()=>brd.getBoundingBox()[0];
-    const xMaxCarrier = g.domain ? g.domain[1] : ()=>brd.getBoundingBox()[2];
-    g.carrier = brd.create('functiongraph',[g.fn, xMinCarrier, xMaxCarrier],
-      { visible:false, strokeOpacity:0, fixed:true });
-
+    const xMinCarrier = g.domain ? g.domain[0] : () => brd.getBoundingBox()[0];
+    const xMaxCarrier = g.domain ? g.domain[1] : () => brd.getBoundingBox()[2];
+    g.carrier = brd.create('functiongraph', [g.fn, xMinCarrier, xMaxCarrier], {
+      visible: false,
+      strokeOpacity: 0,
+      fixed: true
+    });
     graphs.push(g);
-    if(label){ makeSmartCurveLabel(g, i, label); }
+    if (label) {
+      makeSmartCurveLabel(g, i, label);
+    }
   });
-
   rebuildAllFunctionSegments();
   updateAllBrackets();
 
   // glidere
-  const n = SIMPLE_PARSED.pointsCount|0;
-  if(n>0 && graphs.length>0){
+  const n = SIMPLE_PARSED.pointsCount | 0;
+  if (n > 0 && graphs.length > 0) {
     const G = graphs[0];
-    const sxList = (SIMPLE_PARSED.startX && SIMPLE_PARSED.startX.length>0)
-      ? SIMPLE_PARSED.startX : (ADV.points.startX && ADV.points.startX.length>0 ? ADV.points.startX : [0]);
-
-    function stepXg(){ return (ADV.points.snap.stepX!=null ? ADV.points.snap.stepX : +ADV.axis.grid.majorX) || 1; }
-    const clampToDomain = x => (G.domain ? Math.min(G.domain[1], Math.max(G.domain[0], x)) : x);
-    const applySnap = P => { const xs = clampToDomain(Math.round(P.X()/stepXg())*stepXg()); P.moveTo([xs, G.fn(xs)]); };
-
-    for(let i=0;i<n;i++){
-      const xi = sxList[i]!=null ? clampToDomain(sxList[i]) : clampToDomain(sxList[0]);
-      const P = brd.create('glider',[xi, G.fn(xi), G.carrier],
-        { name:'', withLabel:true, face:'o', size:3,
-          strokeColor:G.color, fillColor:'#fff', showInfobox:false });
-
-      // HARD KLAMMING TIL DOMENE UNDER DRAG
-      P.on('drag', ()=>{
-        let x = clampToDomain(P.X());
-        P.moveTo([x, G.fn(x)]);
-        if(ADV.points.snap.enabled && (ADV.points.snap.mode||'up')==='drag') applySnap(P);
+    const sxList = SIMPLE_PARSED.startX && SIMPLE_PARSED.startX.length > 0 ? SIMPLE_PARSED.startX : ADV.points.startX && ADV.points.startX.length > 0 ? ADV.points.startX : [0];
+    function stepXg() {
+      return (ADV.points.snap.stepX != null ? ADV.points.snap.stepX : +ADV.axis.grid.majorX) || 1;
+    }
+    const clampToDomain = x => G.domain ? Math.min(G.domain[1], Math.max(G.domain[0], x)) : x;
+    const applySnap = P => {
+      const xs = clampToDomain(Math.round(P.X() / stepXg()) * stepXg());
+      P.moveTo([xs, G.fn(xs)]);
+    };
+    for (let i = 0; i < n; i++) {
+      const xi = sxList[i] != null ? clampToDomain(sxList[i]) : clampToDomain(sxList[0]);
+      const P = brd.create('glider', [xi, G.fn(xi), G.carrier], {
+        name: '',
+        withLabel: true,
+        face: 'o',
+        size: 3,
+        strokeColor: G.color,
+        fillColor: '#fff',
+        showInfobox: false
       });
 
-      if(ADV.points.showCoordsOnHover){
-        P.label.setAttribute({visible:false});
-        P.on('over', ()=>{ P.label.setText(()=>fmtCoordsStatic(P)); P.label.setAttribute({visible:true}); });
-        P.on('drag', ()=>{ P.label.setText(()=>fmtCoordsDrag(P));   P.label.setAttribute({visible:true}); });
-        P.on('up',   ()=>{ P.label.setText(()=>fmtCoordsStatic(P)); });
-        P.on('out',  ()=> P.label.setAttribute({visible:false}));
+      // HARD KLAMMING TIL DOMENE UNDER DRAG
+      P.on('drag', () => {
+        let x = clampToDomain(P.X());
+        P.moveTo([x, G.fn(x)]);
+        if (ADV.points.snap.enabled && (ADV.points.snap.mode || 'up') === 'drag') applySnap(P);
+      });
+      if (ADV.points.showCoordsOnHover) {
+        P.label.setAttribute({
+          visible: false
+        });
+        P.on('over', () => {
+          P.label.setText(() => fmtCoordsStatic(P));
+          P.label.setAttribute({
+            visible: true
+          });
+        });
+        P.on('drag', () => {
+          P.label.setText(() => fmtCoordsDrag(P));
+          P.label.setAttribute({
+            visible: true
+          });
+        });
+        P.on('up', () => {
+          P.label.setText(() => fmtCoordsStatic(P));
+        });
+        P.on('out', () => P.label.setAttribute({
+          visible: false
+        }));
       }
-      if(ADV.points.snap.enabled && (ADV.points.snap.mode||'up')==='up'){
-        P.on('up', ()=>applySnap(P));
+      if (ADV.points.snap.enabled && (ADV.points.snap.mode || 'up') === 'up') {
+        P.on('up', () => applySnap(P));
       }
-      if(MODE==='functions' && ADV.points.guideArrows){
-        brd.create('arrow',[()=>[P.X(),P.Y()],()=>[0,P.Y()] ],
-          { strokeColor:'#64748b', strokeWidth:2, dash:2, lastArrow:true, firstArrow:false, fixed:true, layer:10, highlight:false });
-        brd.create('arrow',[()=>[P.X(),P.Y()],()=>[P.X(),0] ],
-          { strokeColor:'#64748b', strokeWidth:2, dash:2, lastArrow:true, firstArrow:false, fixed:true, layer:10, highlight:false });
+      if (MODE === 'functions' && ADV.points.guideArrows) {
+        brd.create('arrow', [() => [P.X(), P.Y()], () => [0, P.Y()]], {
+          strokeColor: '#64748b',
+          strokeWidth: 2,
+          dash: 2,
+          lastArrow: true,
+          firstArrow: false,
+          fixed: true,
+          layer: 10,
+          highlight: false
+        });
+        brd.create('arrow', [() => [P.X(), P.Y()], () => [P.X(), 0]], {
+          strokeColor: '#64748b',
+          strokeWidth: 2,
+          dash: 2,
+          lastArrow: true,
+          firstArrow: false,
+          fixed: true,
+          layer: 10,
+          highlight: false
+        });
       }
     }
   }
 }
 
 /* =================== LINJE FRA PUNKTER =================== */
-function buildPointsLine(){
+function buildPointsLine() {
+  var _SIMPLE_PARSED$funcs$;
   A = null;
   B = null;
   moving = [];
-  const first = SIMPLE_PARSED.funcs[0] ?? {rhs:'ax+b'};
-  const rhs = first.rhs.replace(/\s+/g,'').toLowerCase();
-
-  let kind='two', anchorC=0, slopeM=1;
-  if(/^a\*?x([+-])(\d+(?:\.\d+)?)$/.test(rhs)){
-    kind='anchorY'; anchorC = RegExp.$1==='-'? -parseFloat(RegExp.$2): parseFloat(RegExp.$2);
-  }else if(/^([+-]?\d*(?:\.\d+)?)\*?x\+b$/.test(rhs)){
-    kind='fixedSlope';
-    const raw = RegExp.$1; slopeM = (raw===''||raw==='+')?1:(raw==='-'?-1:parseFloat(raw));
+  const first = (_SIMPLE_PARSED$funcs$ = SIMPLE_PARSED.funcs[0]) !== null && _SIMPLE_PARSED$funcs$ !== void 0 ? _SIMPLE_PARSED$funcs$ : {
+    rhs: 'ax+b'
+  };
+  const rhs = first.rhs.replace(/\s+/g, '').toLowerCase();
+  let kind = 'two',
+    anchorC = 0,
+    slopeM = 1;
+  if (/^a\*?x([+-])(\d+(?:\.\d+)?)$/.test(rhs)) {
+    kind = 'anchorY';
+    anchorC = RegExp.$1 === '-' ? -parseFloat(RegExp.$2) : parseFloat(RegExp.$2);
+  } else if (/^([+-]?\d*(?:\.\d+)?)\*?x\+b$/.test(rhs)) {
+    kind = 'fixedSlope';
+    const raw = RegExp.$1;
+    slopeM = raw === '' || raw === '+' ? 1 : raw === '-' ? -1 : parseFloat(raw);
   }
-
-  const start0 = ADV.points.start[0], start1=ADV.points.start[1];
-
-  if(kind==='two'){
-    const P0=brd.create('point',start0.slice(),{name:'',size:3,face:'o',fillColor:'#fff',strokeColor:'#9333ea',withLabel:true,showInfobox:false});
-    const P1=brd.create('point',start1.slice(),{name:'',size:3,face:'o',fillColor:'#fff',strokeColor:'#9333ea',withLabel:true,showInfobox:false});
-    A=P0; B=P1; moving=[P0,P1];
-  }else if(kind==='anchorY'){
-    const F=brd.create('point',[0,anchorC],{name:'',visible:false,fixed:true});
-    const P=brd.create('point',start0.slice(),{name:'',size:3,face:'o',fillColor:'#fff',strokeColor:'#9333ea',withLabel:true,showInfobox:false});
-    A=F; B=P; moving=[P];
-  }else{
-    const P=brd.create('point',start0.slice(),{name:'',size:3,face:'o',fillColor:'#fff',strokeColor:'#9333ea',withLabel:true,showInfobox:false});
-    const Q=brd.create('point',[()=>P.X()+1,()=>P.Y()+slopeM],{name:'',visible:false,fixed:true});
-    A=P; B=Q; moving=[P];
+  const start0 = ADV.points.start[0],
+    start1 = ADV.points.start[1];
+  if (kind === 'two') {
+    const P0 = brd.create('point', start0.slice(), {
+      name: '',
+      size: 3,
+      face: 'o',
+      fillColor: '#fff',
+      strokeColor: '#9333ea',
+      withLabel: true,
+      showInfobox: false
+    });
+    const P1 = brd.create('point', start1.slice(), {
+      name: '',
+      size: 3,
+      face: 'o',
+      fillColor: '#fff',
+      strokeColor: '#9333ea',
+      withLabel: true,
+      showInfobox: false
+    });
+    A = P0;
+    B = P1;
+    moving = [P0, P1];
+  } else if (kind === 'anchorY') {
+    const F = brd.create('point', [0, anchorC], {
+      name: '',
+      visible: false,
+      fixed: true
+    });
+    const P = brd.create('point', start0.slice(), {
+      name: '',
+      size: 3,
+      face: 'o',
+      fillColor: '#fff',
+      strokeColor: '#9333ea',
+      withLabel: true,
+      showInfobox: false
+    });
+    A = F;
+    B = P;
+    moving = [P];
+  } else {
+    const P = brd.create('point', start0.slice(), {
+      name: '',
+      size: 3,
+      face: 'o',
+      fillColor: '#fff',
+      strokeColor: '#9333ea',
+      withLabel: true,
+      showInfobox: false
+    });
+    const Q = brd.create('point', [() => P.X() + 1, () => P.Y() + slopeM], {
+      name: '',
+      visible: false,
+      fixed: true
+    });
+    A = P;
+    B = Q;
+    moving = [P];
   }
-
-  brd.create('line',[A,B],{strokeColor:'#9333ea',strokeWidth:4});
-
-  function stepXv(){return (ADV.points.snap.stepX!=null?ADV.points.snap.stepX:+ADV.axis.grid.majorX)||1;}
-  function stepYv(){return (ADV.points.snap.stepY!=null?ADV.points.snap.stepY:+ADV.axis.grid.majorY)||1;}
-  function snap(P){P.moveTo([nearestMultiple(P.X(),stepXv()), nearestMultiple(P.Y(),stepYv())]);}
-
-  if(ADV.points.snap.enabled){
-    const mode=ADV.points.snap.mode||'up';
-    for(const P of moving){
-      if(mode==='drag') P.on('drag',()=>snap(P));
-      else              P.on('up',  ()=>{ snap(P); if(P.label) P.label.setText(()=>fmtCoordsStatic(P)); });
+  brd.create('line', [A, B], {
+    strokeColor: '#9333ea',
+    strokeWidth: 4
+  });
+  function stepXv() {
+    return (ADV.points.snap.stepX != null ? ADV.points.snap.stepX : +ADV.axis.grid.majorX) || 1;
+  }
+  function stepYv() {
+    return (ADV.points.snap.stepY != null ? ADV.points.snap.stepY : +ADV.axis.grid.majorY) || 1;
+  }
+  function snap(P) {
+    P.moveTo([nearestMultiple(P.X(), stepXv()), nearestMultiple(P.Y(), stepYv())]);
+  }
+  if (ADV.points.snap.enabled) {
+    const mode = ADV.points.snap.mode || 'up';
+    for (const P of moving) {
+      if (mode === 'drag') P.on('drag', () => snap(P));else P.on('up', () => {
+        snap(P);
+        if (P.label) P.label.setText(() => fmtCoordsStatic(P));
+      });
     }
   }
-
-  if(ADV.points.showCoordsOnHover){
-    for(const P of moving){
-      P.label.setAttribute({visible:false});
-      P.on('over',()=>{ P.label.setText(()=>fmtCoordsStatic(P)); P.label.setAttribute({visible:true}); });
-      P.on('drag',()=>{ P.label.setText(()=>fmtCoordsDrag(P));   P.label.setAttribute({visible:true}); });
-      P.on('up',  ()=>{ P.label.setText(()=>fmtCoordsStatic(P)); });
-      P.on('out', ()=> P.label.setAttribute({visible:false}));
+  if (ADV.points.showCoordsOnHover) {
+    for (const P of moving) {
+      P.label.setAttribute({
+        visible: false
+      });
+      P.on('over', () => {
+        P.label.setText(() => fmtCoordsStatic(P));
+        P.label.setAttribute({
+          visible: true
+        });
+      });
+      P.on('drag', () => {
+        P.label.setText(() => fmtCoordsDrag(P));
+        P.label.setAttribute({
+          visible: true
+        });
+      });
+      P.on('up', () => {
+        P.label.setText(() => fmtCoordsStatic(P));
+      });
+      P.on('out', () => P.label.setAttribute({
+        visible: false
+      }));
     }
   }
 
   // Fasit-sjekk (hvis "Riktig:" finnes)
-  if (SIMPLE_PARSED.answer){
-    const {btn, msg, setStatus} = ensureCheckControls();
-    if(btn){ btn.style.display = ''; }
-    if(msg){ msg.style.display = ''; }
-    setStatus('info','');
-    if(btn){
+  if (SIMPLE_PARSED.answer) {
+    const {
+      btn,
+      msg,
+      setStatus
+    } = ensureCheckControls();
+    if (btn) {
+      btn.style.display = '';
+    }
+    if (msg) {
+      msg.style.display = '';
+    }
+    setStatus('info', '');
+    if (btn) {
       btn.onclick = () => {
-      const {m, b} = currentMB();
-      const ans = parseAnswerToMB(SIMPLE_PARSED.answer);
-      if(!ans){ setStatus('err','Kunne ikke tolke fasit.'); return; }
-      const okM = Math.abs(m - ans.m) <= ADV.check.slopeTol;
-      const okB = Math.abs(b - ans.b) <= ADV.check.interTol;
-      if(okM && okB){
-        setStatus('ok', `Riktig! ${linearStr(ans.m, ans.b)}`);
-      }else{
-        setStatus('err', `Ikke helt. Nå: ${linearStr(m, b)}`);
-      }
-    };
+        const {
+          m,
+          b
+        } = currentMB();
+        const ans = parseAnswerToMB(SIMPLE_PARSED.answer);
+        if (!ans) {
+          setStatus('err', 'Kunne ikke tolke fasit.');
+          return;
+        }
+        const okM = Math.abs(m - ans.m) <= ADV.check.slopeTol;
+        const okB = Math.abs(b - ans.b) <= ADV.check.interTol;
+        if (okM && okB) {
+          setStatus('ok', `Riktig! ${linearStr(ans.m, ans.b)}`);
+        } else {
+          setStatus('err', `Ikke helt. Nå: ${linearStr(m, b)}`);
+        }
+      };
     }
   }
 }
 
 /* ====== MB fra punktene + tolke fasit-uttrykk robust ====== */
-function currentMB(){
-  const dx = (B.X()-A.X());
-  const m  = (Math.abs(dx)<1e-12) ? NaN : (B.Y()-A.Y())/dx;
-  const b  = Number.isFinite(m) ? (A.Y() - m*A.X()) : NaN;
-  return { m, b };
+function currentMB() {
+  const dx = B.X() - A.X();
+  const m = Math.abs(dx) < 1e-12 ? NaN : (B.Y() - A.Y()) / dx;
+  const b = Number.isFinite(m) ? A.Y() - m * A.X() : NaN;
+  return {
+    m,
+    b
+  };
 }
-function parseAnswerToMB(answerLine){
+function parseAnswerToMB(answerLine) {
   const rhs = String(answerLine).split('=').slice(1).join('=').trim();
-  if(!rhs) return null;
+  if (!rhs) return null;
   const fn = parseFunctionSpec(`f(x)=${rhs}`);
-  try{
+  try {
     const b = fn(0);
     const m = fn(1) - b;
-    if(!Number.isFinite(m) || !Number.isFinite(b)) return null;
-    return { m, b };
-  }catch(_){ return null; }
+    if (!Number.isFinite(m) || !Number.isFinite(b)) return null;
+    return {
+      m,
+      b
+    };
+  } catch (_) {
+    return null;
+  }
 }
-
-function addFixedPoints(){
-  if(!Array.isArray(SIMPLE_PARSED.extraPoints)) return;
-  for(const pt of SIMPLE_PARSED.extraPoints){
-    const P = brd.create('point', pt.slice(), {name:'', size:3, face:'o', fillColor:'#fff', strokeColor:'#111827', withLabel:true, fixed:true, showInfobox:false});
-    if(ADV.points.showCoordsOnHover){
-      P.label.setAttribute({visible:false});
-      P.on('over', ()=>{ P.label.setText(()=>fmtCoordsStatic(P)); P.label.setAttribute({visible:true}); });
-      P.on('out',  ()=> P.label.setAttribute({visible:false}));
+function addFixedPoints() {
+  if (!Array.isArray(SIMPLE_PARSED.extraPoints)) return;
+  for (const pt of SIMPLE_PARSED.extraPoints) {
+    const P = brd.create('point', pt.slice(), {
+      name: '',
+      size: 3,
+      face: 'o',
+      fillColor: '#fff',
+      strokeColor: '#111827',
+      withLabel: true,
+      fixed: true,
+      showInfobox: false
+    });
+    if (ADV.points.showCoordsOnHover) {
+      P.label.setAttribute({
+        visible: false
+      });
+      P.on('over', () => {
+        P.label.setText(() => fmtCoordsStatic(P));
+        P.label.setAttribute({
+          visible: true
+        });
+      });
+      P.on('out', () => P.label.setAttribute({
+        visible: false
+      }));
     }
   }
 }
 
 /* ================= bygg valgt modus ================= */
-function hideCheckControls(){
+function hideCheckControls() {
   const btn = document.getElementById('btnCheck');
   const msg = document.getElementById('checkMsg');
-  if(btn){
+  if (btn) {
     btn.style.display = 'none';
     btn.onclick = null;
   }
-  if(msg){
+  if (msg) {
     msg.style.display = 'none';
     msg.textContent = '';
     msg.className = 'status status--info';
@@ -1293,133 +1811,137 @@ function hideCheckControls(){
 }
 
 /* ================= Oppdater / resize ================= */
-function updateAfterViewChange(){
-  if(!brd) return;
+function updateAfterViewChange() {
+  if (!brd) return;
   enforceAspectStrict();
   rebuildGrid();
   applyTickSettings();
   placeAxisNames();
-  if(MODE==='functions'){
+  if (MODE === 'functions') {
     rebuildAllFunctionSegments();
     updateAllBrackets();
   }
 }
-
-function rebuildAll(){
+function rebuildAll() {
   syncSimpleFromWindow();
-  if(typeof window !== 'undefined'){ window.SIMPLE = SIMPLE; }
-  if(typeof SIMPLE !== 'string'){ SIMPLE = SIMPLE == null ? '' : String(SIMPLE); }
+  if (typeof window !== 'undefined') {
+    window.SIMPLE = SIMPLE;
+  }
+  if (typeof SIMPLE !== 'string') {
+    SIMPLE = SIMPLE == null ? '' : String(SIMPLE);
+  }
   SIMPLE_PARSED = parseSimple(SIMPLE);
   MODE = decideMode(SIMPLE_PARSED);
-
   hideCheckControls();
-
   destroyBoard();
   initBoard();
-  if(!brd) return;
-
-  if(MODE==='functions'){
+  if (!brd) return;
+  if (MODE === 'functions') {
     buildFunctions();
-  }else{
+  } else {
     buildPointsLine();
   }
   addFixedPoints();
-
   brd.on('boundingbox', updateAfterViewChange);
   updateAfterViewChange();
 }
-
-window.addEventListener('resize', ()=>{
-  const resizeBoards = JXG?.JSXGraph?.resizeBoards;
-  if(typeof resizeBoards === 'function'){
+window.addEventListener('resize', () => {
+  var _JXG;
+  const resizeBoards = (_JXG = JXG) === null || _JXG === void 0 || (_JXG = _JXG.JSXGraph) === null || _JXG === void 0 ? void 0 : _JXG.resizeBoards;
+  if (typeof resizeBoards === 'function') {
     resizeBoards();
-  }else if(brd && typeof brd.resizeContainer === 'function'){
-    const cw = brd.containerObj?.clientWidth;
-    const ch = brd.containerObj?.clientHeight;
-    if(cw && ch){
+  } else if (brd && typeof brd.resizeContainer === 'function') {
+    var _brd$containerObj, _brd$containerObj2;
+    const cw = (_brd$containerObj = brd.containerObj) === null || _brd$containerObj === void 0 ? void 0 : _brd$containerObj.clientWidth;
+    const ch = (_brd$containerObj2 = brd.containerObj) === null || _brd$containerObj2 === void 0 ? void 0 : _brd$containerObj2.clientHeight;
+    if (cw && ch) {
       brd.resizeContainer(cw, ch);
       brd.update();
     }
   }
   updateAfterViewChange();
 });
-
 rebuildAll();
 window.render = rebuildAll;
 
 /* ====== Sjekk-knapp + status (monteres i #checkArea i HTML) ====== */
-function ensureCheckControls(){
+function ensureCheckControls() {
   const host = document.getElementById('checkArea') || document.body;
-
   let btn = document.getElementById('btnCheck');
   let msg = document.getElementById('checkMsg');
-
-  if(!btn){
+  if (!btn) {
     btn = document.createElement('button');
     btn.id = 'btnCheck';
     btn.textContent = 'Sjekk';
     btn.className = 'btn';
     host.appendChild(btn);
   }
-  if(!msg){
+  if (!msg) {
     msg = document.createElement('div');
     msg.id = 'checkMsg';
     msg.className = 'status status--info';
     msg.textContent = '';
     host.appendChild(msg);
   }
-
   const setStatus = (type, text) => {
-    msg.className = 'status ' + (type==='ok' ? 'status--ok' : type==='err' ? 'status--err' : 'status--info');
+    msg.className = 'status ' + (type === 'ok' ? 'status--ok' : type === 'err' ? 'status--err' : 'status--info');
     msg.textContent = text || '';
   };
-
-  return {btn, msg, setStatus};
+  return {
+    btn,
+    msg,
+    setStatus
+  };
 }
 
 /* ====== Reset & SVG (robust eksport) ====== */
-const btnReset=document.getElementById('btnReset');
-if(btnReset){
-  btnReset.addEventListener('click', ()=>{
+const btnReset = document.getElementById('btnReset');
+if (btnReset) {
+  btnReset.addEventListener('click', () => {
     const scr = initialScreen();
     brd.setBoundingBox(toBB(scr), true);
     updateAfterViewChange();
   });
 }
-const btnSvg=document.getElementById('btnSvg');
-if(btnSvg){
-  btnSvg.addEventListener('click', ()=>{
+const btnSvg = document.getElementById('btnSvg');
+if (btnSvg) {
+  btnSvg.addEventListener('click', () => {
     const src = brd.renderer.svgRoot.cloneNode(true);
     src.removeAttribute('style');
-    const w = brd.canvasWidth, h = brd.canvasHeight;
-    src.setAttribute('width',  `${w}`);
+    const w = brd.canvasWidth,
+      h = brd.canvasHeight;
+    src.setAttribute('width', `${w}`);
     src.setAttribute('height', `${h}`);
     src.setAttribute('viewBox', `0 0 ${w} ${h}`);
-    src.setAttribute('xmlns','http://www.w3.org/2000/svg');
-    src.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
-    const xml = new XMLSerializer().serializeToString(src)
-      .replace(/\swidth="[^"]*"\s(?=.*width=")/, ' ')
-      .replace(/\sheight="[^"]*"\s(?=.*height=")/, ' ');
-    const blob=new Blob([xml],{type:'image/svg+xml;charset=utf-8'});
-    const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='graf.svg'; a.click(); URL.revokeObjectURL(a.href);
+    src.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    src.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+    const xml = new XMLSerializer().serializeToString(src).replace(/\swidth="[^"]*"\s(?=.*width=")/, ' ').replace(/\sheight="[^"]*"\s(?=.*height=")/, ' ');
+    const blob = new Blob([xml], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'graf.svg';
+    a.click();
+    URL.revokeObjectURL(a.href);
   });
 }
-
-const btnPng=document.getElementById('btnPng');
-if(btnPng){
-  btnPng.addEventListener('click', ()=>{
+const btnPng = document.getElementById('btnPng');
+if (btnPng) {
+  btnPng.addEventListener('click', () => {
     const src = brd.renderer.svgRoot.cloneNode(true);
     src.removeAttribute('style');
-    const w = brd.canvasWidth, h = brd.canvasHeight;
-    src.setAttribute('width',  `${w}`);
+    const w = brd.canvasWidth,
+      h = brd.canvasHeight;
+    src.setAttribute('width', `${w}`);
     src.setAttribute('height', `${h}`);
     src.setAttribute('viewBox', `0 0 ${w} ${h}`);
-    src.setAttribute('xmlns','http://www.w3.org/2000/svg');
-    src.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
-    const xml = new XMLSerializer().serializeToString(src)
-      .replace(/\swidth="[^"]*"\s(?=.*width=")/, ' ')
-      .replace(/\sheight="[^"]*"\s(?=.*height=")/, ' ');
-    const svgBlob = new Blob([xml], {type:'image/svg+xml;charset=utf-8'});
+    src.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    src.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+    const xml = new XMLSerializer().serializeToString(src).replace(/\swidth="[^"]*"\s(?=.*width=")/, ' ').replace(/\sheight="[^"]*"\s(?=.*height=")/, ' ');
+    const svgBlob = new Blob([xml], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
     const url = URL.createObjectURL(svgBlob);
     const img = new Image();
     img.onload = () => {
@@ -1440,23 +1962,20 @@ if(btnPng){
     img.src = url;
   });
 }
-
 setupSettingsForm();
-
-function setupSettingsForm(){
+function setupSettingsForm() {
   const root = document.querySelector('.settings');
-  if(!root) return;
+  if (!root) return;
   const funcRows = document.getElementById('funcRows');
   const addBtn = document.createElement('button');
   addBtn.id = 'addFunc';
   addBtn.type = 'button';
   addBtn.className = 'btn';
   addBtn.textContent = '+';
-  addBtn.setAttribute('aria-label','Legg til funksjon');
+  addBtn.setAttribute('aria-label', 'Legg til funksjon');
   const g = id => document.getElementById(id);
   const showNamesInput = g('cfgShowNames');
   const showExprInput = g('cfgShowExpr');
-
   const gliderRow = document.createElement('div');
   gliderRow.className = 'settings-row glider-row';
   gliderRow.innerHTML = `
@@ -1472,139 +1991,121 @@ function setupSettingsForm(){
     </label>
   `;
   const fieldset = root.querySelector('fieldset');
-  if(fieldset){
+  if (fieldset) {
     root.insertBefore(gliderRow, fieldset);
-  }else{
+  } else {
     root.appendChild(gliderRow);
   }
   gliderRow.style.display = 'none';
   const gliderCountInput = gliderRow.querySelector('[data-points]');
   const gliderStartInput = gliderRow.querySelector('input[data-startx]');
   const gliderStartLabel = gliderStartInput ? gliderStartInput.closest('label') : null;
-
   const isCoords = str => /^\s*(?:\(\s*-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?\s*\)|-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?)(?:\s*;\s*(?:\(\s*-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?\s*\)|-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?))*\s*$/.test(str);
   const isExplicitFun = str => {
     const m = str.match(/^[a-zA-Z]\w*\s*\(\s*x\s*\)\s*=\s*(.+)$/) || str.match(/^y\s*=\s*(.+)$/i);
     const rhs = m ? m[1] : str;
-    if(!/x/.test(rhs)) return false;
+    if (!/x/.test(rhs)) return false;
     return isExplicitRHS(rhs);
   };
-
   const formatNumber = val => {
-    if(typeof val !== 'number') return '';
-    if(!Number.isFinite(val)) return '';
+    if (typeof val !== 'number') return '';
+    if (!Number.isFinite(val)) return '';
     const str = String(val);
     return str.replace(/\.0+(?=$)/, '').replace(/(\.\d*?)0+(?=$)/, '$1');
   };
-
   const parseStartXValues = value => {
-    if(!value) return [];
+    if (!value) return [];
     const matches = String(value).match(/-?\d+(?:[.,]\d+)?/g);
-    if(!matches) return [];
-    return matches
-      .map(str => Number.parseFloat(str.replace(',', '.')))
-      .filter(Number.isFinite);
+    if (!matches) return [];
+    return matches.map(str => Number.parseFloat(str.replace(',', '.'))).filter(Number.isFinite);
   };
-
   const getGliderCount = () => {
-    if(!gliderCountInput) return 0;
+    if (!gliderCountInput) return 0;
     const n = Number.parseInt(gliderCountInput.value, 10);
-    if(!Number.isFinite(n)) return 0;
+    if (!Number.isFinite(n)) return 0;
     const clamped = Math.max(0, Math.min(2, n));
     return clamped > 0 ? clamped : 0;
   };
-
   const shouldEnableGliders = () => {
-    const firstRowInput = funcRows?.querySelector('.func-row:first-child input[data-fun]');
-    if(!firstRowInput) return false;
+    const firstRowInput = funcRows === null || funcRows === void 0 ? void 0 : funcRows.querySelector('.func-row:first-child input[data-fun]');
+    if (!firstRowInput) return false;
     const value = firstRowInput.value.trim();
-    if(!value) return false;
-    if(isCoords(value)) return false;
+    if (!value) return false;
+    if (isCoords(value)) return false;
     return isExplicitFun(value);
   };
-
   const updateStartInputState = () => {
-    if(!gliderStartInput) return;
+    if (!gliderStartInput) return;
     const active = shouldEnableGliders();
     const count = getGliderCount();
     gliderStartInput.disabled = !active || count <= 0;
-    if(gliderStartLabel){
+    if (gliderStartLabel) {
       gliderStartLabel.style.display = active && count > 0 ? '' : 'none';
     }
   };
-
   const updateGliderVisibility = () => {
-    if(!gliderRow) return;
+    if (!gliderRow) return;
     const show = shouldEnableGliders();
     gliderRow.style.display = show ? '' : 'none';
-    if(gliderCountInput){
+    if (gliderCountInput) {
       gliderCountInput.disabled = !show;
     }
     updateStartInputState();
   };
-
   const buildSimpleFromForm = () => {
+    var _rows$;
     const rows = Array.from(funcRows.querySelectorAll('.func-row'));
-    const firstVal = rows[0]?.querySelector('input[data-fun]')?.value.trim() || '';
+    const firstVal = ((_rows$ = rows[0]) === null || _rows$ === void 0 || (_rows$ = _rows$.querySelector('input[data-fun]')) === null || _rows$ === void 0 ? void 0 : _rows$.value.trim()) || '';
     const firstIsCoords = !!firstVal && isCoords(firstVal);
     const lines = [];
-
     rows.forEach((row, idx) => {
       const funInput = row.querySelector('input[data-fun]');
       const domInput = row.querySelector('input[data-dom]');
-      if(!funInput) return;
+      if (!funInput) return;
       const fun = funInput.value.trim();
-      if(!fun) return;
-      if(idx === 0 && firstIsCoords){
+      if (!fun) return;
+      if (idx === 0 && firstIsCoords) {
         lines.push(`coords=${fun}`);
         return;
       }
       const dom = domInput ? domInput.value.trim() : '';
       lines.push(dom ? `${fun}, x in ${dom}` : fun);
     });
-
     const hasCoordsLine = lines.some(L => /^\s*coords\s*=/i.test(L));
     const hasPointsLine = lines.some(L => /^\s*points\s*=/i.test(L));
     const hasStartXLine = lines.some(L => /^\s*startx\s*=/i.test(L));
     const hasAnswerLine = lines.some(L => /^\s*riktig\s*:/i.test(L));
-
     const glidersActive = shouldEnableGliders();
     const gliderCount = glidersActive ? getGliderCount() : 0;
-    if(glidersActive && !hasPointsLine && gliderCount > 0){
+    if (glidersActive && !hasPointsLine && gliderCount > 0) {
       lines.push(`points=${gliderCount}`);
     }
-
-    if(glidersActive && !hasStartXLine && gliderCount > 0){
-      const startValues = parseStartXValues(gliderStartInput?.value || '');
-      if(startValues.length){
+    if (glidersActive && !hasStartXLine && gliderCount > 0) {
+      const startValues = parseStartXValues((gliderStartInput === null || gliderStartInput === void 0 ? void 0 : gliderStartInput.value) || '');
+      if (startValues.length) {
         lines.push(`startx=${startValues.map(formatNumber).join(', ')}`);
       }
     }
-
-    if(!hasCoordsLine && Array.isArray(SIMPLE_PARSED.extraPoints)){
-      const coords = SIMPLE_PARSED.extraPoints
-        .filter(pt => Array.isArray(pt) && pt.length === 2 && pt.every(Number.isFinite))
-        .map(pt => `(${formatNumber(pt[0])}, ${formatNumber(pt[1])})`);
-      if(coords.length){
+    if (!hasCoordsLine && Array.isArray(SIMPLE_PARSED.extraPoints)) {
+      const coords = SIMPLE_PARSED.extraPoints.filter(pt => Array.isArray(pt) && pt.length === 2 && pt.every(Number.isFinite)).map(pt => `(${formatNumber(pt[0])}, ${formatNumber(pt[1])})`);
+      if (coords.length) {
         lines.push(`coords=${coords.join('; ')}`);
       }
     }
-
-    if(!hasAnswerLine && SIMPLE_PARSED.answer){
+    if (!hasAnswerLine && SIMPLE_PARSED.answer) {
       lines.push(`riktig: ${SIMPLE_PARSED.answer}`);
     }
-
     return lines.join('\n');
   };
-
   const syncSimpleFromForm = () => {
     const simple = buildSimpleFromForm();
-    if(simple === SIMPLE) return;
+    if (simple === SIMPLE) return;
     SIMPLE = simple;
-    if(typeof window !== 'undefined'){ window.SIMPLE = SIMPLE; }
+    if (typeof window !== 'undefined') {
+      window.SIMPLE = SIMPLE;
+    }
   };
-
-  if(gliderCountInput){
+  if (gliderCountInput) {
     const onCountChange = () => {
       updateStartInputState();
       syncSimpleFromForm();
@@ -1612,23 +2113,21 @@ function setupSettingsForm(){
     gliderCountInput.addEventListener('input', onCountChange);
     gliderCountInput.addEventListener('change', onCountChange);
   }
-  if(gliderStartInput){
+  if (gliderStartInput) {
     gliderStartInput.addEventListener('input', syncSimpleFromForm);
   }
-
   const toggleDomain = input => {
     const row = input.closest('.func-row');
     const domLabel = row.querySelector('label.domain');
-    if(isExplicitFun(input.value.trim())){
+    if (isExplicitFun(input.value.trim())) {
       domLabel.style.display = '';
-    }else{
+    } else {
       domLabel.style.display = 'none';
       const domInput = domLabel.querySelector('input[data-dom]');
-      if(domInput) domInput.value = '';
+      if (domInput) domInput.value = '';
     }
     updateGliderVisibility();
   };
-
   const createRow = (index, funVal = '', domVal = '') => {
     const row = document.createElement('div');
     row.className = 'settings-row func-row';
@@ -1643,42 +2142,40 @@ function setupSettingsForm(){
     funcRows.appendChild(row);
     const funInput = row.querySelector('input[data-fun]');
     const domInput = row.querySelector('input[data-dom]');
-    if(funInput){
+    if (funInput) {
       funInput.value = funVal || '';
-      funInput.addEventListener('input', () => { toggleDomain(funInput); syncSimpleFromForm(); });
+      funInput.addEventListener('input', () => {
+        toggleDomain(funInput);
+        syncSimpleFromForm();
+      });
     }
-    if(domInput){
+    if (domInput) {
       domInput.value = domVal || '';
       domInput.addEventListener('input', syncSimpleFromForm);
     }
-    if(funInput){
+    if (funInput) {
       toggleDomain(funInput);
     }
     return row;
   };
-
   const appendAddBtn = () => {
-    if(addBtn.parentElement) addBtn.parentElement.removeChild(addBtn);
+    if (addBtn.parentElement) addBtn.parentElement.removeChild(addBtn);
     const lastRow = funcRows.querySelector('.func-row:last-child');
-    if(lastRow) lastRow.appendChild(addBtn);
+    if (lastRow) lastRow.appendChild(addBtn);
   };
-
-  const fillFormFromSimple = (simple) => {
-    if(addBtn.parentElement){
+  const fillFormFromSimple = simple => {
+    if (addBtn.parentElement) {
       addBtn.parentElement.removeChild(addBtn);
     }
-    const source = typeof simple === 'string' ? simple : (typeof window !== 'undefined' ? window.SIMPLE : SIMPLE);
+    const source = typeof simple === 'string' ? simple : typeof window !== 'undefined' ? window.SIMPLE : SIMPLE;
     const text = typeof source === 'string' ? source : '';
-    if(typeof source === 'string'){
+    if (typeof source === 'string') {
       SIMPLE = source;
       SIMPLE_PARSED = parseSimple(SIMPLE);
     }
-    const lines = text
-      .split(/\r?\n/)
-      .map(line => line.trim())
-      .filter(line => line.length > 0);
+    const lines = text.split(/\r?\n/).map(line => line.trim()).filter(line => line.length > 0);
     const filteredLines = lines.filter(line => !/^\s*points\s*=/i.test(line) && !/^\s*startx\s*=/i.test(line));
-    if(filteredLines.length === 0){
+    if (filteredLines.length === 0) {
       filteredLines.push('');
     }
     funcRows.innerHTML = '';
@@ -1686,61 +2183,67 @@ function setupSettingsForm(){
       let funVal = line;
       let domVal = '';
       const domMatch = line.match(/,\s*x\s*(?:in|∈)\s*(.+)$/i);
-      if(domMatch){
+      if (domMatch) {
         funVal = line.slice(0, domMatch.index).trim();
         domVal = domMatch[1].trim();
       }
       createRow(idx + 1, funVal, domVal);
     });
     appendAddBtn();
-    if(gliderCountInput){
-      const count = Number.isFinite(SIMPLE_PARSED?.pointsCount) ? SIMPLE_PARSED.pointsCount : 0;
+    if (gliderCountInput) {
+      var _SIMPLE_PARSED;
+      const count = Number.isFinite((_SIMPLE_PARSED = SIMPLE_PARSED) === null || _SIMPLE_PARSED === void 0 ? void 0 : _SIMPLE_PARSED.pointsCount) ? SIMPLE_PARSED.pointsCount : 0;
       const clamped = Math.max(0, Math.min(2, count));
       gliderCountInput.value = String(clamped);
     }
-    if(gliderStartInput){
-      const startVals = Array.isArray(SIMPLE_PARSED?.startX)
-        ? SIMPLE_PARSED.startX.filter(Number.isFinite)
-        : [];
+    if (gliderStartInput) {
+      var _SIMPLE_PARSED2;
+      const startVals = Array.isArray((_SIMPLE_PARSED2 = SIMPLE_PARSED) === null || _SIMPLE_PARSED2 === void 0 ? void 0 : _SIMPLE_PARSED2.startX) ? SIMPLE_PARSED.startX.filter(Number.isFinite) : [];
       gliderStartInput.value = startVals.length ? startVals.map(formatNumber).join(', ') : '1';
     }
     updateGliderVisibility();
     syncSimpleFromForm();
   };
-
   fillFormFromSimple(SIMPLE);
-
   addBtn.addEventListener('click', () => {
     const index = funcRows.querySelectorAll('.func-row').length + 1;
     createRow(index, '', '');
     appendAddBtn();
     syncSimpleFromForm();
   });
-
-  if(typeof window !== 'undefined'){
+  if (typeof window !== 'undefined') {
     window.addEventListener('examples:loaded', () => {
       fillFormFromSimple(window.SIMPLE);
     });
   }
-  g('cfgScreen').value = paramStr('screen','');
+  g('cfgScreen').value = paramStr('screen', '');
   g('cfgLock').checked = params.has('lock') ? paramBool('lock') : true;
-  g('cfgAxisX').value = paramStr('xName','x');
-  g('cfgAxisY').value = paramStr('yName','y');
+  g('cfgAxisX').value = paramStr('xName', 'x');
+  g('cfgAxisY').value = paramStr('yName', 'y');
   g('cfgPan').checked = paramBool('pan');
   g('cfgQ1').checked = paramBool('q1');
-  if(showNamesInput){ showNamesInput.checked = !!ADV.curveName.showName; }
-  if(showExprInput){ showExprInput.checked = !!ADV.curveName.showExpression; }
+  if (showNamesInput) {
+    showNamesInput.checked = !!ADV.curveName.showName;
+  }
+  if (showExprInput) {
+    showExprInput.checked = !!ADV.curveName.showExpression;
+  }
   const snapCheckbox = g('cfgSnap');
-  if(snapCheckbox){
+  if (snapCheckbox) {
     snapCheckbox.checked = ADV.points.snap.enabled;
   }
   const tickFontInput = g('cfgFontTicks');
-  if(tickFontInput){ tickFontInput.value = String(ADV.axis.grid.fontSize); }
+  if (tickFontInput) {
+    tickFontInput.value = String(ADV.axis.grid.fontSize);
+  }
   const axisFontInput = g('cfgFontAxes');
-  if(axisFontInput){ axisFontInput.value = String(ADV.axis.labels.fontSize); }
+  if (axisFontInput) {
+    axisFontInput.value = String(ADV.axis.labels.fontSize);
+  }
   const curveFontInput = g('cfgFontCurve');
-  if(curveFontInput){ curveFontInput.value = String(ADV.curveName.fontSize); }
-
+  if (curveFontInput) {
+    curveFontInput.value = String(ADV.curveName.fontSize);
+  }
   const apply = () => {
     syncSimpleFromForm();
     const p = new URLSearchParams();
@@ -1748,48 +2251,52 @@ function setupSettingsForm(){
     funcRows.querySelectorAll('.func-row').forEach((row, rowIdx) => {
       const fun = row.querySelector('input[data-fun]').value.trim();
       const dom = row.querySelector('input[data-dom]').value.trim();
-      if(!fun) return;
-      if(rowIdx === 0 && isCoords(fun)){
+      if (!fun) return;
+      if (rowIdx === 0 && isCoords(fun)) {
         p.set('coords', fun);
       } else {
         p.set(`fun${idx}`, fun);
-        if(dom) p.set(`dom${idx}`, dom);
+        if (dom) p.set(`dom${idx}`, dom);
         idx++;
       }
     });
-    if(shouldEnableGliders()){
+    if (shouldEnableGliders()) {
       const count = getGliderCount();
-      if(count > 0){
+      if (count > 0) {
         p.set('points', String(count));
-        const startVals = parseStartXValues(gliderStartInput?.value || '');
-        if(startVals.length){
+        const startVals = parseStartXValues((gliderStartInput === null || gliderStartInput === void 0 ? void 0 : gliderStartInput.value) || '');
+        if (startVals.length) {
           p.set('startx', startVals.map(formatNumber).join(', '));
         }
       }
     }
-    if(g('cfgScreen').value.trim()) p.set('screen', g('cfgScreen').value.trim());
-    if(g('cfgLock').checked) p.set('lock','1'); else p.set('lock','0');
-    if(g('cfgAxisX').value.trim() && g('cfgAxisX').value.trim() !== 'x') p.set('xName', g('cfgAxisX').value.trim());
-    if(g('cfgAxisY').value.trim() && g('cfgAxisY').value.trim() !== 'y') p.set('yName', g('cfgAxisY').value.trim());
-    if(g('cfgPan').checked) p.set('pan','1');
-    if(showNamesInput){ p.set('showNames', showNamesInput.checked ? '1' : '0'); }
-    if(showExprInput){ p.set('showExpr', showExprInput.checked ? '1' : '0'); }
-    const snapInput = g('cfgSnap');
-    if(snapInput){
-      if(snapInput.checked) p.set('snap','1'); else p.set('snap','0');
+    if (g('cfgScreen').value.trim()) p.set('screen', g('cfgScreen').value.trim());
+    if (g('cfgLock').checked) p.set('lock', '1');else p.set('lock', '0');
+    if (g('cfgAxisX').value.trim() && g('cfgAxisX').value.trim() !== 'x') p.set('xName', g('cfgAxisX').value.trim());
+    if (g('cfgAxisY').value.trim() && g('cfgAxisY').value.trim() !== 'y') p.set('yName', g('cfgAxisY').value.trim());
+    if (g('cfgPan').checked) p.set('pan', '1');
+    if (showNamesInput) {
+      p.set('showNames', showNamesInput.checked ? '1' : '0');
     }
-    if(g('cfgQ1').checked) p.set('q1','1');
+    if (showExprInput) {
+      p.set('showExpr', showExprInput.checked ? '1' : '0');
+    }
+    const snapInput = g('cfgSnap');
+    if (snapInput) {
+      if (snapInput.checked) p.set('snap', '1');else p.set('snap', '0');
+    }
+    if (g('cfgQ1').checked) p.set('q1', '1');
     const handleFontInput = (inputId, paramName, fallback) => {
       const input = g(inputId);
-      if(!input) return;
+      if (!input) return;
       const raw = Number.parseFloat(String(input.value || '').replace(',', '.'));
-      if(!Number.isFinite(raw)){
+      if (!Number.isFinite(raw)) {
         input.value = String(fallback);
         return;
       }
       const sanitized = sanitizeFontSize(raw, fallback);
       input.value = String(sanitized);
-      if(Math.abs(sanitized - fallback) > 1e-9){
+      if (Math.abs(sanitized - fallback) > 1e-9) {
         p.set(paramName, String(sanitized));
       }
     };
@@ -1798,9 +2305,8 @@ function setupSettingsForm(){
     handleFontInput('cfgFontCurve', 'curveFont', FONT_DEFAULTS.curve);
     location.search = p.toString();
   };
-
   root.addEventListener('change', apply);
   root.addEventListener('keydown', e => {
-    if(e.key === 'Enter') apply();
+    if (e.key === 'Enter') apply();
   });
 }

--- a/kuler.js
+++ b/kuler.js
@@ -2,18 +2,27 @@
 const SIMPLE = {
   // Global radius for all beads. Optional – falls back to ADV.beadRadius.
   beadRadius: 30,
-  bowls: [
-    {
-      colorCounts: [
-        { color: "blue", count: 2 },
-        { color: "red", count: 3 },
-        { color: "green", count: 0 },
-        { color: "yellow", count: 0 },
-        { color: "pink", count: 0 },
-        { color: "purple", count: 0 }
-      ]
-    }
-  ]
+  bowls: [{
+    colorCounts: [{
+      color: "blue",
+      count: 2
+    }, {
+      color: "red",
+      count: 3
+    }, {
+      color: "green",
+      count: 0
+    }, {
+      color: "yellow",
+      count: 0
+    }, {
+      color: "pink",
+      count: 0
+    }, {
+      color: "purple",
+      count: 0
+    }]
+  }]
 };
 
 /* ============ ADV KONFIG (TEKNISK/VALGFRITT) ============ */
@@ -23,38 +32,42 @@ const ADV = {
   beadGap: 12,
   assets: {
     beads: {
-      blue:   "images/blueWave.svg",
-      red:    "images/redDots.svg",
-      green:  "images/greenStar.svg",
+      blue: "images/blueWave.svg",
+      red: "images/redDots.svg",
+      green: "images/greenStar.svg",
       yellow: "images/yellowGrid.svg",
-      pink:   "images/pinkLabyrinth.svg",
+      pink: "images/pinkLabyrinth.svg",
       purple: "images/purpleZigzag.svg"
     }
   }
 };
 
 /* ============ DERIVERT KONFIG FOR RENDER (IKKE REDIGER) ============ */
-function makeCFG(){
-  const globalRadius = SIMPLE.beadRadius ?? ADV.beadRadius;
+function makeCFG() {
+  var _SIMPLE$beadRadius;
+  const globalRadius = (_SIMPLE$beadRadius = SIMPLE.beadRadius) !== null && _SIMPLE$beadRadius !== void 0 ? _SIMPLE$beadRadius : ADV.beadRadius;
   const bowls = Array.isArray(SIMPLE.bowls) ? SIMPLE.bowls : [];
   const cfgBowls = bowls.map(b => {
     const colorsArr = [];
     const counts = Array.isArray(b.colorCounts) ? b.colorCounts : [];
     counts.forEach(cc => {
       const col = ADV.assets.beads[cc.color];
-      const raw = cc?.count;
+      const raw = cc === null || cc === void 0 ? void 0 : cc.count;
       const count = Number.isFinite(raw) ? Math.max(0, Math.round(raw)) : 0;
-      if(col) for(let i=0; i<count; i++) colorsArr.push(col);
+      if (col) for (let i = 0; i < count; i++) colorsArr.push(col);
     });
-    if(!colorsArr.length) colorsArr.push(...Object.values(ADV.assets.beads));
-    const radiusRaw = Number.isFinite(b?.beadRadius) ? b.beadRadius : globalRadius;
-    const beadRadius = Math.min(60, Math.max(5, radiusRaw ?? ADV.beadRadius));
-    return { colors: colorsArr, beadRadius };
+    if (!colorsArr.length) colorsArr.push(...Object.values(ADV.assets.beads));
+    const radiusRaw = Number.isFinite(b === null || b === void 0 ? void 0 : b.beadRadius) ? b.beadRadius : globalRadius;
+    const beadRadius = Math.min(60, Math.max(5, radiusRaw !== null && radiusRaw !== void 0 ? radiusRaw : ADV.beadRadius));
+    return {
+      colors: colorsArr,
+      beadRadius
+    };
   });
-  if(!cfgBowls.length){
+  if (!cfgBowls.length) {
     cfgBowls.push({
       colors: Object.values(ADV.assets.beads),
-      beadRadius: Math.min(60, Math.max(5, globalRadius ?? ADV.beadRadius))
+      beadRadius: Math.min(60, Math.max(5, globalRadius !== null && globalRadius !== void 0 ? globalRadius : ADV.beadRadius))
     });
   }
   return {
@@ -66,14 +79,14 @@ let CFG = makeCFG();
 
 /* ============ DOM & VIEWBOX ============ */
 const SVG_IDS = ["bowlSVG1", "bowlSVG2"];
-const VB_W = 500, VB_H = 300;
+const VB_W = 500,
+  VB_H = 300;
 const figureViews = [];
 
 /* ============ STATE & INIT ============ */
-const STATE = (window.STATE && typeof window.STATE === "object") ? window.STATE : {};
+const STATE = window.STATE && typeof window.STATE === "object" ? window.STATE : {};
 window.STATE = STATE;
-if(!Array.isArray(STATE.bowls)) STATE.bowls = [];
-
+if (!Array.isArray(STATE.bowls)) STATE.bowls = [];
 const colors = Object.keys(ADV.assets.beads);
 const assetToColor = Object.entries(ADV.assets.beads).reduce((acc, [color, src]) => {
   acc[src] = color;
@@ -87,80 +100,88 @@ const removeBtn1 = document.getElementById("removeBowl1");
 const removeBtn2 = document.getElementById("removeBowl2");
 const exportToolbar2 = document.getElementById("exportToolbar2");
 const gridEl = document.querySelector(".grid");
-
 const initialSideWidth = (() => {
-  if(!gridEl) return 360;
+  if (!gridEl) return 360;
   const inlineVal = Number.parseFloat(gridEl.style.getPropertyValue("--side-width"));
-  if(Number.isFinite(inlineVal)) return inlineVal;
-  try{
+  if (Number.isFinite(inlineVal)) return inlineVal;
+  try {
     const computedVal = Number.parseFloat(getComputedStyle(gridEl).getPropertyValue("--side-width"));
-    if(Number.isFinite(computedVal)) return computedVal;
-  }catch(_){ }
+    if (Number.isFinite(computedVal)) return computedVal;
+  } catch (_) {}
   return 360;
 })();
-
 let lastShowSecond = null;
-
-if(!Array.isArray(SIMPLE.bowls)) SIMPLE.bowls = [];
-if(typeof STATE.figure2Visible !== "boolean"){
+if (!Array.isArray(SIMPLE.bowls)) SIMPLE.bowls = [];
+if (typeof STATE.figure2Visible !== "boolean") {
   STATE.figure2Visible = SIMPLE.bowls.length > 1;
 }
-
 SVG_IDS.forEach((id, idx) => {
   const svg = document.getElementById(id);
-  if(!svg) return;
+  if (!svg) return;
   svg.setAttribute("viewBox", `0 0 ${VB_W} ${VB_H}`);
   svg.innerHTML = "";
-  const gBowls = mk("g", { class: "bowls" });
+  const gBowls = mk("g", {
+    class: "bowls"
+  });
   svg.appendChild(gBowls);
   const fig = createFigure(idx, svg, gBowls);
   figureViews[idx] = fig;
 });
-
 render();
-
-addBtn?.addEventListener("click", () => {
+addBtn === null || addBtn === void 0 || addBtn.addEventListener("click", () => {
+  var _SIMPLE$beadRadius2;
   const first = ensureSimpleBowl(0);
   const copyCounts = colors.map(color => {
-    const entry = Array.isArray(first?.colorCounts) ? first.colorCounts.find(cc => cc.color === color) : null;
-    const count = Number.isFinite(entry?.count) ? Math.max(0, Math.round(entry.count)) : 0;
-    return { color, count };
+    const entry = Array.isArray(first === null || first === void 0 ? void 0 : first.colorCounts) ? first.colorCounts.find(cc => cc.color === color) : null;
+    const count = Number.isFinite(entry === null || entry === void 0 ? void 0 : entry.count) ? Math.max(0, Math.round(entry.count)) : 0;
+    return {
+      color,
+      count
+    };
   });
-  const radiusSource = Number.isFinite(first?.beadRadius) ? first.beadRadius : (SIMPLE.beadRadius ?? ADV.beadRadius);
-  SIMPLE.bowls[1] = { colorCounts: copyCounts, beadRadius: radiusSource };
+  const radiusSource = Number.isFinite(first === null || first === void 0 ? void 0 : first.beadRadius) ? first.beadRadius : (_SIMPLE$beadRadius2 = SIMPLE.beadRadius) !== null && _SIMPLE$beadRadius2 !== void 0 ? _SIMPLE$beadRadius2 : ADV.beadRadius;
+  SIMPLE.bowls[1] = {
+    colorCounts: copyCounts,
+    beadRadius: radiusSource
+  };
   STATE.figure2Visible = true;
   render();
 });
-
-removeBtn1?.addEventListener("click", () => {
+removeBtn1 === null || removeBtn1 === void 0 || removeBtn1.addEventListener("click", () => {
   removeBowl(0);
 });
-
-removeBtn2?.addEventListener("click", () => {
+removeBtn2 === null || removeBtn2 === void 0 || removeBtn2.addEventListener("click", () => {
   removeBowl(1);
 });
-
-const downloadButtons = [
-  { svgBtn: document.getElementById("downloadSVG1"), pngBtn: document.getElementById("downloadPNG1"), idx: 0 },
-  { svgBtn: document.getElementById("downloadSVG2"), pngBtn: document.getElementById("downloadPNG2"), idx: 1 }
-];
-downloadButtons.forEach(({ svgBtn, pngBtn, idx }) => {
-  svgBtn?.addEventListener("click", () => downloadSvgFigure(idx));
-  pngBtn?.addEventListener("click", () => downloadPngFigure(idx));
+const downloadButtons = [{
+  svgBtn: document.getElementById("downloadSVG1"),
+  pngBtn: document.getElementById("downloadPNG1"),
+  idx: 0
+}, {
+  svgBtn: document.getElementById("downloadSVG2"),
+  pngBtn: document.getElementById("downloadPNG2"),
+  idx: 1
+}];
+downloadButtons.forEach(({
+  svgBtn,
+  pngBtn,
+  idx
+}) => {
+  svgBtn === null || svgBtn === void 0 || svgBtn.addEventListener("click", () => downloadSvgFigure(idx));
+  pngBtn === null || pngBtn === void 0 || pngBtn.addEventListener("click", () => downloadPngFigure(idx));
 });
 
 /* ============ FUNKSJONER ============ */
-function createFigure(idx, svg, gBowls){
+function createFigure(idx, svg, gBowls) {
+  var _SIMPLE$beadRadius3, _SIMPLE$beadRadius4;
   const fieldset = document.createElement("fieldset");
   fieldset.className = "bowlFieldset";
   fieldset.id = `kuler${idx + 1}`;
   const legend = document.createElement("legend");
   legend.textContent = `Kuler ${idx + 1}`;
   fieldset.appendChild(legend);
-
   const counts = {};
   const displays = {};
-
   colors.forEach(color => {
     const row = document.createElement("div");
     row.className = "ctrlRow";
@@ -182,7 +203,6 @@ function createFigure(idx, svg, gBowls){
     displays[color] = countSpan;
     counts[color] = 0;
   });
-
   const sizeRow = document.createElement("div");
   sizeRow.className = "ctrlRow ctrlRow--size";
   const sizeLabel = document.createElement("span");
@@ -207,9 +227,7 @@ function createFigure(idx, svg, gBowls){
   sizeInput.addEventListener("input", () => setSize(idx, parseInt(sizeInput.value, 10)));
   sizeRow.append(sizeLabel, sizeMinus, sizeInput, sizePlus, sizeSpan);
   fieldset.appendChild(sizeRow);
-
-  controlsWrap?.appendChild(fieldset);
-
+  controlsWrap === null || controlsWrap === void 0 || controlsWrap.appendChild(fieldset);
   return {
     idx,
     svg,
@@ -219,179 +237,207 @@ function createFigure(idx, svg, gBowls){
     displays,
     sizeDisplay: sizeSpan,
     sizeSlider: sizeInput,
-    beadRadius: Math.min(60, Math.max(5, SIMPLE.beadRadius ?? ADV.beadRadius)),
-    renderRadius: Math.min(60, Math.max(5, SIMPLE.beadRadius ?? ADV.beadRadius))
+    beadRadius: Math.min(60, Math.max(5, (_SIMPLE$beadRadius3 = SIMPLE.beadRadius) !== null && _SIMPLE$beadRadius3 !== void 0 ? _SIMPLE$beadRadius3 : ADV.beadRadius)),
+    renderRadius: Math.min(60, Math.max(5, (_SIMPLE$beadRadius4 = SIMPLE.beadRadius) !== null && _SIMPLE$beadRadius4 !== void 0 ? _SIMPLE$beadRadius4 : ADV.beadRadius))
   };
 }
-
-function ensureSimpleBowl(idx){
-  if(!Array.isArray(SIMPLE.bowls)) SIMPLE.bowls = [];
-  const globalRadius = SIMPLE.beadRadius ?? ADV.beadRadius;
+function ensureSimpleBowl(idx) {
+  var _SIMPLE$beadRadius5;
+  if (!Array.isArray(SIMPLE.bowls)) SIMPLE.bowls = [];
+  const globalRadius = (_SIMPLE$beadRadius5 = SIMPLE.beadRadius) !== null && _SIMPLE$beadRadius5 !== void 0 ? _SIMPLE$beadRadius5 : ADV.beadRadius;
   let bowl = SIMPLE.bowls[idx];
-  if(!bowl || typeof bowl !== "object"){
+  if (!bowl || typeof bowl !== "object") {
     const template = idx > 0 ? ensureSimpleBowl(0) : null;
     const counts = new Map();
-    if(template && Array.isArray(template.colorCounts)){
+    if (template && Array.isArray(template.colorCounts)) {
       template.colorCounts.forEach(cc => {
-        const count = Number.isFinite(cc?.count) ? Math.max(0, Math.round(cc.count)) : 0;
+        const count = Number.isFinite(cc === null || cc === void 0 ? void 0 : cc.count) ? Math.max(0, Math.round(cc.count)) : 0;
         counts.set(cc.color, count);
       });
     }
-    const colorCounts = colors.map(color => ({ color, count: counts.get(color) ?? 0 }));
-    const radiusSource = Number.isFinite(template?.beadRadius) ? template.beadRadius : globalRadius;
-    bowl = { colorCounts, beadRadius: radiusSource };
+    const colorCounts = colors.map(color => {
+      var _counts$get;
+      return {
+        color,
+        count: (_counts$get = counts.get(color)) !== null && _counts$get !== void 0 ? _counts$get : 0
+      };
+    });
+    const radiusSource = Number.isFinite(template === null || template === void 0 ? void 0 : template.beadRadius) ? template.beadRadius : globalRadius;
+    bowl = {
+      colorCounts,
+      beadRadius: radiusSource
+    };
     SIMPLE.bowls[idx] = bowl;
-  }else{
+  } else {
     const counts = new Map();
     (bowl.colorCounts || []).forEach(cc => {
-      const count = Number.isFinite(cc?.count) ? Math.max(0, Math.round(cc.count)) : 0;
+      const count = Number.isFinite(cc === null || cc === void 0 ? void 0 : cc.count) ? Math.max(0, Math.round(cc.count)) : 0;
       counts.set(cc.color, count);
     });
-    bowl.colorCounts = colors.map(color => ({ color, count: counts.get(color) ?? 0 }));
+    bowl.colorCounts = colors.map(color => {
+      var _counts$get2;
+      return {
+        color,
+        count: (_counts$get2 = counts.get(color)) !== null && _counts$get2 !== void 0 ? _counts$get2 : 0
+      };
+    });
     const radiusSource = Number.isFinite(bowl.beadRadius) ? bowl.beadRadius : globalRadius;
     bowl.beadRadius = Math.min(60, Math.max(5, radiusSource));
   }
   return bowl;
 }
-
-function applySimpleToFigures(){
+function applySimpleToFigures() {
   figureViews.forEach(fig => {
-    if(!fig) return;
-    if(fig.idx > 0 && !STATE.figure2Visible && !SIMPLE.bowls[fig.idx]){
+    var _SIMPLE$beadRadius7;
+    if (!fig) return;
+    if (fig.idx > 0 && !STATE.figure2Visible && !SIMPLE.bowls[fig.idx]) {
+      var _SIMPLE$beadRadius6;
       const first = ensureSimpleBowl(0);
-      const radius = Math.min(60, Math.max(5, Number.isFinite(first?.beadRadius) ? first.beadRadius : (SIMPLE.beadRadius ?? ADV.beadRadius)));
+      const radius = Math.min(60, Math.max(5, Number.isFinite(first === null || first === void 0 ? void 0 : first.beadRadius) ? first.beadRadius : (_SIMPLE$beadRadius6 = SIMPLE.beadRadius) !== null && _SIMPLE$beadRadius6 !== void 0 ? _SIMPLE$beadRadius6 : ADV.beadRadius));
       fig.beadRadius = radius;
       fig.renderRadius = radius;
-      if(fig.sizeDisplay) fig.sizeDisplay.textContent = radius;
-      if(fig.sizeSlider) fig.sizeSlider.value = String(radius);
+      if (fig.sizeDisplay) fig.sizeDisplay.textContent = radius;
+      if (fig.sizeSlider) fig.sizeSlider.value = String(radius);
       colors.forEach(color => {
-        const entry = Array.isArray(first?.colorCounts) ? first.colorCounts.find(cc => cc.color === color) : null;
-        const count = Number.isFinite(entry?.count) ? Math.max(0, Math.round(entry.count)) : 0;
+        const entry = Array.isArray(first === null || first === void 0 ? void 0 : first.colorCounts) ? first.colorCounts.find(cc => cc.color === color) : null;
+        const count = Number.isFinite(entry === null || entry === void 0 ? void 0 : entry.count) ? Math.max(0, Math.round(entry.count)) : 0;
         fig.counts[color] = count;
-        if(fig.displays[color]) fig.displays[color].textContent = String(count);
+        if (fig.displays[color]) fig.displays[color].textContent = String(count);
       });
       return;
     }
     const bowl = ensureSimpleBowl(fig.idx);
-    const radius = Math.min(60, Math.max(5, Number.isFinite(bowl?.beadRadius) ? bowl.beadRadius : (SIMPLE.beadRadius ?? ADV.beadRadius)));
+    const radius = Math.min(60, Math.max(5, Number.isFinite(bowl === null || bowl === void 0 ? void 0 : bowl.beadRadius) ? bowl.beadRadius : (_SIMPLE$beadRadius7 = SIMPLE.beadRadius) !== null && _SIMPLE$beadRadius7 !== void 0 ? _SIMPLE$beadRadius7 : ADV.beadRadius));
     fig.beadRadius = radius;
     fig.renderRadius = radius;
-    if(fig.sizeDisplay) fig.sizeDisplay.textContent = radius;
-    if(fig.sizeSlider) fig.sizeSlider.value = String(radius);
+    if (fig.sizeDisplay) fig.sizeDisplay.textContent = radius;
+    if (fig.sizeSlider) fig.sizeSlider.value = String(radius);
     colors.forEach(color => {
       const entry = bowl.colorCounts.find(cc => cc.color === color);
-      const count = Number.isFinite(entry?.count) ? Math.max(0, Math.round(entry.count)) : 0;
+      const count = Number.isFinite(entry === null || entry === void 0 ? void 0 : entry.count) ? Math.max(0, Math.round(entry.count)) : 0;
       fig.counts[color] = count;
-      if(fig.displays[color]) fig.displays[color].textContent = String(count);
+      if (fig.displays[color]) fig.displays[color].textContent = String(count);
     });
   });
 }
-
-function syncSimpleFromFigures(){
+function syncSimpleFromFigures() {
   figureViews.forEach(fig => {
-    if(!fig) return;
-    if(fig.idx > 0 && !STATE.figure2Visible) return;
+    var _ref, _ref2, _fig$beadRadius;
+    if (!fig) return;
+    if (fig.idx > 0 && !STATE.figure2Visible) return;
     const bowl = ensureSimpleBowl(fig.idx);
     bowl.colorCounts = colors.map(color => {
       const value = Number.isFinite(fig.counts[color]) ? Math.max(0, Math.round(fig.counts[color])) : 0;
-      return { color, count: value };
+      return {
+        color,
+        count: value
+      };
     });
-    bowl.beadRadius = Math.min(60, Math.max(5, fig.beadRadius ?? bowl.beadRadius ?? SIMPLE.beadRadius ?? ADV.beadRadius));
+    bowl.beadRadius = Math.min(60, Math.max(5, (_ref = (_ref2 = (_fig$beadRadius = fig.beadRadius) !== null && _fig$beadRadius !== void 0 ? _fig$beadRadius : bowl.beadRadius) !== null && _ref2 !== void 0 ? _ref2 : SIMPLE.beadRadius) !== null && _ref !== void 0 ? _ref : ADV.beadRadius));
   });
-  if(figureViews[0]) SIMPLE.beadRadius = figureViews[0].beadRadius;
+  if (figureViews[0]) SIMPLE.beadRadius = figureViews[0].beadRadius;
 }
-
-function changeCount(idx, color, delta){
+function changeCount(idx, color, delta) {
   const fig = figureViews[idx];
-  if(!fig) return;
+  if (!fig) return;
   const current = Number.isFinite(fig.counts[color]) ? fig.counts[color] : 0;
   const next = Math.max(0, current + delta);
   fig.counts[color] = next;
-  if(fig.displays[color]) fig.displays[color].textContent = String(next);
+  if (fig.displays[color]) fig.displays[color].textContent = String(next);
   updateConfig();
 }
-
-function adjustSize(idx, delta){
+function adjustSize(idx, delta) {
   const fig = figureViews[idx];
-  if(!fig) return;
+  if (!fig) return;
   setSize(idx, fig.beadRadius + delta);
 }
-
-function setSize(idx, value){
+function setSize(idx, value) {
   const fig = figureViews[idx];
-  if(!fig) return;
+  if (!fig) return;
   const next = Math.min(60, Math.max(5, Number.isFinite(value) ? value : fig.beadRadius));
   fig.beadRadius = next;
-  if(fig.sizeDisplay) fig.sizeDisplay.textContent = next;
-  if(fig.sizeSlider && fig.sizeSlider.value !== String(next)) fig.sizeSlider.value = String(next);
+  if (fig.sizeDisplay) fig.sizeDisplay.textContent = next;
+  if (fig.sizeSlider && fig.sizeSlider.value !== String(next)) fig.sizeSlider.value = String(next);
   updateConfig();
 }
-
-function updateConfig(){
+function updateConfig() {
   syncSimpleFromFigures();
   render();
 }
-
-function removeBowl(idx){
-  if(idx < 0) return;
-  if(Array.isArray(SIMPLE.bowls)){
-    if(idx === 0){
-      if(SIMPLE.bowls.length <= 1) return;
+function removeBowl(idx) {
+  var _dragState$fig;
+  if (idx < 0) return;
+  if (Array.isArray(SIMPLE.bowls)) {
+    if (idx === 0) {
+      if (SIMPLE.bowls.length <= 1) return;
       SIMPLE.bowls.splice(0, 1);
-    }else{
+    } else {
       SIMPLE.bowls.splice(idx);
     }
   }
-  if(Array.isArray(STATE.bowls)){
-    if(idx === 0){
-      if(STATE.bowls.length > 1){
+  if (Array.isArray(STATE.bowls)) {
+    if (idx === 0) {
+      if (STATE.bowls.length > 1) {
         STATE.bowls.splice(0, 1);
-      }else if(STATE.bowls.length === 1){
+      } else if (STATE.bowls.length === 1) {
         STATE.bowls[0] = {};
       }
-    }else{
+    } else {
       STATE.bowls.splice(idx);
     }
   }
-  if(dragState && dragState.fig?.idx === idx){
-    const { fig, pointerId } = dragState;
-    if(fig?.svg){
+  if (dragState && ((_dragState$fig = dragState.fig) === null || _dragState$fig === void 0 ? void 0 : _dragState$fig.idx) === idx) {
+    const {
+      fig,
+      pointerId
+    } = dragState;
+    if (fig !== null && fig !== void 0 && fig.svg) {
       fig.svg.removeEventListener("pointermove", onDrag);
       fig.svg.removeEventListener("pointerup", endDrag);
       fig.svg.removeEventListener("pointercancel", endDrag);
-      try{ fig.svg.releasePointerCapture(pointerId); }catch(_){ }
+      try {
+        fig.svg.releasePointerCapture(pointerId);
+      } catch (_) {}
     }
     dragState = null;
   }
-  if(Array.isArray(SIMPLE.bowls) && SIMPLE.bowls.length === 0){
-    const fallback = colors.map(color => ({ color, count: 0 }));
-    SIMPLE.bowls.push({ colorCounts: fallback, beadRadius: SIMPLE.beadRadius ?? ADV.beadRadius });
+  if (Array.isArray(SIMPLE.bowls) && SIMPLE.bowls.length === 0) {
+    var _SIMPLE$beadRadius8;
+    const fallback = colors.map(color => ({
+      color,
+      count: 0
+    }));
+    SIMPLE.bowls.push({
+      colorCounts: fallback,
+      beadRadius: (_SIMPLE$beadRadius8 = SIMPLE.beadRadius) !== null && _SIMPLE$beadRadius8 !== void 0 ? _SIMPLE$beadRadius8 : ADV.beadRadius
+    });
   }
   STATE.figure2Visible = Array.isArray(SIMPLE.bowls) ? SIMPLE.bowls.length > 1 : false;
   render();
 }
-
-function render(){
-  if(typeof STATE.figure2Visible !== "boolean"){
+function render() {
+  if (typeof STATE.figure2Visible !== "boolean") {
     STATE.figure2Visible = SIMPLE.bowls.length > 1;
   }
   CFG = makeCFG();
   applySimpleToFigures();
-  if(STATE.bowls.length > CFG.bowls.length) STATE.bowls.length = CFG.bowls.length;
+  if (STATE.bowls.length > CFG.bowls.length) STATE.bowls.length = CFG.bowls.length;
   figureViews.forEach(fig => renderFigure(fig));
   applyFigureVisibility();
 }
-
-function renderFigure(fig){
-  if(!fig || !fig.svg) return;
+function renderFigure(fig) {
+  var _cfg$beadRadius, _ref3, _fig$beadRadius2;
+  if (!fig || !fig.svg) return;
   const idx = fig.idx;
   const cfg = CFG.bowls[idx];
   fig.gBowls.innerHTML = "";
-  if(!cfg) return;
-  const beadRadius = cfg.beadRadius ?? (fig.beadRadius ?? SIMPLE.beadRadius ?? ADV.beadRadius);
+  if (!cfg) return;
+  const beadRadius = (_cfg$beadRadius = cfg.beadRadius) !== null && _cfg$beadRadius !== void 0 ? _cfg$beadRadius : (_ref3 = (_fig$beadRadius2 = fig.beadRadius) !== null && _fig$beadRadius2 !== void 0 ? _fig$beadRadius2 : SIMPLE.beadRadius) !== null && _ref3 !== void 0 ? _ref3 : ADV.beadRadius;
   fig.renderRadius = beadRadius;
   const beadD = beadRadius * 2;
-  const g = mk("g", { class: "bowl" });
+  const g = mk("g", {
+    class: "bowl"
+  });
   const midX = VB_W / 2;
   const bowlSvgW = 273;
   const bowlSvgH = 251;
@@ -408,8 +454,9 @@ function renderFigure(fig){
     height: VB_H,
     preserveAspectRatio: "xMidYMax meet"
   });
-
-  const gBeads = mk("g", { class: "beads" });
+  const gBeads = mk("g", {
+    class: "beads"
+  });
   const nBeads = cfg.colors.length;
   const bowlState = getBowlState(idx);
   const colorPositions = bowlState.byColor;
@@ -423,25 +470,32 @@ function renderFigure(fig){
   const maxX = VB_W * 0.7;
   const minY = VB_H * 0.5;
   const maxY = VB_H * 0.9;
-  function randPos(){
+  function randPos() {
     let candidate = null;
-    for(let tries=0; tries<1000; tries++){
+    for (let tries = 0; tries < 1000; tries++) {
       const x = minX + Math.random() * (maxX - minX);
       const y = minY + Math.random() * (maxY - minY);
-      if(((x - cx) ** 2) / (rx ** 2) + ((y - cy) ** 2) / (ry ** 2) > 1) continue;
-      candidate = { x, y };
+      if ((x - cx) ** 2 / rx ** 2 + (y - cy) ** 2 / ry ** 2 > 1) continue;
+      candidate = {
+        x,
+        y
+      };
       const collision = placed.some(p => (p.x - candidate.x) ** 2 + (p.y - candidate.y) ** 2 < (beadD + CFG.beadGap) ** 2);
-      if(!collision) return candidate;
+      if (!collision) return candidate;
     }
-    return candidate || { x: cx, y: rimY + bowlDepth * 0.6 };
+    return candidate || {
+      x: cx,
+      y: rimY + bowlDepth * 0.6
+    };
   }
-  for(let i=0; i<nBeads; i++){
+  for (let i = 0; i < nBeads; i++) {
+    var _colorUsage$colorKey;
     const src = cfg.colors[i % cfg.colors.length];
     const colorKey = assetToColor[src] || src;
-    const useIdx = colorUsage[colorKey] ?? 0;
-    const arr = Array.isArray(colorPositions[colorKey]) ? colorPositions[colorKey] : (colorPositions[colorKey] = []);
+    const useIdx = (_colorUsage$colorKey = colorUsage[colorKey]) !== null && _colorUsage$colorKey !== void 0 ? _colorUsage$colorKey : 0;
+    const arr = Array.isArray(colorPositions[colorKey]) ? colorPositions[colorKey] : colorPositions[colorKey] = [];
     let pos = arr[useIdx];
-    if(!pos || !Number.isFinite(pos.x) || !Number.isFinite(pos.y)){
+    if (!pos || !Number.isFinite(pos.x) || !Number.isFinite(pos.y)) {
       pos = randPos();
       arr[useIdx] = pos;
     }
@@ -462,80 +516,76 @@ function renderFigure(fig){
     bead.addEventListener("pointerdown", startDrag);
     gBeads.appendChild(bead);
   }
-
   Object.keys(colorPositions).forEach(key => {
-    const used = colorUsage[key] ?? 0;
-    if(!Array.isArray(colorPositions[key])){
+    var _colorUsage$key;
+    const used = (_colorUsage$key = colorUsage[key]) !== null && _colorUsage$key !== void 0 ? _colorUsage$key : 0;
+    if (!Array.isArray(colorPositions[key])) {
       colorPositions[key] = [];
-    }else if(colorPositions[key].length > used){
+    } else if (colorPositions[key].length > used) {
       colorPositions[key].length = used;
     }
   });
-
   g.appendChild(bowlImg);
   g.appendChild(gBeads);
   fig.gBowls.appendChild(g);
 }
-
-function applyFigureVisibility(){
+function applyFigureVisibility() {
+  var _figureViews$;
   const secondExists = !!figureViews[1];
   const showSecond = !!STATE.figure2Visible && secondExists;
   const firstExists = !!figureViews[0];
-  const figureCount = firstExists ? (showSecond ? 2 : 1) : 0;
+  const figureCount = firstExists ? showSecond ? 2 : 1 : 0;
   const addVisible = !showSecond && secondExists;
-  if(figureGridEl){
-    if(figureCount > 0){
+  if (figureGridEl) {
+    if (figureCount > 0) {
       figureGridEl.dataset.figures = String(figureCount);
-    }else{
+    } else {
       delete figureGridEl.dataset.figures;
     }
-    if(addVisible){
+    if (addVisible) {
       figureGridEl.dataset.addVisible = "true";
-    }else{
+    } else {
       delete figureGridEl.dataset.addVisible;
     }
   }
-  if(controlsWrap) controlsWrap.classList.toggle("controlsWrap--split", showSecond);
-  if(gridEl && showSecond !== lastShowSecond){
-    if(showSecond){
+  if (controlsWrap) controlsWrap.classList.toggle("controlsWrap--split", showSecond);
+  if (gridEl && showSecond !== lastShowSecond) {
+    if (showSecond) {
       const current = Number.parseFloat(gridEl.style.getPropertyValue("--side-width"));
       const base = Number.isFinite(current) ? current : initialSideWidth;
       const desired = Math.max(base, 500);
       gridEl.style.setProperty("--side-width", `${desired}px`);
-    }else{
+    } else {
       gridEl.style.setProperty("--side-width", `${initialSideWidth}px`);
     }
   }
   lastShowSecond = showSecond;
-  if(addBtn) addBtn.style.display = addVisible ? "" : "none";
-  if(panelEls[1]) panelEls[1].style.display = showSecond ? "" : "none";
-  if(exportToolbar2) exportToolbar2.style.display = showSecond ? "" : "none";
-  if(figureViews[1]?.fieldset) figureViews[1].fieldset.style.display = showSecond ? "" : "none";
-  if(removeBtn1){
+  if (addBtn) addBtn.style.display = addVisible ? "" : "none";
+  if (panelEls[1]) panelEls[1].style.display = showSecond ? "" : "none";
+  if (exportToolbar2) exportToolbar2.style.display = showSecond ? "" : "none";
+  if ((_figureViews$ = figureViews[1]) !== null && _figureViews$ !== void 0 && _figureViews$.fieldset) figureViews[1].fieldset.style.display = showSecond ? "" : "none";
+  if (removeBtn1) {
     const extraBowl = Array.isArray(SIMPLE.bowls) ? SIMPLE.bowls.length > 1 : false;
     removeBtn1.disabled = !(showSecond && extraBowl);
   }
 }
-
-function getBowlState(idx){
-  if(!STATE.bowls[idx] || typeof STATE.bowls[idx] !== "object" || Array.isArray(STATE.bowls[idx])){
+function getBowlState(idx) {
+  if (!STATE.bowls[idx] || typeof STATE.bowls[idx] !== "object" || Array.isArray(STATE.bowls[idx])) {
     STATE.bowls[idx] = {};
   }
   const bowlState = STATE.bowls[idx];
-  if(!bowlState.byColor || typeof bowlState.byColor !== "object"){
+  if (!bowlState.byColor || typeof bowlState.byColor !== "object") {
     bowlState.byColor = {};
   }
   return bowlState;
 }
-
 let dragState = null;
-
-function startDrag(e){
+function startDrag(e) {
   const bead = e.target;
-  if(!bead || typeof bead.getAttribute !== "function") return;
+  if (!bead || typeof bead.getAttribute !== "function") return;
   const figIdx = Number.parseInt(bead.dataset.figure, 10);
   const fig = figureViews[figIdx];
-  if(!fig || !fig.svg) return;
+  if (!fig || !fig.svg) return;
   const bowlIdx = Number.parseInt(bead.dataset.bowl, 10);
   const colorIdx = Number.parseInt(bead.dataset.colorIndex, 10);
   const colorKey = bead.dataset.color;
@@ -549,62 +599,90 @@ function startDrag(e){
   const y = parseFloat(bead.getAttribute("y"));
   const offsetX = pt.x - x;
   const offsetY = pt.y - y;
-  dragState = { bead, fig, info, offsetX, offsetY, pointerId: e.pointerId };
+  dragState = {
+    bead,
+    fig,
+    info,
+    offsetX,
+    offsetY,
+    pointerId: e.pointerId
+  };
   fig.svg.addEventListener("pointermove", onDrag);
   fig.svg.addEventListener("pointerup", endDrag);
   fig.svg.addEventListener("pointercancel", endDrag);
-  try{ fig.svg.setPointerCapture(e.pointerId); }catch(_){ }
+  try {
+    fig.svg.setPointerCapture(e.pointerId);
+  } catch (_) {}
 }
-
-function onDrag(e){
-  if(!dragState) return;
-  const { bead, fig, offsetX, offsetY } = dragState;
+function onDrag(e) {
+  if (!dragState) return;
+  const {
+    bead,
+    fig,
+    offsetX,
+    offsetY
+  } = dragState;
   const pt = svgPoint(fig.svg, e);
   bead.setAttribute("x", pt.x - offsetX);
   bead.setAttribute("y", pt.y - offsetY);
   storeDragPosition();
 }
-
-function endDrag(e){
-  if(!dragState) return;
-  const { fig, pointerId } = dragState;
+function endDrag(e) {
+  if (!dragState) return;
+  const {
+    fig,
+    pointerId
+  } = dragState;
   fig.svg.removeEventListener("pointermove", onDrag);
   fig.svg.removeEventListener("pointerup", endDrag);
   fig.svg.removeEventListener("pointercancel", endDrag);
-  try{ fig.svg.releasePointerCapture(pointerId); }catch(_){ }
+  try {
+    fig.svg.releasePointerCapture(pointerId);
+  } catch (_) {}
   storeDragPosition();
   dragState = null;
 }
-
-function storeDragPosition(){
-  if(!dragState) return;
-  const { bead, info, fig } = dragState;
-  const { bowlIdx, colorKey, colorIndex } = info;
-  if(bowlIdx == null || colorKey == null || colorIndex == null) return;
+function storeDragPosition() {
+  var _ref4, _fig$renderRadius, _SIMPLE$beadRadius9;
+  if (!dragState) return;
+  const {
+    bead,
+    info,
+    fig
+  } = dragState;
+  const {
+    bowlIdx,
+    colorKey,
+    colorIndex
+  } = info;
+  if (bowlIdx == null || colorKey == null || colorIndex == null) return;
   const x = parseFloat(bead.getAttribute("x"));
   const y = parseFloat(bead.getAttribute("y"));
-  if(!Number.isFinite(x) || !Number.isFinite(y)) return;
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return;
   const bowlState = getBowlState(bowlIdx);
   const colorPositions = bowlState.byColor;
-  const arr = Array.isArray(colorPositions[colorKey]) ? colorPositions[colorKey] : (colorPositions[colorKey] = []);
-  const radius = fig.renderRadius ?? fig.beadRadius ?? (SIMPLE.beadRadius ?? ADV.beadRadius);
-  arr[colorIndex] = { x: x + radius, y: y + radius };
+  const arr = Array.isArray(colorPositions[colorKey]) ? colorPositions[colorKey] : colorPositions[colorKey] = [];
+  const radius = (_ref4 = (_fig$renderRadius = fig.renderRadius) !== null && _fig$renderRadius !== void 0 ? _fig$renderRadius : fig.beadRadius) !== null && _ref4 !== void 0 ? _ref4 : (_SIMPLE$beadRadius9 = SIMPLE.beadRadius) !== null && _SIMPLE$beadRadius9 !== void 0 ? _SIMPLE$beadRadius9 : ADV.beadRadius;
+  arr[colorIndex] = {
+    x: x + radius,
+    y: y + radius
+  };
 }
-
-function svgPoint(svgEl, evt){
+function svgPoint(svgEl, evt) {
   const p = svgEl.createSVGPoint();
   p.x = evt.clientX;
   p.y = evt.clientY;
   return p.matrixTransform(svgEl.getScreenCTM().inverse());
 }
-
-async function downloadSvgFigure(idx){
+async function downloadSvgFigure(idx) {
   const fig = figureViews[idx];
-  if(!fig || !fig.svg) return;
+  if (!fig || !fig.svg) return;
   const clone = fig.svg.cloneNode(true);
   await inlineImages(clone);
   const data = new XMLSerializer().serializeToString(clone);
-  const blob = new Blob([data], { type: "image/svg+xml" });
+  const blob = new Blob([data], {
+    type: "image/svg+xml"
+  });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
@@ -612,14 +690,15 @@ async function downloadSvgFigure(idx){
   a.click();
   URL.revokeObjectURL(url);
 }
-
-async function downloadPngFigure(idx){
+async function downloadPngFigure(idx) {
   const fig = figureViews[idx];
-  if(!fig || !fig.svg) return;
+  if (!fig || !fig.svg) return;
   const clone = fig.svg.cloneNode(true);
   await inlineImages(clone);
   const data = new XMLSerializer().serializeToString(clone);
-  const svgBlob = new Blob([data], { type: "image/svg+xml" });
+  const svgBlob = new Blob([data], {
+    type: "image/svg+xml"
+  });
   const url = URL.createObjectURL(svgBlob);
   const img = new Image();
   img.onload = () => {
@@ -630,7 +709,7 @@ async function downloadPngFigure(idx){
     ctx.drawImage(img, 0, 0);
     URL.revokeObjectURL(url);
     canvas.toBlob(blob => {
-      if(!blob) return;
+      if (!blob) return;
       const pngUrl = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = pngUrl;
@@ -643,20 +722,19 @@ async function downloadPngFigure(idx){
 }
 
 /* ===== helpers ===== */
-function mk(n, attrs = {}){
+function mk(n, attrs = {}) {
   const e = document.createElementNS("http://www.w3.org/2000/svg", n);
-  for(const [k, v] of Object.entries(attrs)) e.setAttribute(k, v);
+  for (const [k, v] of Object.entries(attrs)) e.setAttribute(k, v);
   return e;
 }
-function cap(s){
+function cap(s) {
   return s[0].toUpperCase() + s.slice(1);
 }
-
-async function inlineImages(svgEl){
+async function inlineImages(svgEl) {
   const imgs = svgEl.querySelectorAll("image");
   await Promise.all(Array.from(imgs).map(async img => {
     const src = img.getAttribute("href");
-    if(!src) return;
+    if (!src) return;
     const res = await fetch(src);
     const blob = await res.blob();
     const dataUrl = await new Promise(resolve => {

--- a/kvikkbilder-monster.js
+++ b/kvikkbilder-monster.js
@@ -1,4 +1,4 @@
-(function(){
+(function () {
   const cfgAntallX = document.getElementById('cfg-antallX');
   const cfgAntallY = document.getElementById('cfg-antallY');
   const cfgAntall = document.getElementById('cfg-antall');
@@ -10,342 +10,329 @@
   const expression = document.getElementById('expression');
   const btnSvg = document.getElementById('btnSvg');
   const btnPng = document.getElementById('btnPng');
-
-  function primeFactors(n){
-    const factors=[];
-    let num=n;
-    let p=2;
-    while(num>1 && factors.length<6){
-      while(num%p===0 && factors.length<6){
+  function primeFactors(n) {
+    const factors = [];
+    let num = n;
+    let p = 2;
+    while (num > 1 && factors.length < 6) {
+      while (num % p === 0 && factors.length < 6) {
         factors.push(p);
-        num/=p;
+        num /= p;
       }
       p++;
     }
-    while(factors.length<6) factors.push(1);
+    while (factors.length < 6) factors.push(1);
     return factors;
   }
-
-  function computeKs(n,f){
-    const [f1,f2,f3,f4,f5,f6]=f;
-
-    let k1=(n<=9?0.5:1)/(f2*f3*f4*f5);
-    if(f3===2 && f4===2) k1*= (f5<3?0.25:0.5);
-    if(f4===2 && f5===2) k1*=0.5;
-    if(f1===2 && f2===2 && f3===2 && f4<3) k1*=2;
-    if(f1===2 && f2===2 && f3===2 && f4===2) k1*=2;
-    if(f3===3) k1*=f2/f1;
-    if(f1===f2 && f2===f3 && f3===f4 && f4===f5) k1*=2;
-    if(n===1) k1=0;
-
+  function computeKs(n, f) {
+    const [f1, f2, f3, f4, f5, f6] = f;
+    let k1 = (n <= 9 ? 0.5 : 1) / (f2 * f3 * f4 * f5);
+    if (f3 === 2 && f4 === 2) k1 *= f5 < 3 ? 0.25 : 0.5;
+    if (f4 === 2 && f5 === 2) k1 *= 0.5;
+    if (f1 === 2 && f2 === 2 && f3 === 2 && f4 < 3) k1 *= 2;
+    if (f1 === 2 && f2 === 2 && f3 === 2 && f4 === 2) k1 *= 2;
+    if (f3 === 3) k1 *= f2 / f1;
+    if (f1 === f2 && f2 === f3 && f3 === f4 && f4 === f5) k1 *= 2;
+    if (n === 1) k1 = 0;
     let k2;
-    if(f2===1) k2=1;
-    else if(f1===2 && f2===2) k2=k1;
-    else if(f3===1) k2=1-1/f2;
-    else if(f2===f1) k2=k1*f2;
-    else if(f3===f2 && f2===3) k2=k1*f1;
-    else if(f3===f2) k2=k1*f2;
-    else if(f1*f2===6 && f3<3) k2=k1*f3/f1;
-    else k2=1/(f3*f4*f5*f6);
-
+    if (f2 === 1) k2 = 1;else if (f1 === 2 && f2 === 2) k2 = k1;else if (f3 === 1) k2 = 1 - 1 / f2;else if (f2 === f1) k2 = k1 * f2;else if (f3 === f2 && f2 === 3) k2 = k1 * f1;else if (f3 === f2) k2 = k1 * f2;else if (f1 * f2 === 6 && f3 < 3) k2 = k1 * f3 / f1;else k2 = 1 / (f3 * f4 * f5 * f6);
     let k3;
-    if(f3===1) k3=1;
-    else {
-      if(f4===1) k3=1-k1;
-      else{
-        k3=1;
-        if(f2*f3===4 && f5===1) k3*=Math.max(f1,f2,f3,f4,f5,f6)/f1;
-        if(f1*f2*f3===8 && f6===1) k3*=1/f2;
-        if(f1===2 && f2===2 && f3===2 && f4===2) k3*=2;
-        k3*=1/(f4*f5);
+    if (f3 === 1) k3 = 1;else {
+      if (f4 === 1) k3 = 1 - k1;else {
+        k3 = 1;
+        if (f2 * f3 === 4 && f5 === 1) k3 *= Math.max(f1, f2, f3, f4, f5, f6) / f1;
+        if (f1 * f2 * f3 === 8 && f6 === 1) k3 *= 1 / f2;
+        if (f1 === 2 && f2 === 2 && f3 === 2 && f4 === 2) k3 *= 2;
+        k3 *= 1 / (f4 * f5);
       }
-      k3*=1/f6;
+      k3 *= 1 / f6;
     }
-    if(f1*f2*f3*f4===16 && f5>2) k3*=2;
-
+    if (f1 * f2 * f3 * f4 === 16 && f5 > 2) k3 *= 2;
     let k4;
-    if(f4===1) k4=1;
-    else if(f5===1 && f1*f2===4) k4=1-k3;
-    else if(f5===1) k4=1-k1;
-    else k4=1/(f5*f6);
-
+    if (f4 === 1) k4 = 1;else if (f5 === 1 && f1 * f2 === 4) k4 = 1 - k3;else if (f5 === 1) k4 = 1 - k1;else k4 = 1 / (f5 * f6);
     let k5;
-    if(f5===1) k5=1;
-    else if(f6===1){
-      const mul=(f1===2&&f2===2&&f3===2&&f4===2)?0.5:1;
-      k5=1-mul*k3;
-    }else{
-      k5=1/f6;
+    if (f5 === 1) k5 = 1;else if (f6 === 1) {
+      const mul = f1 === 2 && f2 === 2 && f3 === 2 && f4 === 2 ? 0.5 : 1;
+      k5 = 1 - mul * k3;
+    } else {
+      k5 = 1 / f6;
     }
-
-    const k6 = f6===1?1:1-k3;
-
-    return [k1,k2,k3,k4,k5,k6];
+    const k6 = f6 === 1 ? 1 : 1 - k3;
+    return [k1, k2, k3, k4, k5, k6];
   }
-
-  function rotate(points,ang){
-    const ca=Math.cos(ang), sa=Math.sin(ang);
-    return points.map(p=>({x:p.x*ca-p.y*sa,y:p.x*sa+p.y*ca}));
+  function rotate(points, ang) {
+    const ca = Math.cos(ang),
+      sa = Math.sin(ang);
+    return points.map(p => ({
+      x: p.x * ca - p.y * sa,
+      y: p.x * sa + p.y * ca
+    }));
   }
-
-  function translate(points,tx,ty){
-    return points.map(p=>({x:p.x+tx,y:p.y+ty}));
+  function translate(points, tx, ty) {
+    return points.map(p => ({
+      x: p.x + tx,
+      y: p.y + ty
+    }));
   }
-
-  function buildLevel(prev,factor,r){
-    if(factor===1) return prev;
-    const res=[];
-    for(let i=0;i<factor;i++){
-      const ang=-2*Math.PI*i/factor;
-      const rotated=rotate(prev,ang);
-      const a=2*Math.PI*i/factor;
-      let tx,ty;
-      if(factor===2){
-        tx=r*Math.cos(a); ty=r*Math.sin(a);
-      }else{
-        tx=r*Math.sin(a); ty=r*Math.cos(a);
+  function buildLevel(prev, factor, r) {
+    if (factor === 1) return prev;
+    const res = [];
+    for (let i = 0; i < factor; i++) {
+      const ang = -2 * Math.PI * i / factor;
+      const rotated = rotate(prev, ang);
+      const a = 2 * Math.PI * i / factor;
+      let tx, ty;
+      if (factor === 2) {
+        tx = r * Math.cos(a);
+        ty = r * Math.sin(a);
+      } else {
+        tx = r * Math.sin(a);
+        ty = r * Math.cos(a);
       }
-      res.push(...translate(rotated,tx,ty));
+      res.push(...translate(rotated, tx, ty));
     }
     return res;
   }
-
-  function byggMonster(n){
-    if(n<=0) return [];
-    const f=primeFactors(n);
-    const ks=computeKs(n,f);
-    let pts=[];
-    const f1=f[0];
-    for(let i=0;i<f1;i++){
-      const ang=2*Math.PI*i/f1;
-      pts.push({x:ks[0]*Math.sin(ang), y:ks[0]*Math.cos(ang)});
+  function byggMonster(n) {
+    if (n <= 0) return [];
+    const f = primeFactors(n);
+    const ks = computeKs(n, f);
+    let pts = [];
+    const f1 = f[0];
+    for (let i = 0; i < f1; i++) {
+      const ang = 2 * Math.PI * i / f1;
+      pts.push({
+        x: ks[0] * Math.sin(ang),
+        y: ks[0] * Math.cos(ang)
+      });
     }
-    pts=buildLevel(pts,f[1],ks[1]);
-    pts=buildLevel(pts,f[2],ks[2]);
-    pts=buildLevel(pts,f[3],ks[3]);
-    pts=buildLevel(pts,f[4],ks[4]);
-    pts=buildLevel(pts,f[5],ks[5]);
-    const scale=0.3;
-    return pts.map(p=>({x:p.x*scale,y:p.y*scale}));
+    pts = buildLevel(pts, f[1], ks[1]);
+    pts = buildLevel(pts, f[2], ks[2]);
+    pts = buildLevel(pts, f[3], ks[3]);
+    pts = buildLevel(pts, f[4], ks[4]);
+    pts = buildLevel(pts, f[5], ks[5]);
+    const scale = 0.3;
+    return pts.map(p => ({
+      x: p.x * scale,
+      y: p.y * scale
+    }));
   }
-
-  function createPatternSvg(points){
-    if(!points.length) return null;
-
-    const radius=10;
-    const spacing=3;
-    const desiredCenterDistance=radius*2+spacing;
-
-    const seen=new Set();
-    const uniquePoints=[];
-    const precision=1e4;
-    points.forEach(p=>{
-      const key=`${Math.round(p.x*precision)}:${Math.round(p.y*precision)}`;
-      if(!seen.has(key)){
+  function createPatternSvg(points) {
+    if (!points.length) return null;
+    const radius = 10;
+    const spacing = 3;
+    const desiredCenterDistance = radius * 2 + spacing;
+    const seen = new Set();
+    const uniquePoints = [];
+    const precision = 1e4;
+    points.forEach(p => {
+      const key = `${Math.round(p.x * precision)}:${Math.round(p.y * precision)}`;
+      if (!seen.has(key)) {
         seen.add(key);
         uniquePoints.push(p);
       }
     });
-
-    let minDist=Infinity;
-    for(let i=0;i<uniquePoints.length;i++){
-      for(let j=i+1;j<uniquePoints.length;j++){
-        const dx=uniquePoints[i].x-uniquePoints[j].x;
-        const dy=uniquePoints[i].y-uniquePoints[j].y;
-        const dist=Math.hypot(dx,dy);
-        if(dist>0 && dist<minDist) minDist=dist;
+    let minDist = Infinity;
+    for (let i = 0; i < uniquePoints.length; i++) {
+      for (let j = i + 1; j < uniquePoints.length; j++) {
+        const dx = uniquePoints[i].x - uniquePoints[j].x;
+        const dy = uniquePoints[i].y - uniquePoints[j].y;
+        const dist = Math.hypot(dx, dy);
+        if (dist > 0 && dist < minDist) minDist = dist;
       }
     }
-    if(!Number.isFinite(minDist) || minDist<=0) minDist=desiredCenterDistance;
-    let scale=desiredCenterDistance/minDist;
-    if(!Number.isFinite(scale) || scale<=0) scale=1;
-    else if(scale<1) scale=1;
-
-    const scaledPoints=points.map(p=>({x:p.x*scale,y:p.y*scale}));
-
-    let minX=Infinity,maxX=-Infinity,minY=Infinity,maxY=-Infinity;
-    scaledPoints.forEach(({x,y})=>{
-      if(x<minX) minX=x;
-      if(x>maxX) maxX=x;
-      if(y<minY) minY=y;
-      if(y>maxY) maxY=y;
+    if (!Number.isFinite(minDist) || minDist <= 0) minDist = desiredCenterDistance;
+    let scale = desiredCenterDistance / minDist;
+    if (!Number.isFinite(scale) || scale <= 0) scale = 1;else if (scale < 1) scale = 1;
+    const scaledPoints = points.map(p => ({
+      x: p.x * scale,
+      y: p.y * scale
+    }));
+    let minX = Infinity,
+      maxX = -Infinity,
+      minY = Infinity,
+      maxY = -Infinity;
+    scaledPoints.forEach(({
+      x,
+      y
+    }) => {
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
     });
-
-    const pad=radius+spacing;
-    const contentWidth=maxX-minX;
-    const contentHeight=maxY-minY;
-    const baseW=contentWidth+pad*2;
-    const baseH=contentHeight+pad*2;
-    const minSize=radius*4;
-    const vbW=Math.max(baseW,minSize);
-    const vbH=Math.max(baseH,minSize);
-    const extraX=(vbW-baseW)/2;
-    const extraY=(vbH-baseH)/2;
-    const offsetX=pad+extraX-minX;
-    const offsetY=pad+extraY-minY;
-
-    const svgNS='http://www.w3.org/2000/svg';
-    const svg=document.createElementNS(svgNS,'svg');
+    const pad = radius + spacing;
+    const contentWidth = maxX - minX;
+    const contentHeight = maxY - minY;
+    const baseW = contentWidth + pad * 2;
+    const baseH = contentHeight + pad * 2;
+    const minSize = radius * 4;
+    const vbW = Math.max(baseW, minSize);
+    const vbH = Math.max(baseH, minSize);
+    const extraX = (vbW - baseW) / 2;
+    const extraY = (vbH - baseH) / 2;
+    const offsetX = pad + extraX - minX;
+    const offsetY = pad + extraY - minY;
+    const svgNS = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(svgNS, 'svg');
     svg.setAttribute('viewBox', `0 0 ${vbW} ${vbH}`);
     svg.setAttribute('width', '100%');
     svg.setAttribute('height', '100%');
-    svg.setAttribute('preserveAspectRatio','xMidYMid meet');
-
-    scaledPoints.forEach(({x,y})=>{
-      const c=document.createElementNS(svgNS,'circle');
-      c.setAttribute('cx', x+offsetX);
-      c.setAttribute('cy', y+offsetY);
+    svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+    scaledPoints.forEach(({
+      x,
+      y
+    }) => {
+      const c = document.createElementNS(svgNS, 'circle');
+      c.setAttribute('cx', x + offsetX);
+      c.setAttribute('cy', y + offsetY);
       c.setAttribute('r', radius);
       c.setAttribute('fill', '#534477');
       svg.appendChild(c);
     });
-
     return svg;
   }
-
-  function render(){
-    const n=parseInt(cfgAntall.value,10)||0;
-    const antallX=parseInt(cfgAntallX.value,10)||0;
-    const antallY=parseInt(cfgAntallY.value,10)||0;
-    patternContainer.innerHTML='';
-
-    const cols=antallX>0?antallX:1;
-    const rows=antallY>0?antallY:1;
-    patternContainer.style.gridTemplateColumns=`repeat(${cols},minmax(0,1fr))`;
-    patternContainer.style.gridTemplateRows=`repeat(${rows},minmax(0,1fr))`;
-    const maxDimension=Math.max(cols,rows);
-    const gapPx=maxDimension<=1?64:maxDimension===2?56:maxDimension===3?44:maxDimension===4?36:28;
-    const itemPaddingPx=Math.min(72,Math.max(18,Math.round(gapPx*0.65)));
-    const containerPaddingPx=Math.min(48,Math.max(12,Math.round(gapPx*0.4)));
-    patternContainer.style.setProperty('--pattern-gap',`${gapPx}px`);
-    patternContainer.style.setProperty('--pattern-item-padding',`${itemPaddingPx}px`);
-    patternContainer.style.setProperty('--pattern-padding',`${containerPaddingPx}px`);
-
-    const points=byggMonster(n);
-    const factors=primeFactors(n).filter(x=>x>1);
-    const baseExpression=factors.length?`${factors.join(' · ')} = ${n}`:`${n}`;
-
-    if(!points.length || antallX<=0 || antallY<=0){
-      expression.textContent=baseExpression;
+  function render() {
+    const n = parseInt(cfgAntall.value, 10) || 0;
+    const antallX = parseInt(cfgAntallX.value, 10) || 0;
+    const antallY = parseInt(cfgAntallY.value, 10) || 0;
+    patternContainer.innerHTML = '';
+    const cols = antallX > 0 ? antallX : 1;
+    const rows = antallY > 0 ? antallY : 1;
+    patternContainer.style.gridTemplateColumns = `repeat(${cols},minmax(0,1fr))`;
+    patternContainer.style.gridTemplateRows = `repeat(${rows},minmax(0,1fr))`;
+    const maxDimension = Math.max(cols, rows);
+    const gapPx = maxDimension <= 1 ? 64 : maxDimension === 2 ? 56 : maxDimension === 3 ? 44 : maxDimension === 4 ? 36 : 28;
+    const itemPaddingPx = Math.min(72, Math.max(18, Math.round(gapPx * 0.65)));
+    const containerPaddingPx = Math.min(48, Math.max(12, Math.round(gapPx * 0.4)));
+    patternContainer.style.setProperty('--pattern-gap', `${gapPx}px`);
+    patternContainer.style.setProperty('--pattern-item-padding', `${itemPaddingPx}px`);
+    patternContainer.style.setProperty('--pattern-padding', `${containerPaddingPx}px`);
+    const points = byggMonster(n);
+    const factors = primeFactors(n).filter(x => x > 1);
+    const baseExpression = factors.length ? `${factors.join(' · ')} = ${n}` : `${n}`;
+    if (!points.length || antallX <= 0 || antallY <= 0) {
+      expression.textContent = baseExpression;
       return;
     }
-
-    const svg=createPatternSvg(points);
-    if(!svg){
-      expression.textContent=baseExpression;
+    const svg = createPatternSvg(points);
+    if (!svg) {
+      expression.textContent = baseExpression;
       return;
     }
-
-    const totalFigures=antallX*antallY;
+    const totalFigures = antallX * antallY;
     svg.setAttribute('aria-label', `Kvikkbilde ${n}`);
-    for(let i=0;i<totalFigures;i++){
-      const wrapper=document.createElement('div');
-      wrapper.className='pattern-item';
+    for (let i = 0; i < totalFigures; i++) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'pattern-item';
       wrapper.appendChild(svg.cloneNode(true));
       patternContainer.appendChild(wrapper);
     }
-
-    if(totalFigures>1){
-      expression.textContent=`${antallX} · ${antallY} · (${baseExpression}) = ${totalFigures} · ${n} = ${totalFigures*n}`;
-    }else{
-      expression.textContent=baseExpression;
+    if (totalFigures > 1) {
+      expression.textContent = `${antallX} · ${antallY} · (${baseExpression}) = ${totalFigures} · ${n} = ${totalFigures * n}`;
+    } else {
+      expression.textContent = baseExpression;
     }
   }
-
-  function applyExpressionVisibility(){
-    if(!expression) return;
+  function applyExpressionVisibility() {
+    if (!expression) return;
     const enabled = !cfgShowExpression || cfgShowExpression.checked;
     const playVisible = playBtn.style.display !== 'none';
-    expression.style.display = (enabled && !playVisible) ? 'block' : 'none';
+    expression.style.display = enabled && !playVisible ? 'block' : 'none';
   }
-
-  function updateVisibility(){
-    if(cfgShowBtn.checked){
-      playBtn.style.display='flex';
-      patternContainer.style.display='none';
-    }else{
-      playBtn.style.display='none';
-      patternContainer.style.display='grid';
+  function updateVisibility() {
+    if (cfgShowBtn.checked) {
+      playBtn.style.display = 'flex';
+      patternContainer.style.display = 'none';
+    } else {
+      playBtn.style.display = 'none';
+      patternContainer.style.display = 'grid';
     }
     applyExpressionVisibility();
   }
-
-  [cfgAntall,cfgAntallX,cfgAntallY].forEach(el=>{
-    el?.addEventListener('input',render);
+  [cfgAntall, cfgAntallX, cfgAntallY].forEach(el => {
+    el === null || el === void 0 || el.addEventListener('input', render);
   });
   cfgShowBtn.addEventListener('change', () => {
     updateVisibility();
-    if(!cfgShowBtn.checked) render();
+    if (!cfgShowBtn.checked) render();
   });
-  cfgShowExpression?.addEventListener('change', applyExpressionVisibility);
-
-  playBtn.addEventListener('click',()=>{
-    const duration=parseInt(cfgDuration.value,10)||0;
+  cfgShowExpression === null || cfgShowExpression === void 0 || cfgShowExpression.addEventListener('change', applyExpressionVisibility);
+  playBtn.addEventListener('click', () => {
+    const duration = parseInt(cfgDuration.value, 10) || 0;
     render();
-    playBtn.style.display='none';
-    patternContainer.style.display='grid';
+    playBtn.style.display = 'none';
+    patternContainer.style.display = 'grid';
     applyExpressionVisibility();
-    setTimeout(()=>{
+    setTimeout(() => {
       updateVisibility();
-    }, duration*1000);
+    }, duration * 1000);
   });
-  btnSvg?.addEventListener('click', ()=>{
+  btnSvg === null || btnSvg === void 0 || btnSvg.addEventListener('click', () => {
     const svg = patternContainer.querySelector('svg');
-    if(svg) downloadSVG(svg, 'kvikkbilder-monster.svg');
+    if (svg) downloadSVG(svg, 'kvikkbilder-monster.svg');
   });
-  btnPng?.addEventListener('click', ()=>{
+  btnPng === null || btnPng === void 0 || btnPng.addEventListener('click', () => {
     const svg = patternContainer.querySelector('svg');
-    if(svg) downloadPNG(svg, 'kvikkbilder-monster.png', 2);
+    if (svg) downloadPNG(svg, 'kvikkbilder-monster.png', 2);
   });
   updateVisibility();
   render();
   applyExpressionVisibility();
-
-  function svgToString(svgEl){
+  function svgToString(svgEl) {
     const clone = svgEl.cloneNode(true);
     const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
     const style = document.createElement('style');
     style.textContent = css;
     clone.insertBefore(style, clone.firstChild);
-    clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
-    clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
   }
-  function downloadSVG(svgEl, filename){
+  function downloadSVG(svgEl, filename) {
     const data = svgToString(svgEl);
-    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const blob = new Blob([data], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
     a.download = filename.endsWith('.svg') ? filename : filename + '.svg';
-    document.body.appendChild(a); a.click(); a.remove();
-    setTimeout(()=>URL.revokeObjectURL(url),1000);
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
-  function downloadPNG(svgEl, filename, scale=2, bg='#fff'){
-    const vb = svgEl.viewBox?.baseVal;
-    const w = vb?.width || svgEl.clientWidth || 420;
-    const h = vb?.height|| svgEl.clientHeight || 420;
+  function downloadPNG(svgEl, filename, scale = 2, bg = '#fff') {
+    var _svgEl$viewBox;
+    const vb = (_svgEl$viewBox = svgEl.viewBox) === null || _svgEl$viewBox === void 0 ? void 0 : _svgEl$viewBox.baseVal;
+    const w = (vb === null || vb === void 0 ? void 0 : vb.width) || svgEl.clientWidth || 420;
+    const h = (vb === null || vb === void 0 ? void 0 : vb.height) || svgEl.clientHeight || 420;
     const data = svgToString(svgEl);
-    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
-    const url  = URL.createObjectURL(blob);
+    const blob = new Blob([data], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
+    const url = URL.createObjectURL(blob);
     const img = new Image();
-    img.onload = ()=>{
+    img.onload = () => {
       const canvas = document.createElement('canvas');
-      canvas.width  = Math.round(w * scale);
+      canvas.width = Math.round(w * scale);
       canvas.height = Math.round(h * scale);
       const ctx = canvas.getContext('2d');
       ctx.fillStyle = bg;
-      ctx.fillRect(0,0,canvas.width,canvas.height);
-      ctx.drawImage(img,0,0,canvas.width,canvas.height);
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
       URL.revokeObjectURL(url);
-      canvas.toBlob(blob=>{
+      canvas.toBlob(blob => {
         const urlPng = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = urlPng;
         a.download = filename.endsWith('.png') ? filename : filename + '.png';
-        document.body.appendChild(a); a.click(); a.remove();
-        setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
-      },'image/png');
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(urlPng), 1000);
+      }, 'image/png');
     };
     img.src = url;
   }

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -1,8 +1,7 @@
-(function(){
+(function () {
   const cfgType = document.getElementById('cfg-type');
   const klosserConfig = document.getElementById('klosserConfig');
   const monsterConfig = document.getElementById('monsterConfig');
-
   const cfgAntallX = document.getElementById('cfg-antallX');
   const cfgAntallY = document.getElementById('cfg-antallY');
   const cfgBredde = document.getElementById('cfg-bredde');
@@ -11,22 +10,18 @@
   const cfgDurationKlosser = document.getElementById('cfg-duration-klosser');
   const cfgShowBtn = document.getElementById('cfg-showBtn');
   const cfgShowExpression = document.getElementById('cfg-show-expression');
-
   const cfgMonsterAntallX = document.getElementById('cfg-monster-antallX');
   const cfgMonsterAntallY = document.getElementById('cfg-monster-antallY');
   const cfgAntall = document.getElementById('cfg-antall');
   const cfgDurationMonster = document.getElementById('cfg-duration-monster');
   const cfgShowBtnMonster = document.getElementById('cfg-showBtn-monster');
-
   const brickContainer = document.getElementById('brickContainer');
   const patternContainer = document.getElementById('patternContainer');
   const playBtn = document.getElementById('playBtn');
   const expression = document.getElementById('expression');
   const btnSvg = document.getElementById('btnSvg');
   const btnPng = document.getElementById('btnPng');
-
   let BRICK_SRC;
-
   const DEFAULT_CFG = {
     type: 'klosser',
     showExpression: true,
@@ -47,121 +42,113 @@
       showBtn: false
     }
   };
-
-  function deepClone(value){
-    if(value == null) return value;
-    if(typeof structuredClone === 'function'){
-      try{
+  function deepClone(value) {
+    if (value == null) return value;
+    if (typeof structuredClone === 'function') {
+      try {
         return structuredClone(value);
-      }catch(_){ }
+      } catch (_) {}
     }
-    try{
+    try {
       return JSON.parse(JSON.stringify(value));
-    }catch(_){
+    } catch (_) {
       return value;
     }
   }
-
-  function createExampleCfg(overrides){
+  function createExampleCfg(overrides) {
     const base = deepClone(DEFAULT_CFG) || {};
     const normalized = overrides && typeof overrides === 'object' ? overrides : {};
-    if(typeof normalized.type === 'string'){
+    if (typeof normalized.type === 'string') {
       base.type = normalized.type === 'monster' ? 'monster' : 'klosser';
     }
-    if(Object.prototype.hasOwnProperty.call(normalized, 'showExpression')){
+    if (Object.prototype.hasOwnProperty.call(normalized, 'showExpression')) {
       base.showExpression = normalized.showExpression !== false;
     }
-    if(normalized.klosser && typeof normalized.klosser === 'object'){
+    if (normalized.klosser && typeof normalized.klosser === 'object') {
       base.klosser = Object.assign({}, base.klosser, normalized.klosser);
     }
-    if(normalized.monster && typeof normalized.monster === 'object'){
+    if (normalized.monster && typeof normalized.monster === 'object') {
       base.monster = Object.assign({}, base.monster, normalized.monster);
     }
     return base;
   }
-
-  const DEFAULT_KVIKKBILDER_EXAMPLES = [
-    {
-      id: 'kvikkbilder-klosser-1',
-      exampleNumber: '1',
-      title: '4 · 2 · (2 · 3 · 2)',
-      isDefault: true,
-      config: {
-        CFG: createExampleCfg({
-          type: 'klosser',
-          showExpression: true,
-          klosser: {
-            antallX: 4,
-            antallY: 2,
-            bredde: 2,
-            hoyde: 3,
-            dybde: 2,
-            showBtn: false
-          }
-        })
-      }
-    },
-    {
-      id: 'kvikkbilder-klosser-2',
-      exampleNumber: '2',
-      title: '3 · 3 · (3 · 2 · 1)',
-      config: {
-        CFG: createExampleCfg({
-          type: 'klosser',
-          showExpression: true,
-          klosser: {
-            antallX: 3,
-            antallY: 3,
-            bredde: 3,
-            hoyde: 2,
-            dybde: 1,
-            showBtn: false
-          }
-        })
-      }
-    },
-    {
-      id: 'kvikkbilder-monster-3',
-      exampleNumber: '3',
-      title: 'Kvikkbilde 12',
-      config: {
-        CFG: createExampleCfg({
-          type: 'monster',
-          showExpression: true,
-          monster: {
-            antallX: 2,
-            antallY: 2,
-            antall: 12,
-            showBtn: false
-          }
-        })
-      }
+  const DEFAULT_KVIKKBILDER_EXAMPLES = [{
+    id: 'kvikkbilder-klosser-1',
+    exampleNumber: '1',
+    title: '4 · 2 · (2 · 3 · 2)',
+    isDefault: true,
+    config: {
+      CFG: createExampleCfg({
+        type: 'klosser',
+        showExpression: true,
+        klosser: {
+          antallX: 4,
+          antallY: 2,
+          bredde: 2,
+          hoyde: 3,
+          dybde: 2,
+          showBtn: false
+        }
+      })
     }
-  ];
-
-  if(typeof window !== 'undefined'){
+  }, {
+    id: 'kvikkbilder-klosser-2',
+    exampleNumber: '2',
+    title: '3 · 3 · (3 · 2 · 1)',
+    config: {
+      CFG: createExampleCfg({
+        type: 'klosser',
+        showExpression: true,
+        klosser: {
+          antallX: 3,
+          antallY: 3,
+          bredde: 3,
+          hoyde: 2,
+          dybde: 1,
+          showBtn: false
+        }
+      })
+    }
+  }, {
+    id: 'kvikkbilder-monster-3',
+    exampleNumber: '3',
+    title: 'Kvikkbilde 12',
+    config: {
+      CFG: createExampleCfg({
+        type: 'monster',
+        showExpression: true,
+        monster: {
+          antallX: 2,
+          antallY: 2,
+          antall: 12,
+          showBtn: false
+        }
+      })
+    }
+  }];
+  if (typeof window !== 'undefined') {
     window.__EXAMPLES_FORCE_PROVIDED__ = true;
-    window.DEFAULT_EXAMPLES = DEFAULT_KVIKKBILDER_EXAMPLES.map(example => ({
-      ...example,
-      config: {
-        ...example.config,
-        CFG: deepClone(example.config?.CFG)
-      }
-    }));
+    window.DEFAULT_EXAMPLES = DEFAULT_KVIKKBILDER_EXAMPLES.map(example => {
+      var _example$config;
+      return {
+        ...example,
+        config: {
+          ...example.config,
+          CFG: deepClone((_example$config = example.config) === null || _example$config === void 0 ? void 0 : _example$config.CFG)
+        }
+      };
+    });
   }
-
-  const globalCfg = (typeof window.CFG === 'object' && window.CFG) ? window.CFG : {};
+  const globalCfg = typeof window.CFG === 'object' && window.CFG ? window.CFG : {};
   const CFG = window.CFG = globalCfg;
-
-  function iso(x,y,z,tileW,tileH,unitH){
+  function iso(x, y, z, tileW, tileH, unitH) {
     return {
-      x:(x - y) * tileW/2,
-      y:(x + y) * tileH/2 - z * unitH
+      x: (x - y) * tileW / 2,
+      y: (x + y) * tileH / 2 - z * unitH
     };
   }
-
-  function createBrick(bredde, hoyde, dybde){
-    if(!BRICK_SRC) return document.createElementNS('http://www.w3.org/2000/svg','svg');
+  function createBrick(bredde, hoyde, dybde) {
+    if (!BRICK_SRC) return document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     const tileW = 26;
     const tileH = 13;
     const unitH = 13;
@@ -169,58 +156,62 @@
     const imgH = 32.5;
     const offsetX = 0.5;
     const offsetY = 25.75;
-    const p = (x,y,z)=>iso(x,y,z,tileW,tileH,unitH);
-
+    const p = (x, y, z) => iso(x, y, z, tileW, tileH, unitH);
     const widthCount = Math.max(1, Math.trunc(bredde));
     const heightCount = Math.max(1, Math.trunc(hoyde));
     const depthCount = Math.max(1, Math.trunc(dybde));
-
     const bricks = [];
-    for(let z=0; z<heightCount; z++){
-      for(let y=0; y<depthCount; y++){
-        for(let x=0; x<widthCount; x++){
-          const pos = p(x,y,z);
-          bricks.push({x,y,z,pos});
+    for (let z = 0; z < heightCount; z++) {
+      for (let y = 0; y < depthCount; y++) {
+        for (let x = 0; x < widthCount; x++) {
+          const pos = p(x, y, z);
+          bricks.push({
+            x,
+            y,
+            z,
+            pos
+          });
         }
       }
     }
-
-    bricks.sort((a,b)=>(a.x+a.y+a.z)-(b.x+b.y+b.z));
-
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    bricks.forEach(({pos})=>{
+    bricks.sort((a, b) => a.x + a.y + a.z - (b.x + b.y + b.z));
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
+    bricks.forEach(({
+      pos
+    }) => {
       const x = pos.x - offsetX;
       const y = pos.y - offsetY;
-      if(x < minX) minX = x;
-      if(y < minY) minY = y;
-      if(x + imgW > maxX) maxX = x + imgW;
-      if(y + imgH > maxY) maxY = y + imgH;
+      if (x < minX) minX = x;
+      if (y < minY) minY = y;
+      if (x + imgW > maxX) maxX = x + imgW;
+      if (y + imgH > maxY) maxY = y + imgH;
     });
-
     const w = Math.max(1, maxX - minX);
     const diagonalLayers = Math.max(0, widthCount - 1) + Math.max(0, depthCount - 1);
     const diagonalHeight = diagonalLayers * (tileH / 2);
     const targetHeight = Math.max(1, imgH + (heightCount - 1) * unitH + diagonalHeight);
-
-    const svg = document.createElementNS('http://www.w3.org/2000/svg','svg');
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     svg.setAttribute('viewBox', `0 0 ${w} ${targetHeight}`);
     svg.setAttribute('width', '100%');
     svg.setAttribute('height', '100%');
-
     const group = document.createElementNS(svg.namespaceURI, 'g');
     const translateX = -minX;
     const translateY = -minY;
     const transforms = [];
-    if(translateX !== 0 || translateY !== 0){
+    if (translateX !== 0 || translateY !== 0) {
       transforms.push(`translate(${translateX},${translateY})`);
     }
-    if(transforms.length){
+    if (transforms.length) {
       group.setAttribute('transform', transforms.join(' '));
     }
-
-    bricks.forEach(({pos})=>{
-      const img = document.createElementNS(svg.namespaceURI,'image');
-      img.setAttributeNS('http://www.w3.org/1999/xlink','href', BRICK_SRC);
+    bricks.forEach(({
+      pos
+    }) => {
+      const img = document.createElementNS(svg.namespaceURI, 'image');
+      img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', BRICK_SRC);
       img.setAttribute('href', BRICK_SRC);
       img.setAttribute('width', imgW);
       img.setAttribute('height', imgH);
@@ -228,282 +219,264 @@
       img.setAttribute('y', pos.y - offsetY);
       group.appendChild(img);
     });
-
     svg.appendChild(group);
-
     return svg;
   }
-
-  function renderKlosser(){
-    const {antallX = 0, antallY = 0, bredde = 0, hoyde = 0, dybde = 0} = CFG.klosser || {};
+  function renderKlosser() {
+    const {
+      antallX = 0,
+      antallY = 0,
+      bredde = 0,
+      hoyde = 0,
+      dybde = 0
+    } = CFG.klosser || {};
     const cols = Math.max(0, Math.trunc(antallX));
     const rows = Math.max(0, Math.trunc(antallY));
     const width = Math.max(1, Math.trunc(bredde));
     const height = Math.max(1, Math.trunc(hoyde));
     const depth = Math.max(1, Math.trunc(dybde));
-
     brickContainer.innerHTML = '';
     brickContainer.style.gridTemplateColumns = cols > 0 ? `repeat(${cols}, 1fr)` : '';
     brickContainer.style.gridTemplateRows = rows > 0 ? `repeat(${rows}, 1fr)` : '';
-
     const perFig = width * height * depth;
     const total = cols * rows * perFig;
     const dot = ' · ';
     expression.textContent = `${cols}${dot}${rows}${dot}(${width}${dot}${height}${dot}${depth}) = ${cols * rows}${dot}${perFig} = ${total}`;
-
-    if(!BRICK_SRC) return;
-
+    if (!BRICK_SRC) return;
     const totalFigures = cols * rows;
-    for(let i = 0; i < totalFigures; i++){
+    for (let i = 0; i < totalFigures; i++) {
       const fig = createBrick(width, height, depth);
       fig.setAttribute('aria-label', `${width}x${height}x${depth} kloss`);
       brickContainer.appendChild(fig);
     }
   }
-
-  function primeFactors(n){
-    const factors=[];
-    let num=n;
-    let p=2;
-    while(num>1 && factors.length<6){
-      while(num%p===0 && factors.length<6){
+  function primeFactors(n) {
+    const factors = [];
+    let num = n;
+    let p = 2;
+    while (num > 1 && factors.length < 6) {
+      while (num % p === 0 && factors.length < 6) {
         factors.push(p);
-        num/=p;
+        num /= p;
       }
       p++;
     }
-    while(factors.length<6) factors.push(1);
+    while (factors.length < 6) factors.push(1);
     return factors;
   }
-
-  function computeKs(n,f){
-    const [f1,f2,f3,f4,f5,f6]=f;
-
-    let k1=(n<=9?0.5:1)/(f2*f3*f4*f5);
-    if(f3===2 && f4===2) k1*=(f5<3?0.25:0.5);
-    if(f4===2 && f5===2) k1*=0.5;
-    if(f1===2 && f2===2 && f3===2 && f4<3) k1*=2;
-    if(f1===2 && f2===2 && f3===2 && f4===2) k1*=2;
-    if(f3===3) k1*=f2/f1;
-    if(f1===f2 && f2===f3 && f3===f4 && f4===f5) k1*=2;
-    if(n===1) k1=0;
-
+  function computeKs(n, f) {
+    const [f1, f2, f3, f4, f5, f6] = f;
+    let k1 = (n <= 9 ? 0.5 : 1) / (f2 * f3 * f4 * f5);
+    if (f3 === 2 && f4 === 2) k1 *= f5 < 3 ? 0.25 : 0.5;
+    if (f4 === 2 && f5 === 2) k1 *= 0.5;
+    if (f1 === 2 && f2 === 2 && f3 === 2 && f4 < 3) k1 *= 2;
+    if (f1 === 2 && f2 === 2 && f3 === 2 && f4 === 2) k1 *= 2;
+    if (f3 === 3) k1 *= f2 / f1;
+    if (f1 === f2 && f2 === f3 && f3 === f4 && f4 === f5) k1 *= 2;
+    if (n === 1) k1 = 0;
     let k2;
-    if(f2===1) k2=1;
-    else if(f1===2 && f2===2) k2=k1;
-    else if(f3===1) k2=1-1/f2;
-    else if(f2===f1) k2=k1*f2;
-    else if(f3===f2 && f2===3) k2=k1*f1;
-    else if(f3===f2) k2=k1*f2;
-    else if(f1*f2===6 && f3<3) k2=k1*f3/f1;
-    else k2=1/(f3*f4*f5*f6);
-
+    if (f2 === 1) k2 = 1;else if (f1 === 2 && f2 === 2) k2 = k1;else if (f3 === 1) k2 = 1 - 1 / f2;else if (f2 === f1) k2 = k1 * f2;else if (f3 === f2 && f2 === 3) k2 = k1 * f1;else if (f3 === f2) k2 = k1 * f2;else if (f1 * f2 === 6 && f3 < 3) k2 = k1 * f3 / f1;else k2 = 1 / (f3 * f4 * f5 * f6);
     let k3;
-    if(f3===1) k3=1;
-    else{
-      if(f4===1) k3=1-k1;
-      else{
-        k3=1;
-        if(f2*f3===4 && f5===1) k3*=Math.max(...f)/f1;
-        if(f1*f2*f3===8 && f6===1) k3*=1/f2;
-        if(f1===2 && f2===2 && f3===2 && f4===2) k3*=2;
-        k3*=1/(f4*f5);
+    if (f3 === 1) k3 = 1;else {
+      if (f4 === 1) k3 = 1 - k1;else {
+        k3 = 1;
+        if (f2 * f3 === 4 && f5 === 1) k3 *= Math.max(...f) / f1;
+        if (f1 * f2 * f3 === 8 && f6 === 1) k3 *= 1 / f2;
+        if (f1 === 2 && f2 === 2 && f3 === 2 && f4 === 2) k3 *= 2;
+        k3 *= 1 / (f4 * f5);
       }
-      k3*=1/f6;
+      k3 *= 1 / f6;
     }
-    if(f1*f2*f3*f4===16 && f5>2) k3*=2;
-
+    if (f1 * f2 * f3 * f4 === 16 && f5 > 2) k3 *= 2;
     let k4;
-    if(f4===1) k4=1;
-    else if(f5===1 && f1*f2===4) k4=1-k3;
-    else if(f5===1) k4=1-k1;
-    else k4=1/(f5*f6);
-
+    if (f4 === 1) k4 = 1;else if (f5 === 1 && f1 * f2 === 4) k4 = 1 - k3;else if (f5 === 1) k4 = 1 - k1;else k4 = 1 / (f5 * f6);
     let k5;
-    if(f5===1) k5=1;
-    else if(f6===1){
-      const mul=(f1===2 && f2===2 && f3===2 && f4===2)?0.5:1;
-      k5=1-mul*k3;
-    }else{
-      k5=1/f6;
+    if (f5 === 1) k5 = 1;else if (f6 === 1) {
+      const mul = f1 === 2 && f2 === 2 && f3 === 2 && f4 === 2 ? 0.5 : 1;
+      k5 = 1 - mul * k3;
+    } else {
+      k5 = 1 / f6;
     }
-
-    const k6=f6===1?1:1-k3;
-
-    return [k1,k2,k3,k4,k5,k6];
+    const k6 = f6 === 1 ? 1 : 1 - k3;
+    return [k1, k2, k3, k4, k5, k6];
   }
-
-  function rotate(points,angle){
-    const cos=Math.cos(angle);
-    const sin=Math.sin(angle);
-    return points.map(p=>({x:p.x*cos - p.y*sin, y:p.x*sin + p.y*cos}));
+  function rotate(points, angle) {
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    return points.map(p => ({
+      x: p.x * cos - p.y * sin,
+      y: p.x * sin + p.y * cos
+    }));
   }
-
-  function translate(points,tx,ty){
-    return points.map(p=>({x:p.x+tx, y:p.y+ty}));
+  function translate(points, tx, ty) {
+    return points.map(p => ({
+      x: p.x + tx,
+      y: p.y + ty
+    }));
   }
-
-  function buildLevel(points,factor,r){
-    if(factor===1) return points;
-    const res=[];
-    for(let i=0;i<factor;i++){
-      const rotAngle=-2*Math.PI*i/factor;
-      const rotated=rotate(points,rotAngle);
-      const baseAngle=2*Math.PI*i/factor;
-      let tx,ty;
-      if(factor===2){
-        tx=r*Math.cos(baseAngle);
-        ty=r*Math.sin(baseAngle);
-      }else{
-        tx=r*Math.sin(baseAngle);
-        ty=r*Math.cos(baseAngle);
+  function buildLevel(points, factor, r) {
+    if (factor === 1) return points;
+    const res = [];
+    for (let i = 0; i < factor; i++) {
+      const rotAngle = -2 * Math.PI * i / factor;
+      const rotated = rotate(points, rotAngle);
+      const baseAngle = 2 * Math.PI * i / factor;
+      let tx, ty;
+      if (factor === 2) {
+        tx = r * Math.cos(baseAngle);
+        ty = r * Math.sin(baseAngle);
+      } else {
+        tx = r * Math.sin(baseAngle);
+        ty = r * Math.cos(baseAngle);
       }
-      res.push(...translate(rotated,tx,ty));
+      res.push(...translate(rotated, tx, ty));
     }
     return res;
   }
-
-  function byggMonster(n){
-    if(n<=0) return [];
-    const factors=primeFactors(n);
-    const ks=computeKs(n,factors);
-    let pts=[];
-    const f1=factors[0];
-    for(let i=0;i<f1;i++){
-      const angle=2*Math.PI*i/f1;
-      pts.push({x:ks[0]*Math.sin(angle), y:ks[0]*Math.cos(angle)});
+  function byggMonster(n) {
+    if (n <= 0) return [];
+    const factors = primeFactors(n);
+    const ks = computeKs(n, factors);
+    let pts = [];
+    const f1 = factors[0];
+    for (let i = 0; i < f1; i++) {
+      const angle = 2 * Math.PI * i / f1;
+      pts.push({
+        x: ks[0] * Math.sin(angle),
+        y: ks[0] * Math.cos(angle)
+      });
     }
-    pts=buildLevel(pts,factors[1],ks[1]);
-    pts=buildLevel(pts,factors[2],ks[2]);
-    pts=buildLevel(pts,factors[3],ks[3]);
-    pts=buildLevel(pts,factors[4],ks[4]);
-    pts=buildLevel(pts,factors[5],ks[5]);
-    const scale=0.3;
-    return pts.map(p=>({x:p.x*scale, y:p.y*scale}));
+    pts = buildLevel(pts, factors[1], ks[1]);
+    pts = buildLevel(pts, factors[2], ks[2]);
+    pts = buildLevel(pts, factors[3], ks[3]);
+    pts = buildLevel(pts, factors[4], ks[4]);
+    pts = buildLevel(pts, factors[5], ks[5]);
+    const scale = 0.3;
+    return pts.map(p => ({
+      x: p.x * scale,
+      y: p.y * scale
+    }));
   }
-
-  function createPatternSvg(points){
-    if(!points.length) return null;
-
-    const radius=10;
-    const spacing=3;
-    const desiredCenterDistance=radius*2+spacing;
-
-    const seen=new Set();
-    const uniquePoints=[];
-    const precision=1e4;
-    points.forEach(p=>{
-      const key=`${Math.round(p.x*precision)}:${Math.round(p.y*precision)}`;
-      if(!seen.has(key)){
+  function createPatternSvg(points) {
+    if (!points.length) return null;
+    const radius = 10;
+    const spacing = 3;
+    const desiredCenterDistance = radius * 2 + spacing;
+    const seen = new Set();
+    const uniquePoints = [];
+    const precision = 1e4;
+    points.forEach(p => {
+      const key = `${Math.round(p.x * precision)}:${Math.round(p.y * precision)}`;
+      if (!seen.has(key)) {
         seen.add(key);
         uniquePoints.push(p);
       }
     });
-
-    let minDist=Infinity;
-    for(let i=0;i<uniquePoints.length;i++){
-      for(let j=i+1;j<uniquePoints.length;j++){
-        const dx=uniquePoints[i].x-uniquePoints[j].x;
-        const dy=uniquePoints[i].y-uniquePoints[j].y;
-        const dist=Math.hypot(dx,dy);
-        if(dist>0 && dist<minDist) minDist=dist;
+    let minDist = Infinity;
+    for (let i = 0; i < uniquePoints.length; i++) {
+      for (let j = i + 1; j < uniquePoints.length; j++) {
+        const dx = uniquePoints[i].x - uniquePoints[j].x;
+        const dy = uniquePoints[i].y - uniquePoints[j].y;
+        const dist = Math.hypot(dx, dy);
+        if (dist > 0 && dist < minDist) minDist = dist;
       }
     }
-    if(!Number.isFinite(minDist) || minDist<=0) minDist=desiredCenterDistance;
-    let scale=desiredCenterDistance/minDist;
-    if(!Number.isFinite(scale) || scale<=0) scale=1;
-    else if(scale<1) scale=1;
-
-    const scaledPoints=points.map(p=>({x:p.x*scale,y:p.y*scale}));
-
-    let minX=Infinity,maxX=-Infinity,minY=Infinity,maxY=-Infinity;
-    scaledPoints.forEach(({x,y})=>{
-      if(x<minX) minX=x;
-      if(x>maxX) maxX=x;
-      if(y<minY) minY=y;
-      if(y>maxY) maxY=y;
+    if (!Number.isFinite(minDist) || minDist <= 0) minDist = desiredCenterDistance;
+    let scale = desiredCenterDistance / minDist;
+    if (!Number.isFinite(scale) || scale <= 0) scale = 1;else if (scale < 1) scale = 1;
+    const scaledPoints = points.map(p => ({
+      x: p.x * scale,
+      y: p.y * scale
+    }));
+    let minX = Infinity,
+      maxX = -Infinity,
+      minY = Infinity,
+      maxY = -Infinity;
+    scaledPoints.forEach(({
+      x,
+      y
+    }) => {
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
     });
-
-    const pad=radius+spacing;
-    const contentWidth=maxX-minX;
-    const contentHeight=maxY-minY;
-    const baseW=contentWidth+pad*2;
-    const baseH=contentHeight+pad*2;
-    const minSize=radius*4;
-    const vbW=Math.max(baseW,minSize);
-    const vbH=Math.max(baseH,minSize);
-    const extraX=(vbW-baseW)/2;
-    const extraY=(vbH-baseH)/2;
-    const offsetX=pad+extraX-minX;
-    const offsetY=pad+extraY-minY;
-
-    const svgNS='http://www.w3.org/2000/svg';
-    const svg=document.createElementNS(svgNS,'svg');
+    const pad = radius + spacing;
+    const contentWidth = maxX - minX;
+    const contentHeight = maxY - minY;
+    const baseW = contentWidth + pad * 2;
+    const baseH = contentHeight + pad * 2;
+    const minSize = radius * 4;
+    const vbW = Math.max(baseW, minSize);
+    const vbH = Math.max(baseH, minSize);
+    const extraX = (vbW - baseW) / 2;
+    const extraY = (vbH - baseH) / 2;
+    const offsetX = pad + extraX - minX;
+    const offsetY = pad + extraY - minY;
+    const svgNS = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(svgNS, 'svg');
     svg.setAttribute('viewBox', `0 0 ${vbW} ${vbH}`);
     svg.setAttribute('width', '100%');
     svg.setAttribute('height', '100%');
-    svg.setAttribute('preserveAspectRatio','xMidYMid meet');
-
-    scaledPoints.forEach(({x,y})=>{
-      const c=document.createElementNS(svgNS,'circle');
-      c.setAttribute('cx', x+offsetX);
-      c.setAttribute('cy', y+offsetY);
+    svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+    scaledPoints.forEach(({
+      x,
+      y
+    }) => {
+      const c = document.createElementNS(svgNS, 'circle');
+      c.setAttribute('cx', x + offsetX);
+      c.setAttribute('cy', y + offsetY);
       c.setAttribute('r', radius);
       c.setAttribute('fill', '#534477');
       svg.appendChild(c);
     });
-
     return svg;
   }
-
-  function renderMonster(){
-    const {antallX = 0, antallY = 0, antall = 0} = CFG.monster || {};
-    patternContainer.innerHTML='';
-
+  function renderMonster() {
+    const {
+      antallX = 0,
+      antallY = 0,
+      antall = 0
+    } = CFG.monster || {};
+    patternContainer.innerHTML = '';
     const cols = Math.max(0, Math.trunc(antallX));
     const rows = Math.max(0, Math.trunc(antallY));
     patternContainer.style.gridTemplateColumns = cols > 0 ? `repeat(${cols},minmax(0,1fr))` : '';
     patternContainer.style.gridTemplateRows = rows > 0 ? `repeat(${rows},minmax(0,1fr))` : '';
-
     const count = Math.max(0, Math.trunc(antall));
     const points = byggMonster(count);
-    const factors = primeFactors(count).filter(x=>x>1);
+    const factors = primeFactors(count).filter(x => x > 1);
     const baseExpression = factors.length ? `${factors.join(' · ')} = ${count}` : `${count}`;
-
-    if(!points.length || cols<=0 || rows<=0){
+    if (!points.length || cols <= 0 || rows <= 0) {
       expression.textContent = baseExpression;
       return;
     }
-
     const svg = createPatternSvg(points);
-    if(!svg){
+    if (!svg) {
       expression.textContent = baseExpression;
       return;
     }
-
     const totalFigures = cols * rows;
     svg.setAttribute('aria-label', `Kvikkbilde ${count}`);
-    for(let i=0;i<totalFigures;i++){
+    for (let i = 0; i < totalFigures; i++) {
       patternContainer.appendChild(svg.cloneNode(true));
     }
-
-    if(totalFigures>1){
-      expression.textContent = `${cols} · ${rows} · (${baseExpression}) = ${totalFigures} · ${count} = ${totalFigures*count}`;
-    }else{
+    if (totalFigures > 1) {
+      expression.textContent = `${cols} · ${rows} · (${baseExpression}) = ${totalFigures} · ${count} = ${totalFigures * count}`;
+    } else {
       expression.textContent = baseExpression;
     }
   }
-
-  function applyExpressionVisibility(){
-    if(!expression) return;
+  function applyExpressionVisibility() {
+    if (!expression) return;
     const enabled = CFG.showExpression !== false;
     const playVisible = playBtn.style.display !== 'none';
-    expression.style.display = (enabled && !playVisible) ? 'block' : 'none';
+    expression.style.display = enabled && !playVisible ? 'block' : 'none';
   }
-
-  function updateVisibilityKlosser(){
+  function updateVisibilityKlosser() {
+    var _CFG$klosser;
     patternContainer.style.display = 'none';
-    if(CFG.klosser?.showBtn){
+    if ((_CFG$klosser = CFG.klosser) !== null && _CFG$klosser !== void 0 && _CFG$klosser.showBtn) {
       playBtn.style.display = 'flex';
       brickContainer.style.display = 'none';
     } else {
@@ -512,10 +485,10 @@
     }
     applyExpressionVisibility();
   }
-
-  function updateVisibilityMonster(){
+  function updateVisibilityMonster() {
+    var _CFG$monster;
     brickContainer.style.display = 'none';
-    if(CFG.monster?.showBtn){
+    if ((_CFG$monster = CFG.monster) !== null && _CFG$monster !== void 0 && _CFG$monster.showBtn) {
       playBtn.style.display = 'flex';
       patternContainer.style.display = 'none';
     } else {
@@ -524,25 +497,21 @@
     }
     applyExpressionVisibility();
   }
-
-  function clampInt(value, min, fallback){
+  function clampInt(value, min, fallback) {
     const num = Number.parseInt(value, 10);
-    if(Number.isFinite(num)){
+    if (Number.isFinite(num)) {
       const safeMin = Number.isFinite(min) ? min : -Infinity;
       return Math.max(safeMin, Math.trunc(num));
     }
     return fallback;
   }
-
-  function sanitizeCfg(){
-    if(CFG.type !== 'monster' && CFG.type !== 'klosser'){
+  function sanitizeCfg() {
+    if (CFG.type !== 'monster' && CFG.type !== 'klosser') {
       CFG.type = DEFAULT_CFG.type;
     }
     CFG.showExpression = CFG.showExpression !== false;
-
-    if(!CFG.klosser || typeof CFG.klosser !== 'object') CFG.klosser = {};
-    if(!CFG.monster || typeof CFG.monster !== 'object') CFG.monster = {};
-
+    if (!CFG.klosser || typeof CFG.klosser !== 'object') CFG.klosser = {};
+    if (!CFG.monster || typeof CFG.monster !== 'object') CFG.monster = {};
     const k = CFG.klosser;
     const dk = DEFAULT_CFG.klosser;
     k.antallX = clampInt(k.antallX, 0, dk.antallX);
@@ -552,7 +521,6 @@
     k.dybde = clampInt(k.dybde, 1, dk.dybde);
     k.duration = clampInt(k.duration, 0, dk.duration);
     k.showBtn = k.showBtn === true;
-
     const m = CFG.monster;
     const dm = DEFAULT_CFG.monster;
     m.antallX = clampInt(m.antallX, 0, dm.antallX);
@@ -560,118 +528,100 @@
     m.antall = clampInt(m.antall, 0, dm.antall);
     m.duration = clampInt(m.duration, 0, dm.duration);
     m.showBtn = m.showBtn === true;
-
     return CFG;
   }
-
-  function syncControlsToCfg(){
+  function syncControlsToCfg() {
     sanitizeCfg();
-    if(cfgType) cfgType.value = CFG.type;
-    if(cfgShowExpression) cfgShowExpression.checked = CFG.showExpression !== false;
-
-    if(cfgAntallX) cfgAntallX.value = CFG.klosser.antallX;
-    if(cfgAntallY) cfgAntallY.value = CFG.klosser.antallY;
-    if(cfgBredde) cfgBredde.value = CFG.klosser.bredde;
-    if(cfgHoyde) cfgHoyde.value = CFG.klosser.hoyde;
-    if(cfgDybde) cfgDybde.value = CFG.klosser.dybde;
-    if(cfgDurationKlosser) cfgDurationKlosser.value = CFG.klosser.duration;
-    if(cfgShowBtn) cfgShowBtn.checked = CFG.klosser.showBtn;
-
-    if(cfgMonsterAntallX) cfgMonsterAntallX.value = CFG.monster.antallX;
-    if(cfgMonsterAntallY) cfgMonsterAntallY.value = CFG.monster.antallY;
-    if(cfgAntall) cfgAntall.value = CFG.monster.antall;
-    if(cfgDurationMonster) cfgDurationMonster.value = CFG.monster.duration;
-    if(cfgShowBtnMonster) cfgShowBtnMonster.checked = CFG.monster.showBtn;
+    if (cfgType) cfgType.value = CFG.type;
+    if (cfgShowExpression) cfgShowExpression.checked = CFG.showExpression !== false;
+    if (cfgAntallX) cfgAntallX.value = CFG.klosser.antallX;
+    if (cfgAntallY) cfgAntallY.value = CFG.klosser.antallY;
+    if (cfgBredde) cfgBredde.value = CFG.klosser.bredde;
+    if (cfgHoyde) cfgHoyde.value = CFG.klosser.hoyde;
+    if (cfgDybde) cfgDybde.value = CFG.klosser.dybde;
+    if (cfgDurationKlosser) cfgDurationKlosser.value = CFG.klosser.duration;
+    if (cfgShowBtn) cfgShowBtn.checked = CFG.klosser.showBtn;
+    if (cfgMonsterAntallX) cfgMonsterAntallX.value = CFG.monster.antallX;
+    if (cfgMonsterAntallY) cfgMonsterAntallY.value = CFG.monster.antallY;
+    if (cfgAntall) cfgAntall.value = CFG.monster.antall;
+    if (cfgDurationMonster) cfgDurationMonster.value = CFG.monster.duration;
+    if (cfgShowBtnMonster) cfgShowBtnMonster.checked = CFG.monster.showBtn;
   }
-
-  function renderView(){
+  function renderView() {
     sanitizeCfg();
-    if(CFG.type === 'klosser'){
-      if(klosserConfig) klosserConfig.style.display = 'block';
-      if(monsterConfig) monsterConfig.style.display = 'none';
+    if (CFG.type === 'klosser') {
+      if (klosserConfig) klosserConfig.style.display = 'block';
+      if (monsterConfig) monsterConfig.style.display = 'none';
       renderKlosser();
       updateVisibilityKlosser();
-    }else{
-      if(klosserConfig) klosserConfig.style.display = 'none';
-      if(monsterConfig) monsterConfig.style.display = 'block';
+    } else {
+      if (klosserConfig) klosserConfig.style.display = 'none';
+      if (monsterConfig) monsterConfig.style.display = 'block';
       renderMonster();
       updateVisibilityMonster();
     }
   }
-
-  function render(){
+  function render() {
     syncControlsToCfg();
     renderView();
   }
-
   window.render = render;
-
-  function bindNumberInput(input, targetGetter, key, min = 0){
-    if(!input) return;
+  function bindNumberInput(input, targetGetter, key, min = 0) {
+    if (!input) return;
     input.addEventListener('input', () => {
       const target = targetGetter();
-      if(!target) return;
+      if (!target) return;
       const num = Number.parseInt(input.value, 10);
-      if(Number.isFinite(num)){
+      if (Number.isFinite(num)) {
         target[key] = Math.max(min, Math.trunc(num));
         input.value = String(target[key]);
       }
       renderView();
     });
   }
-
   sanitizeCfg();
-
   bindNumberInput(cfgAntallX, () => CFG.klosser, 'antallX', 0);
   bindNumberInput(cfgAntallY, () => CFG.klosser, 'antallY', 0);
   bindNumberInput(cfgBredde, () => CFG.klosser, 'bredde', 1);
   bindNumberInput(cfgHoyde, () => CFG.klosser, 'hoyde', 1);
   bindNumberInput(cfgDybde, () => CFG.klosser, 'dybde', 1);
-
-  cfgDurationKlosser?.addEventListener('input', () => {
+  cfgDurationKlosser === null || cfgDurationKlosser === void 0 || cfgDurationKlosser.addEventListener('input', () => {
     const num = Number.parseInt(cfgDurationKlosser.value, 10);
-    if(Number.isFinite(num)){
+    if (Number.isFinite(num)) {
       CFG.klosser.duration = Math.max(0, Math.trunc(num));
       cfgDurationKlosser.value = String(CFG.klosser.duration);
     }
   });
-
-  cfgShowBtn?.addEventListener('change', () => {
+  cfgShowBtn === null || cfgShowBtn === void 0 || cfgShowBtn.addEventListener('change', () => {
     CFG.klosser.showBtn = !!cfgShowBtn.checked;
     renderView();
   });
-
   bindNumberInput(cfgMonsterAntallX, () => CFG.monster, 'antallX', 0);
   bindNumberInput(cfgMonsterAntallY, () => CFG.monster, 'antallY', 0);
   bindNumberInput(cfgAntall, () => CFG.monster, 'antall', 0);
-
-  cfgDurationMonster?.addEventListener('input', () => {
+  cfgDurationMonster === null || cfgDurationMonster === void 0 || cfgDurationMonster.addEventListener('input', () => {
     const num = Number.parseInt(cfgDurationMonster.value, 10);
-    if(Number.isFinite(num)){
+    if (Number.isFinite(num)) {
       CFG.monster.duration = Math.max(0, Math.trunc(num));
       cfgDurationMonster.value = String(CFG.monster.duration);
     }
   });
-
-  cfgShowBtnMonster?.addEventListener('change', () => {
+  cfgShowBtnMonster === null || cfgShowBtnMonster === void 0 || cfgShowBtnMonster.addEventListener('change', () => {
     CFG.monster.showBtn = !!cfgShowBtnMonster.checked;
     renderView();
   });
-
-  cfgType?.addEventListener('change', () => {
+  cfgType === null || cfgType === void 0 || cfgType.addEventListener('change', () => {
     CFG.type = cfgType.value === 'monster' ? 'monster' : 'klosser';
     cfgType.value = CFG.type;
     renderView();
   });
-
-  cfgShowExpression?.addEventListener('change', () => {
+  cfgShowExpression === null || cfgShowExpression === void 0 || cfgShowExpression.addEventListener('change', () => {
     CFG.showExpression = !!cfgShowExpression.checked;
     applyExpressionVisibility();
   });
-
   playBtn.addEventListener('click', () => {
     sanitizeCfg();
-    if(CFG.type === 'klosser'){
+    if (CFG.type === 'klosser') {
       const duration = Math.max(0, Number.isFinite(CFG.klosser.duration) ? CFG.klosser.duration : 0);
       renderKlosser();
       playBtn.style.display = 'none';
@@ -680,7 +630,7 @@
       setTimeout(() => {
         updateVisibilityKlosser();
       }, duration * 1000);
-    }else{
+    } else {
       const duration = Math.max(0, Number.isFinite(CFG.monster.duration) ? CFG.monster.duration : 0);
       renderMonster();
       playBtn.style.display = 'none';
@@ -691,70 +641,74 @@
       }, duration * 1000);
     }
   });
-
-  btnSvg?.addEventListener('click', ()=>{
+  btnSvg === null || btnSvg === void 0 || btnSvg.addEventListener('click', () => {
     const svg = brickContainer.querySelector('svg') || patternContainer.querySelector('svg');
-    if(svg) downloadSVG(svg, 'kvikkbilder.svg');
+    if (svg) downloadSVG(svg, 'kvikkbilder.svg');
   });
-  btnPng?.addEventListener('click', ()=>{
+  btnPng === null || btnPng === void 0 || btnPng.addEventListener('click', () => {
     const svg = brickContainer.querySelector('svg') || patternContainer.querySelector('svg');
-    if(svg) downloadPNG(svg, 'kvikkbilder.png', 2);
+    if (svg) downloadPNG(svg, 'kvikkbilder.png', 2);
   });
-
-  function svgToString(svgEl){
+  function svgToString(svgEl) {
     const clone = svgEl.cloneNode(true);
     const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
     const style = document.createElement('style');
     style.textContent = css;
     clone.insertBefore(style, clone.firstChild);
-    clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
-    clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
   }
-  function downloadSVG(svgEl, filename){
+  function downloadSVG(svgEl, filename) {
     const data = svgToString(svgEl);
-    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const blob = new Blob([data], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
     a.download = filename.endsWith('.svg') ? filename : filename + '.svg';
-    document.body.appendChild(a); a.click(); a.remove();
-    setTimeout(()=>URL.revokeObjectURL(url),1000);
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
-  function downloadPNG(svgEl, filename, scale=2, bg='#fff'){
-    const vb = svgEl.viewBox?.baseVal;
-    const w = vb?.width || svgEl.clientWidth || 420;
-    const h = vb?.height|| svgEl.clientHeight || 420;
+  function downloadPNG(svgEl, filename, scale = 2, bg = '#fff') {
+    var _svgEl$viewBox;
+    const vb = (_svgEl$viewBox = svgEl.viewBox) === null || _svgEl$viewBox === void 0 ? void 0 : _svgEl$viewBox.baseVal;
+    const w = (vb === null || vb === void 0 ? void 0 : vb.width) || svgEl.clientWidth || 420;
+    const h = (vb === null || vb === void 0 ? void 0 : vb.height) || svgEl.clientHeight || 420;
     const data = svgToString(svgEl);
-    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
-    const url  = URL.createObjectURL(blob);
+    const blob = new Blob([data], {
+      type: 'image/svg+xml;charset=utf-8'
+    });
+    const url = URL.createObjectURL(blob);
     const img = new Image();
-    img.onload = ()=>{
+    img.onload = () => {
       const canvas = document.createElement('canvas');
-      canvas.width  = Math.round(w * scale);
+      canvas.width = Math.round(w * scale);
       canvas.height = Math.round(h * scale);
       const ctx = canvas.getContext('2d');
       ctx.fillStyle = bg;
-      ctx.fillRect(0,0,canvas.width,canvas.height);
-      ctx.drawImage(img,0,0,canvas.width,canvas.height);
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
       URL.revokeObjectURL(url);
-      canvas.toBlob(blob=>{
+      canvas.toBlob(blob => {
         const urlPng = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = urlPng;
         a.download = filename.endsWith('.png') ? filename : filename + '.png';
-        document.body.appendChild(a); a.click(); a.remove();
-        setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
-      },'image/png');
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(urlPng), 1000);
+      }, 'image/png');
     };
     img.src = url;
   }
-
   render();
-  fetch('images/brick1.svg')
-    .then(r=>r.text())
-    .then(txt=>{
-      BRICK_SRC = `data:image/svg+xml;base64,${btoa(txt)}`;
-      renderView();
-    });
+  fetch('images/brick1.svg').then(r => r.text()).then(txt => {
+    BRICK_SRC = `data:image/svg+xml;base64,${btoa(txt)}`;
+    renderView();
+  });
 })();

--- a/nkant.js
+++ b/nkant.js
@@ -15,15 +15,22 @@ const ADV_CONFIG = {
     factor: 0.28,
     min: 18,
     max: 60,
-
     // Tekstplassering langs vinkelhalveringen:
-    insideK:  { right: 1.5, other: 1.5 }, // vinkelverdi (innsiden)
-    outsideK: { right: 0.5, other: 0.50 }, // punktnavn (utsiden)
+    insideK: {
+      right: 1.5,
+      other: 1.5
+    },
+    // vinkelverdi (innsiden)
+    outsideK: {
+      right: 0.5,
+      other: 0.50
+    },
+    // punktnavn (utsiden)
     outsidePad: 0,
-
     // Hindrer at punktnavn "flyr" for langt ut
-    outsideMaxFactor: 0.90, // maks 90% av korteste naboside
-    outsideMin: 6          // liten gulvavstand ut fra hjørnet
+    outsideMaxFactor: 0.90,
+    // maks 90% av korteste naboside
+    outsideMin: 6 // liten gulvavstand ut fra hjørnet
   }
 };
 
@@ -31,33 +38,70 @@ const ADV_CONFIG = {
 const STATE = {
   specsText: "",
   fig1: {
-    sides:  { default: "value", a:"inherit", b:"inherit", c:"inherit", d:"inherit",
-              aText:"a", bText:"b", cText:"c", dText:"d" },
-    angles: { default: "custom+mark+value", A:"inherit", B:"inherit", C:"inherit", D:"inherit",
-              AText:"A", BText:"B", CText:"C", DText:"D" }
+    sides: {
+      default: "value",
+      a: "inherit",
+      b: "inherit",
+      c: "inherit",
+      d: "inherit",
+      aText: "a",
+      bText: "b",
+      cText: "c",
+      dText: "d"
+    },
+    angles: {
+      default: "custom+mark+value",
+      A: "inherit",
+      B: "inherit",
+      C: "inherit",
+      D: "inherit",
+      AText: "A",
+      BText: "B",
+      CText: "C",
+      DText: "D"
+    }
   },
   fig2: {
-    sides:  { default: "none", a:"inherit", b:"inherit", c:"inherit", d:"inherit",
-              aText:"a", bText:"b", cText:"c", dText:"d" },
-    angles: { default: "custom+mark+value", A:"inherit", B:"inherit", C:"inherit", D:"inherit",
-              AText:"A", BText:"B", CText:"C", DText:"D" }
+    sides: {
+      default: "none",
+      a: "inherit",
+      b: "inherit",
+      c: "inherit",
+      d: "inherit",
+      aText: "a",
+      bText: "b",
+      cText: "c",
+      dText: "d"
+    },
+    angles: {
+      default: "custom+mark+value",
+      A: "inherit",
+      B: "inherit",
+      C: "inherit",
+      D: "inherit",
+      AText: "A",
+      BText: "B",
+      CText: "C",
+      DText: "D"
+    }
   },
   layout: "row" // "row" | "col"
 };
 const DEFAULT_STATE = JSON.parse(JSON.stringify(STATE));
-
-function ensureStateDefaults(){
-  const fill = (target, defaults)=>{
-    if(!defaults || typeof defaults !== "object") return;
+function ensureStateDefaults() {
+  const fill = (target, defaults) => {
+    if (!defaults || typeof defaults !== "object") return;
     Object.keys(defaults).forEach(key => {
       const defVal = defaults[key];
       const curVal = target[key];
-      if(defVal && typeof defVal === "object" && !Array.isArray(defVal)){
-        if(!curVal || typeof curVal !== "object"){
-          target[key] = Array.isArray(defVal) ? defVal.slice() : {...defVal};
+      if (defVal && typeof defVal === "object" && !Array.isArray(defVal)) {
+        if (!curVal || typeof curVal !== "object") {
+          target[key] = Array.isArray(defVal) ? defVal.slice() : {
+            ...defVal
+          };
         }
         fill(target[key], defVal);
-      }else if(!(key in target)){
+      } else if (!(key in target)) {
         target[key] = Array.isArray(defVal) ? defVal.slice() : defVal;
       }
     });
@@ -83,284 +127,359 @@ const STYLE = {
 };
 
 /* ---------- HJELPERE ---------- */
-const deg  = r => r * 180 / Math.PI;
-const rad  = d => d * Math.PI / 180;
+const deg = r => r * 180 / Math.PI;
+const rad = d => d * Math.PI / 180;
 const clamp = (x, lo, hi) => Math.max(lo, Math.min(hi, x));
 const clampCos = x => clamp(x, -1, 1);
-const fmt = n => (Math.round(n*10)/10).toString().replace(".", ",");
+const fmt = n => (Math.round(n * 10) / 10).toString().replace(".", ",");
 const rand = (min, max) => min + Math.random() * (max - min);
-
-function deepAssign(target, src){
-  if(!src) return;
-  Object.entries(src).forEach(([k,v])=>{
-    if(v && typeof v === "object" && !Array.isArray(v)){
-      if(!target[k] || typeof target[k] !== "object") target[k] = {};
+function deepAssign(target, src) {
+  if (!src) return;
+  Object.entries(src).forEach(([k, v]) => {
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      if (!target[k] || typeof target[k] !== "object") target[k] = {};
       deepAssign(target[k], v);
     } else {
       target[k] = v;
     }
   });
 }
-
-function add(parent, name, attrs = {}){
+function add(parent, name, attrs = {}) {
   const el = document.createElementNS("http://www.w3.org/2000/svg", name);
-  Object.entries(attrs).forEach(([k,v]) => el.setAttribute(k, String(v)));
+  Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, String(v)));
   parent.appendChild(el);
   return el;
 }
-const dist = (P,Q)=> Math.hypot(P.x-Q.x, P.y-Q.y);
-const mid  = (P,Q)=> ({x:(P.x+Q.x)/2, y:(P.y+Q.y)/2});
-
-function polygonArea(pts){
-  let s=0; for(let i=0;i<pts.length;i++){const a=pts[i], b=pts[(i+1)%pts.length]; s+=a.x*b.y-b.x*a.y;}
-  return s/2;
-}
-function polygonCentroid(pts){
-  let A=0, cx=0, cy=0;
-  for(let i=0;i<pts.length;i++){
-    const p=pts[i], q=pts[(i+1)%pts.length];
-    const c=p.x*q.y-q.x*p.y; A+=c; cx+=(p.x+q.x)*c; cy+=(p.y+q.y)*c;
+const dist = (P, Q) => Math.hypot(P.x - Q.x, P.y - Q.y);
+const mid = (P, Q) => ({
+  x: (P.x + Q.x) / 2,
+  y: (P.y + Q.y) / 2
+});
+function polygonArea(pts) {
+  let s = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const a = pts[i],
+      b = pts[(i + 1) % pts.length];
+    s += a.x * b.y - b.x * a.y;
   }
-  A=A/2; if(Math.abs(A)<1e-9) return mid(pts[0], pts[2]||pts[0]);
-  return {x:cx/(6*A), y:cy/(6*A)};
+  return s / 2;
 }
-
-function fitTransformToRect(pts, rectW, rectH, margin=46){
-  const xs=pts.map(p=>p.x), ys=pts.map(p=>p.y);
-  const minx=Math.min(...xs), maxx=Math.max(...xs);
-  const miny=Math.min(...ys), maxy=Math.max(...ys);
-  const cw=Math.max(1e-6, maxx-minx);
-  const ch=Math.max(1e-6, maxy-miny);
-  const k = Math.min((rectW-2*margin)/cw, (rectH-2*margin)/ch);
-
-  const T = p => ({ x: margin + k*(p.x - minx), y: (rectH - margin) - k*(p.y - miny) });
-  return {T,k};
+function polygonCentroid(pts) {
+  let A = 0,
+    cx = 0,
+    cy = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const p = pts[i],
+      q = pts[(i + 1) % pts.length];
+    const c = p.x * q.y - q.x * p.y;
+    A += c;
+    cx += (p.x + q.x) * c;
+    cy += (p.y + q.y) * c;
+  }
+  A = A / 2;
+  if (Math.abs(A) < 1e-9) return mid(pts[0], pts[2] || pts[0]);
+  return {
+    x: cx / (6 * A),
+    y: cy / (6 * A)
+  };
 }
-
-function angleAt(V, P, R){
-  const ux=P.x-V.x, uy=P.y-V.y, vx=R.x-V.x, vy=R.y-V.y;
-  const du=Math.hypot(ux,uy)||1, dv=Math.hypot(vx,vy)||1;
-  const c = clampCos((ux*vx+uy*vy)/(du*dv));
+function fitTransformToRect(pts, rectW, rectH, margin = 46) {
+  const xs = pts.map(p => p.x),
+    ys = pts.map(p => p.y);
+  const minx = Math.min(...xs),
+    maxx = Math.max(...xs);
+  const miny = Math.min(...ys),
+    maxy = Math.max(...ys);
+  const cw = Math.max(1e-6, maxx - minx);
+  const ch = Math.max(1e-6, maxy - miny);
+  const k = Math.min((rectW - 2 * margin) / cw, (rectH - 2 * margin) / ch);
+  const T = p => ({
+    x: margin + k * (p.x - minx),
+    y: rectH - margin - k * (p.y - miny)
+  });
+  return {
+    T,
+    k
+  };
+}
+function angleAt(V, P, R) {
+  const ux = P.x - V.x,
+    uy = P.y - V.y,
+    vx = R.x - V.x,
+    vy = R.y - V.y;
+  const du = Math.hypot(ux, uy) || 1,
+    dv = Math.hypot(vx, vy) || 1;
+  const c = clampCos((ux * vx + uy * vy) / (du * dv));
   return deg(Math.acos(c));
 }
-function unitVec(A,B){ const dx=B.x-A.x, dy=B.y-A.y, L=Math.hypot(dx,dy)||1; return {x:dx/L, y:dy/L}; }
-
-function addHaloText(parent, x, y, txt, fontSizePx, extraAttrs = {}){
+function unitVec(A, B) {
+  const dx = B.x - A.x,
+    dy = B.y - A.y,
+    L = Math.hypot(dx, dy) || 1;
+  return {
+    x: dx / L,
+    y: dy / L
+  };
+}
+function addHaloText(parent, x, y, txt, fontSizePx, extraAttrs = {}) {
   const t = add(parent, "text", {
-    x, y, fill: STYLE.textFill, "font-size": fontSizePx,
+    x,
+    y,
+    fill: STYLE.textFill,
+    "font-size": fontSizePx,
     style: `paint-order:stroke fill;stroke:${STYLE.textHalo};stroke-width:${STYLE.textHaloW};stroke-linejoin:round;`
   });
-  Object.entries(extraAttrs).forEach(([k,v])=>t.setAttribute(k, String(v)));
+  Object.entries(extraAttrs).forEach(([k, v]) => t.setAttribute(k, String(v)));
   t.textContent = txt;
   return t;
 }
 
 /* ---------- PARSE ---------- */
-function parseSpec(str){
+function parseSpec(str) {
   const out = {};
-  if(!str) return out;
+  if (!str) return out;
   str = str.replace(/\bog\b/gi, ',');
-  str.split(/[\s,;\n]+/).forEach(chunk=>{
+  str.split(/[\s,;\n]+/).forEach(chunk => {
     const [kRaw, vRaw] = chunk.split("=");
-    if(!kRaw || !vRaw) return;
-    const key = kRaw.trim().replace(/\s+/g,""); // a,b,c,d,A,B,C,D
-    const v = parseFloat(vRaw.trim().replace(",","."));
-    if(!isFinite(v)) return;
+    if (!kRaw || !vRaw) return;
+    const key = kRaw.trim().replace(/\s+/g, ""); // a,b,c,d,A,B,C,D
+    const v = parseFloat(vRaw.trim().replace(",", "."));
+    if (!isFinite(v)) return;
     out[key] = v;
   });
   return out;
 }
-
-function parseSpecFreeform(str){
+function parseSpecFreeform(str) {
   const out = {};
-  if(!str) return out;
+  if (!str) return out;
 
   // Håndter eksplisitte nøkkel/verdi-par før vi normaliserer teksten
   const pairRegex = /([abcdABCD])\s*=\s*([0-9]+(?:[.,][0-9]+)?)/g;
   let m;
-  while((m = pairRegex.exec(str))){
+  while (m = pairRegex.exec(str)) {
     out[m[1]] = parseFloat(m[2].replace(',', '.'));
   }
-  if(Object.keys(out).length > 0) return out;
-
+  if (Object.keys(out).length > 0) return out;
   let text = str.toLowerCase();
-
   const angMatch = text.match(/rett\s*vinkel\s*(?:i|ved)?\s*([abcd])/);
-  if(angMatch){
+  if (angMatch) {
     const letter = angMatch[1].toUpperCase();
     out[letter] = 90;
     text = text.replace(angMatch[0], "");
   }
   let sidePart = text;
   const mSides = text.match(/(sider?|sidelengder?)\s+(.*)/);
-  if(mSides) sidePart = mSides[2];
-
+  if (mSides) sidePart = mSides[2];
   const nums = [];
   sidePart.split(/[^0-9.,]+/).forEach(tok => {
-    if(!tok) return;
-    if(/^\d+[.,]\d+$/.test(tok)){
+    if (!tok) return;
+    if (/^\d+[.,]\d+$/.test(tok)) {
       nums.push(parseFloat(tok.replace(',', '.')));
-    }else{
-      tok.split(/,+/).forEach(n => { if(n) nums.push(parseFloat(n)); });
+    } else {
+      tok.split(/,+/).forEach(n => {
+        if (n) nums.push(parseFloat(n));
+      });
     }
   });
-
-  if(/kvadrat/.test(text)){
-    const s = nums[0] ?? rand(1,5);
-    Object.assign(out, {a:s, b:s, c:s, d:s, B:90});
+  if (/kvadrat/.test(text)) {
+    var _nums$;
+    const s = (_nums$ = nums[0]) !== null && _nums$ !== void 0 ? _nums$ : rand(1, 5);
+    Object.assign(out, {
+      a: s,
+      b: s,
+      c: s,
+      d: s,
+      B: 90
+    });
     return out;
   }
-
-  if(/firkant/.test(text)){
-    if(nums.length >= 2){
+  if (/firkant/.test(text)) {
+    if (nums.length >= 2) {
       const w = nums[0];
       const h = nums[1];
-      Object.assign(out, {a:w, c:w, b:h, d:h, B:90});
-    }else{
-      const s = nums[0] ?? rand(1,5);
-      Object.assign(out, {a:s, b:s, c:s, d:s, B:90});
+      Object.assign(out, {
+        a: w,
+        c: w,
+        b: h,
+        d: h,
+        B: 90
+      });
+    } else {
+      var _nums$2;
+      const s = (_nums$2 = nums[0]) !== null && _nums$2 !== void 0 ? _nums$2 : rand(1, 5);
+      Object.assign(out, {
+        a: s,
+        b: s,
+        c: s,
+        d: s,
+        B: 90
+      });
     }
     return out;
   }
-
-  if(/rektangel/.test(text)){
+  if (/rektangel/.test(text)) {
     let w, h;
-    if(nums.length >= 2){
+    if (nums.length >= 2) {
       [w, h] = nums;
-    }else if(nums.length === 1){
+    } else if (nums.length === 1) {
       w = nums[0];
-      h = rand(1,5);
-      if(Math.abs(h - w) < 1e-6) h += 1;
-    }else{
-      w = rand(1,5);
-      h = rand(1,5);
-      if(Math.abs(h - w) < 1e-6) h += 1;
+      h = rand(1, 5);
+      if (Math.abs(h - w) < 1e-6) h += 1;
+    } else {
+      w = rand(1, 5);
+      h = rand(1, 5);
+      if (Math.abs(h - w) < 1e-6) h += 1;
     }
-    Object.assign(out, {a:w, c:w, b:h, d:h, B:90});
+    Object.assign(out, {
+      a: w,
+      c: w,
+      b: h,
+      d: h,
+      B: 90
+    });
     return out;
   }
-
-  if(/parallellogram/.test(text)){
-    const w = nums[0] ?? rand(1,5);
-    const h = nums[1] ?? rand(1,5);
-    let B = nums[2] ?? rand(60,120);
-    if(Math.abs(B - 90) < 1e-6) B = 60;
-    Object.assign(out, {a:w, c:w, b:h, d:h, B});
+  if (/parallellogram/.test(text)) {
+    var _nums$3, _nums$4, _nums$5;
+    const w = (_nums$3 = nums[0]) !== null && _nums$3 !== void 0 ? _nums$3 : rand(1, 5);
+    const h = (_nums$4 = nums[1]) !== null && _nums$4 !== void 0 ? _nums$4 : rand(1, 5);
+    let B = (_nums$5 = nums[2]) !== null && _nums$5 !== void 0 ? _nums$5 : rand(60, 120);
+    if (Math.abs(B - 90) < 1e-6) B = 60;
+    Object.assign(out, {
+      a: w,
+      c: w,
+      b: h,
+      d: h,
+      B
+    });
     return out;
   }
-
-  if(/rombe/.test(text)){
-    const s = nums[0] ?? rand(1,5);
-    let B = nums[1] ?? rand(60,120);
-    if(Math.abs(B - 90) < 1e-6) B = 60;
-    Object.assign(out, {a:s, b:s, c:s, d:s, B});
+  if (/rombe/.test(text)) {
+    var _nums$6, _nums$7;
+    const s = (_nums$6 = nums[0]) !== null && _nums$6 !== void 0 ? _nums$6 : rand(1, 5);
+    let B = (_nums$7 = nums[1]) !== null && _nums$7 !== void 0 ? _nums$7 : rand(60, 120);
+    if (Math.abs(B - 90) < 1e-6) B = 60;
+    Object.assign(out, {
+      a: s,
+      b: s,
+      c: s,
+      d: s,
+      B
+    });
     return out;
   }
-
-  if(/likesidet/.test(text) && /trekant/.test(text)){
-    const s = nums[0] ?? 1;
-    Object.assign(out, {a:s, b:s, c:s});
+  if (/likesidet/.test(text) && /trekant/.test(text)) {
+    var _nums$8;
+    const s = (_nums$8 = nums[0]) !== null && _nums$8 !== void 0 ? _nums$8 : 1;
+    Object.assign(out, {
+      a: s,
+      b: s,
+      c: s
+    });
     return out;
   }
-
-  if(/likebeint/.test(text) && /trekant/.test(text)){
+  if (/likebeint/.test(text) && /trekant/.test(text)) {
     let s, base;
-    if(nums.length >= 2){
+    if (nums.length >= 2) {
       s = nums[0];
       base = nums[1];
-    }else if(nums.length === 1){
+    } else if (nums.length === 1) {
       s = nums[0];
-      base = Math.min(2*s - 0.1, rand(1, 2*s - 0.1));
-    }else{
-      s = rand(2,6);
-      base = rand(1, 2*s - 0.5);
+      base = Math.min(2 * s - 0.1, rand(1, 2 * s - 0.1));
+    } else {
+      s = rand(2, 6);
+      base = rand(1, 2 * s - 0.5);
     }
-    if(base >= 2*s) base = 2*s - 0.1;
-    Object.assign(out, {a:s, b:s, c:base});
+    if (base >= 2 * s) base = 2 * s - 0.1;
+    Object.assign(out, {
+      a: s,
+      b: s,
+      c: base
+    });
     return out;
   }
-
-  if(/rettvinkle[dt]/.test(text) && /trekant/.test(text)){
-    const rightLetter = ["A","B","C"].find(L => out[L] === 90) || "C";
-    const legKeys = rightLetter === "A" ? ["b","c"]
-                   : rightLetter === "B" ? ["a","c"]
-                   : ["a","b"];
-
-    if(nums.length === 2){
-      const [x,y] = nums;
+  if (/rettvinkle[dt]/.test(text) && /trekant/.test(text)) {
+    const rightLetter = ["A", "B", "C"].find(L => out[L] === 90) || "C";
+    const legKeys = rightLetter === "A" ? ["b", "c"] : rightLetter === "B" ? ["a", "c"] : ["a", "b"];
+    if (nums.length === 2) {
+      const [x, y] = nums;
       out[legKeys[0]] = x;
       out[legKeys[1]] = y;
       out[rightLetter] = 90;
       return out;
     }
-
-    if(nums.length === 0){
-      const k = rand(1,4);
-      out[legKeys[0]] = 3*k;
-      out[legKeys[1]] = 4*k;
+    if (nums.length === 0) {
+      const k = rand(1, 4);
+      out[legKeys[0]] = 3 * k;
+      out[legKeys[1]] = 4 * k;
       out[rightLetter] = 90;
       return out;
     }
-
     out[rightLetter] = 90;
   }
-
-  if(/trekant/.test(text) && nums.length === 0){
-    const a = rand(2,6);
-    const b = rand(2,6);
-    const cMin = Math.abs(a-b) + 0.5;
+  if (/trekant/.test(text) && nums.length === 0) {
+    const a = rand(2, 6);
+    const b = rand(2, 6);
+    const cMin = Math.abs(a - b) + 0.5;
     const cMax = a + b - 0.5;
     const c = rand(cMin, cMax);
-    Object.assign(out, {a, b, c});
+    Object.assign(out, {
+      a,
+      b,
+      c
+    });
     return out;
   }
-
-  if(nums.length >= 3){
-    const sides = nums.slice(0,3);
-    const assignRemaining = (letters, values)=>{ letters.forEach((L,i)=> out[L] = values[i]); };
-    if(out.A === 90 || out.B === 90 || out.C === 90){
+  if (nums.length >= 3) {
+    const sides = nums.slice(0, 3);
+    const assignRemaining = (letters, values) => {
+      letters.forEach((L, i) => out[L] = values[i]);
+    };
+    if (out.A === 90 || out.B === 90 || out.C === 90) {
       const max = Math.max(...sides);
       const idx = sides.indexOf(max);
-      const others = sides.slice(0,idx).concat(sides.slice(idx+1));
-      if(out.A === 90){
-        out.a = max; assignRemaining(["b","c"], others);
-      }else if(out.B === 90){
-        out.b = max; assignRemaining(["a","c"], others);
-      }else if(out.C === 90){
-        out.c = max; assignRemaining(["a","b"], others);
+      const others = sides.slice(0, idx).concat(sides.slice(idx + 1));
+      if (out.A === 90) {
+        out.a = max;
+        assignRemaining(["b", "c"], others);
+      } else if (out.B === 90) {
+        out.b = max;
+        assignRemaining(["a", "c"], others);
+      } else if (out.C === 90) {
+        out.c = max;
+        assignRemaining(["a", "b"], others);
       }
-    }else{
-      assignRemaining(["a","b","c"], sides);
+    } else {
+      assignRemaining(["a", "b", "c"], sides);
     }
   }
   return out;
 }
-
-function objToSpec(obj){
-  const order = ["a","b","c","d","A","B","C","D"];
-  return order.filter(k => k in obj)
-              .map(k => `${k}=${fmt(obj[k])}`)
-              .join(', ');
+function objToSpec(obj) {
+  const order = ["a", "b", "c", "d", "A", "B", "C", "D"];
+  return order.filter(k => k in obj).map(k => `${k}=${fmt(obj[k])}`).join(', ');
 }
-
-async function parseSpecAI(str){
+async function parseSpecAI(str) {
   const direct = parseSpec(str);
-  if(Object.keys(direct).length > 0) return direct;
-
+  if (Object.keys(direct).length > 0) return direct;
   const quick = parseSpecFreeform(str);
-  if(Object.keys(quick).length > 0) return quick;
-
-  try{
+  if (Object.keys(quick).length > 0) return quick;
+  try {
+    var _data$choices;
     const apiKey = window.OPENAI_API_KEY;
-    if(!apiKey) throw new Error('missing api key');
-
+    if (!apiKey) throw new Error('missing api key');
     const body = {
       model: 'gpt-4o-mini',
-      response_format: { type: 'json_object' },
-      messages: [
-        { role: 'system', content: 'Returner kun JSON med tall for a,b,c,d,A,B,C,D.' },
-        { role: 'user', content: str }
-      ]
+      response_format: {
+        type: 'json_object'
+      },
+      messages: [{
+        role: 'system',
+        content: 'Returner kun JSON med tall for a,b,c,d,A,B,C,D.'
+      }, {
+        role: 'user',
+        content: str
+      }]
     };
     const res = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -371,19 +490,19 @@ async function parseSpecAI(str){
       body: JSON.stringify(body)
     });
     const data = await res.json();
-    const txt = data.choices?.[0]?.message?.content;
-    if(!txt) throw new Error('no content');
+    const txt = (_data$choices = data.choices) === null || _data$choices === void 0 || (_data$choices = _data$choices[0]) === null || _data$choices === void 0 || (_data$choices = _data$choices.message) === null || _data$choices === void 0 ? void 0 : _data$choices.content;
+    if (!txt) throw new Error('no content');
     const parsed = JSON.parse(txt);
     const out = {};
-    Object.entries(parsed).forEach(([k,v])=>{
-      if(/^[abcdABCD]$/.test(k)){
+    Object.entries(parsed).forEach(([k, v]) => {
+      if (/^[abcdABCD]$/.test(k)) {
         const n = parseFloat(String(v).replace(',', '.'));
-        if(isFinite(n)) out[k] = n;
+        if (isFinite(n)) out[k] = n;
       }
     });
-    if(Object.keys(out).length===0) return parseSpec(str);
+    if (Object.keys(out).length === 0) return parseSpec(str);
     return out;
-  }catch(err){
+  } catch (err) {
     console.warn('parseSpecAI fallback', err);
     return parseSpec(str);
   }
@@ -391,341 +510,538 @@ async function parseSpecAI(str){
 
 /* ---------- VISNINGSTEKSTER ---------- */
 // Sider: none | value | custom | custom+value
-function buildSideText(mode, valueStr, customText){
-  const t = (mode ?? "value").toString().trim();
-  if(t === "none")            return null;
-  if(t === "value")           return valueStr;
-  if(t === "custom")          return (customText ?? "");
-  if(t === "custom+value")    return `${customText ?? ""}=${valueStr}`;
+function buildSideText(mode, valueStr, customText) {
+  const t = (mode !== null && mode !== void 0 ? mode : "value").toString().trim();
+  if (t === "none") return null;
+  if (t === "value") return valueStr;
+  if (t === "custom") return customText !== null && customText !== void 0 ? customText : "";
+  if (t === "custom+value") return `${customText !== null && customText !== void 0 ? customText : ""}=${valueStr}`;
   return valueStr; // fallback
 }
 
 /* Vinkler/punkter:
    none | mark | mark+value | custom | custom+mark | custom+mark+value
    → { mark:bool, angleText:string|null, pointLabel:string|null } */
-function parseAnglePointMode(modeStr, valueDeg, customText, fallbackPointLetter){
+function parseAnglePointMode(modeStr, valueDeg, customText, fallbackPointLetter) {
   // tolerer "custum..." som synonym
-  let t = (modeStr ?? "mark+value").toString().trim();
+  let t = (modeStr !== null && modeStr !== void 0 ? modeStr : "mark+value").toString().trim();
   t = t.replace(/^custum/, "custom");
-
-  if(t === "none") return { mark:false, angleText:null, pointLabel:null };
-  const hasMark  = t.includes("mark");
-  const hasVal   = t.includes("value");
+  if (t === "none") return {
+    mark: false,
+    angleText: null,
+    pointLabel: null
+  };
+  const hasMark = t.includes("mark");
+  const hasVal = t.includes("value");
   const isCustom = t.startsWith("custom");
-
   const angleText = hasVal ? `${Math.round(valueDeg)}°` : null;
-  const pointLabel = isCustom ? (customText || fallbackPointLetter || "") : null;
-  return { mark: hasMark, angleText, pointLabel };
+  const pointLabel = isCustom ? customText || fallbackPointLetter || "" : null;
+  return {
+    mark: hasMark,
+    angleText,
+    pointLabel
+  };
 }
 
 /* ---------- ANGLE RADIUS (smart default + ADV) ---------- */
-function angleRadius(Q, P, R){
-  const f   = ADV_CONFIG.angle.factor;
-  const r0  = f * Math.min(dist(Q,P), dist(Q,R));
+function angleRadius(Q, P, R) {
+  const f = ADV_CONFIG.angle.factor;
+  const r0 = f * Math.min(dist(Q, P), dist(Q, R));
   return clamp(r0, ADV_CONFIG.angle.min, ADV_CONFIG.angle.max);
 }
 
 /* ---------- VINKELTEGNING + PLASSERING (NY) ---------- */
-function renderAngle(g, Q, P, R, r, opts){
-  const aDeg = angleAt(Q,P,R);
+function renderAngle(g, Q, P, R, r, opts) {
+  const aDeg = angleAt(Q, P, R);
   const isRight = Math.abs(aDeg - 90) < 0.5;
 
   // retningsvektorer og vinkelhalvering
-  const u = unitVec(Q,P), v = unitVec(Q,R);
-  const bisLen = Math.hypot(u.x+v.x, u.y+v.y) || 1;
-  const bis  = { x:(u.x+v.x)/bisLen, y:(u.y+v.y)/bisLen }; // inn i sektoren
-  const nBis = { x:-bis.x,          y:-bis.y          };   // ut av figuren
+  const u = unitVec(Q, P),
+    v = unitVec(Q, R);
+  const bisLen = Math.hypot(u.x + v.x, u.y + v.y) || 1;
+  const bis = {
+    x: (u.x + v.x) / bisLen,
+    y: (u.y + v.y) / bisLen
+  }; // inn i sektoren
+  const nBis = {
+    x: -bis.x,
+    y: -bis.y
+  }; // ut av figuren
 
   // markering (bue/kvadrat)
-  if(opts.mark){
-    if (isRight){
+  if (opts.mark) {
+    if (isRight) {
       const s = r * 1.0;
-      const q  = {x:Q.x,               y:Q.y};
-      const p1 = {x:Q.x + u.x*s,       y:Q.y + u.y*s};
-      const p2 = {x:Q.x + (u.x+v.x)*s, y:Q.y + (u.y+v.y)*s};
-      const p3 = {x:Q.x + v.x*s,       y:Q.y + v.y*s};
-      add(g,"polygon",{ points:`${q.x},${q.y} ${p1.x},${p1.y} ${p2.x},${p2.y} ${p3.x},${p3.y}`, fill: STYLE.angFill, stroke:"none" });
-      add(g,"polyline",{ points:`${p1.x},${p1.y} ${p2.x},${p2.y} ${p3.x},${p3.y}`, fill:"none", stroke: STYLE.angStroke, "stroke-width": STYLE.angWidth, "stroke-linejoin":"round", "stroke-linecap":"round" });
+      const q = {
+        x: Q.x,
+        y: Q.y
+      };
+      const p1 = {
+        x: Q.x + u.x * s,
+        y: Q.y + u.y * s
+      };
+      const p2 = {
+        x: Q.x + (u.x + v.x) * s,
+        y: Q.y + (u.y + v.y) * s
+      };
+      const p3 = {
+        x: Q.x + v.x * s,
+        y: Q.y + v.y * s
+      };
+      add(g, "polygon", {
+        points: `${q.x},${q.y} ${p1.x},${p1.y} ${p2.x},${p2.y} ${p3.x},${p3.y}`,
+        fill: STYLE.angFill,
+        stroke: "none"
+      });
+      add(g, "polyline", {
+        points: `${p1.x},${p1.y} ${p2.x},${p2.y} ${p3.x},${p3.y}`,
+        fill: "none",
+        stroke: STYLE.angStroke,
+        "stroke-width": STYLE.angWidth,
+        "stroke-linejoin": "round",
+        "stroke-linecap": "round"
+      });
     } else {
-      const a1 = Math.atan2(P.y-Q.y, P.x-Q.x);
-      const a2 = Math.atan2(R.y-Q.y, R.x-Q.x);
-      let d = a2 - a1; while(d<=-Math.PI) d+=2*Math.PI; while(d>Math.PI) d-=2*Math.PI;
-      const o = Math.sign((P.x-Q.x)*(R.y-Q.y) - (P.y-Q.y)*(R.x-Q.x));
-      if(o>0 && d<0) d+=2*Math.PI;
-      if(o<0 && d>0) d-=2*Math.PI;
-      const large = Math.abs(d)>Math.PI ? 1 : 0;
-      const sweep = (o>0)?1:0;
-      const A1 = {x:Q.x + r*Math.cos(a1),   y:Q.y + r*Math.sin(a1)};
-      const B1 = {x:Q.x + r*Math.cos(a1+d), y:Q.y + r*Math.sin(a1+d)};
+      const a1 = Math.atan2(P.y - Q.y, P.x - Q.x);
+      const a2 = Math.atan2(R.y - Q.y, R.x - Q.x);
+      let d = a2 - a1;
+      while (d <= -Math.PI) d += 2 * Math.PI;
+      while (d > Math.PI) d -= 2 * Math.PI;
+      const o = Math.sign((P.x - Q.x) * (R.y - Q.y) - (P.y - Q.y) * (R.x - Q.x));
+      if (o > 0 && d < 0) d += 2 * Math.PI;
+      if (o < 0 && d > 0) d -= 2 * Math.PI;
+      const large = Math.abs(d) > Math.PI ? 1 : 0;
+      const sweep = o > 0 ? 1 : 0;
+      const A1 = {
+        x: Q.x + r * Math.cos(a1),
+        y: Q.y + r * Math.sin(a1)
+      };
+      const B1 = {
+        x: Q.x + r * Math.cos(a1 + d),
+        y: Q.y + r * Math.sin(a1 + d)
+      };
       const path = `M ${Q.x} ${Q.y} L ${A1.x} ${A1.y} A ${r} ${r} 0 ${large} ${sweep} ${B1.x} ${B1.y} Z`;
-      add(g,"path",{ d:path, fill: STYLE.angFill, stroke:"none" });
-      add(g,"path",{ d:path.replace("Z",""), fill:"none", stroke: STYLE.angStroke, "stroke-width": STYLE.angWidth });
+      add(g, "path", {
+        d: path,
+        fill: STYLE.angFill,
+        stroke: "none"
+      });
+      add(g, "path", {
+        d: path.replace("Z", ""),
+        fill: "none",
+        stroke: STYLE.angStroke,
+        "stroke-width": STYLE.angWidth
+      });
     }
   }
-
   const cfg = ADV_CONFIG.angle;
-  const insideK  = isRight ? cfg.insideK.right  : cfg.insideK.other;
+  const insideK = isRight ? cfg.insideK.right : cfg.insideK.other;
   const outsideK = isRight ? cfg.outsideK.right : cfg.outsideK.other;
 
   // 90°: hvis markert, dropp verditekst
   const showAngleValue = opts.angleText && !(isRight && opts.mark);
 
   // vinkelverdi (inne i sektoren)
-  if(showAngleValue){
-    const Ti = { x: Q.x + bis.x * (insideK*r), y: Q.y + bis.y * (insideK*r) };
+  if (showAngleValue) {
+    const Ti = {
+      x: Q.x + bis.x * (insideK * r),
+      y: Q.y + bis.y * (insideK * r)
+    };
     addHaloText(g, Ti.x, Ti.y, opts.angleText, STYLE.angFS, {
-      "text-anchor":"middle", "dominant-baseline":"middle"
+      "text-anchor": "middle",
+      "dominant-baseline": "middle"
     });
   }
 
   // punktnavn (ute på samme linje) – med clamp
-  if(opts.pointLabel){
-    const baseLen   = Math.min(dist(Q,P), dist(Q,R));
-    const outTarget = outsideK*r + cfg.outsidePad;
-    const outMax    = (cfg.outsideMaxFactor ?? 0.9) * baseLen;
-    const outLen    = clamp(outTarget, (cfg.outsideMin ?? 0), outMax);
-    const To = { x: Q.x + nBis.x * outLen, y: Q.y + nBis.y * outLen };
+  if (opts.pointLabel) {
+    var _cfg$outsideMaxFactor, _cfg$outsideMin;
+    const baseLen = Math.min(dist(Q, P), dist(Q, R));
+    const outTarget = outsideK * r + cfg.outsidePad;
+    const outMax = ((_cfg$outsideMaxFactor = cfg.outsideMaxFactor) !== null && _cfg$outsideMaxFactor !== void 0 ? _cfg$outsideMaxFactor : 0.9) * baseLen;
+    const outLen = clamp(outTarget, (_cfg$outsideMin = cfg.outsideMin) !== null && _cfg$outsideMin !== void 0 ? _cfg$outsideMin : 0, outMax);
+    const To = {
+      x: Q.x + nBis.x * outLen,
+      y: Q.y + nBis.y * outLen
+    };
     addHaloText(g, To.x, To.y, opts.pointLabel, STYLE.ptFS, {
-      "text-anchor":"middle", "dominant-baseline":"middle"
+      "text-anchor": "middle",
+      "dominant-baseline": "middle"
     });
   }
 }
 
 /* ---------- TEKST FOR SIDER ---------- */
 function sideLabelText(g, P, Q, text, rotate, centroid, offset = 14) {
-  if(!text) return;
-  const M = { x: (P.x + Q.x) / 2, y: (P.y + Q.y) / 2 };
-  const vx = Q.x - P.x, vy = Q.y - P.y;
-
-  const nx = -vy, ny = vx;
+  if (!text) return;
+  const M = {
+    x: (P.x + Q.x) / 2,
+    y: (P.y + Q.y) / 2
+  };
+  const vx = Q.x - P.x,
+    vy = Q.y - P.y;
+  const nx = -vy,
+    ny = vx;
   const dot = (centroid.x - M.x) * nx + (centroid.y - M.y) * ny;
   const sgn = dot > 0 ? 1 : -1;
   const nlen = Math.hypot(nx, ny) || 1;
-
-  const adj = Math.max(offset, Math.min(22, dist(P,Q)*0.18));
-  const x = M.x + (sgn * adj * nx) / nlen;
-  const y = M.y + (sgn * adj * ny) / nlen;
-
-  const t = addHaloText(g, x, y, text, STYLE.sideFS, { "text-anchor":"middle", "dominant-baseline":"middle" });
-
+  const adj = Math.max(offset, Math.min(22, dist(P, Q) * 0.18));
+  const x = M.x + sgn * adj * nx / nlen;
+  const y = M.y + sgn * adj * ny / nlen;
+  const t = addHaloText(g, x, y, text, STYLE.sideFS, {
+    "text-anchor": "middle",
+    "dominant-baseline": "middle"
+  });
   if (rotate) {
     let theta = Math.atan2(vy, vx) * 180 / Math.PI;
-    if (theta > 90)  theta -= 180;
+    if (theta > 90) theta -= 180;
     if (theta < -90) theta += 180;
     t.setAttribute("transform", `rotate(${theta}, ${x}, ${y})`);
   }
 }
 
 /* ---------- TEGN FIGURER ---------- */
-function ptsTo(arr){ return arr.map(p=>`${p.x},${p.y}`).join(" "); }
-function shift(P, rect){ return {x:P.x + rect.x, y:P.y + rect.y}; }
-function errorBox(g, rect, msg){
-  add(g,"rect",{x:rect.x+10, y:rect.y+10, width:rect.w-20, height:40, rx:8, fill:"#ffecec", stroke:"#ffb3b3"});
-  add(g,"text",{x:rect.x+20, y:rect.y+36, fill:"#c00", "font-size":16}).textContent = msg;
+function ptsTo(arr) {
+  return arr.map(p => `${p.x},${p.y}`).join(" ");
 }
-
-function drawTriangleToGroup(g, rect, spec, adv){
-  const s = (typeof spec === 'string') ? parseSpec(spec) : spec;
+function shift(P, rect) {
+  return {
+    x: P.x + rect.x,
+    y: P.y + rect.y
+  };
+}
+function errorBox(g, rect, msg) {
+  add(g, "rect", {
+    x: rect.x + 10,
+    y: rect.y + 10,
+    width: rect.w - 20,
+    height: 40,
+    rx: 8,
+    fill: "#ffecec",
+    stroke: "#ffb3b3"
+  });
+  add(g, "text", {
+    x: rect.x + 20,
+    y: rect.y + 36,
+    fill: "#c00",
+    "font-size": 16
+  }).textContent = msg;
+}
+function drawTriangleToGroup(g, rect, spec, adv) {
+  var _Cs$1$y, _Cs$, _m$a, _m$b, _m$c, _am$A, _am$B, _am$C;
+  const s = typeof spec === 'string' ? parseSpec(spec) : spec;
   const sol = solveTriangle(s);
 
   // y-opp konfig
-  const A0={x:0, y:0};
-  const B0={x:sol.c, y:0};
+  const A0 = {
+    x: 0,
+    y: 0
+  };
+  const B0 = {
+    x: sol.c,
+    y: 0
+  };
   const Cs = circleCircle(A0, sol.b, B0, sol.a);
-  if(Cs.length===0) throw new Error("Trekant: ingen løsning fra oppgitte verdier.");
-  const C0 = (Cs[0].y >= (Cs[1]?.y ?? -1e9) ? Cs[0] : (Cs[1] || Cs[0]));
-
-  const base=[A0,B0,C0];
-  const {T} = fitTransformToRect(base, rect.w, rect.h, 46);
-  const A=shift(T(A0),rect), B=shift(T(B0),rect), C=shift(T(C0),rect), poly=[A,B,C];
-
-  add(g,"polygon",{points:ptsTo(poly), fill:STYLE.faceFill, stroke:"none"});
+  if (Cs.length === 0) throw new Error("Trekant: ingen løsning fra oppgitte verdier.");
+  const C0 = Cs[0].y >= ((_Cs$1$y = (_Cs$ = Cs[1]) === null || _Cs$ === void 0 ? void 0 : _Cs$.y) !== null && _Cs$1$y !== void 0 ? _Cs$1$y : -1e9) ? Cs[0] : Cs[1] || Cs[0];
+  const base = [A0, B0, C0];
+  const {
+    T
+  } = fitTransformToRect(base, rect.w, rect.h, 46);
+  const A = shift(T(A0), rect),
+    B = shift(T(B0), rect),
+    C = shift(T(C0), rect),
+    poly = [A, B, C];
+  add(g, "polygon", {
+    points: ptsTo(poly),
+    fill: STYLE.faceFill,
+    stroke: "none"
+  });
   const ctr = polygonCentroid(poly);
 
   // sider
-  const m = adv.sides.mode, st = adv.sides.text;
-  sideLabelText(g, B, C, buildSideText(m.a ?? m.default, fmt(sol.a), st.a), true, ctr);
-  sideLabelText(g, C, A, buildSideText(m.b ?? m.default, fmt(sol.b), st.b), true, ctr);
-  sideLabelText(g, A, B, buildSideText(m.c ?? m.default, fmt(sol.c), st.c), true, ctr);
+  const m = adv.sides.mode,
+    st = adv.sides.text;
+  sideLabelText(g, B, C, buildSideText((_m$a = m.a) !== null && _m$a !== void 0 ? _m$a : m.default, fmt(sol.a), st.a), true, ctr);
+  sideLabelText(g, C, A, buildSideText((_m$b = m.b) !== null && _m$b !== void 0 ? _m$b : m.default, fmt(sol.b), st.b), true, ctr);
+  sideLabelText(g, A, B, buildSideText((_m$c = m.c) !== null && _m$c !== void 0 ? _m$c : m.default, fmt(sol.c), st.c), true, ctr);
 
   // vinkler/punkter
-  const am = adv.angles.mode, at = adv.angles.text;
-  const Ares = parseAnglePointMode(am.A ?? am.default, angleAt(A,B,C), at.A, "A");
-  const Bres = parseAnglePointMode(am.B ?? am.default, angleAt(B,C,A), at.B, "B");
-  const Cres = parseAnglePointMode(am.C ?? am.default, angleAt(C,A,B), at.C, "C");
-
-  renderAngle(g, A, B, C, angleRadius(A,B,C), { mark:Ares.mark, angleText:Ares.angleText, pointLabel:Ares.pointLabel });
-  renderAngle(g, B, C, A, angleRadius(B,C,A), { mark:Bres.mark, angleText:Bres.angleText, pointLabel:Bres.pointLabel });
-  renderAngle(g, C, A, B, angleRadius(C,A,B), { mark:Cres.mark, angleText:Cres.angleText, pointLabel:Cres.pointLabel });
-
-  add(g,"polygon",{points:ptsTo(poly), fill:"none", stroke:STYLE.edgeStroke, "stroke-width": STYLE.edgeWidth, "stroke-linejoin":"round","stroke-linecap":"round"});
+  const am = adv.angles.mode,
+    at = adv.angles.text;
+  const Ares = parseAnglePointMode((_am$A = am.A) !== null && _am$A !== void 0 ? _am$A : am.default, angleAt(A, B, C), at.A, "A");
+  const Bres = parseAnglePointMode((_am$B = am.B) !== null && _am$B !== void 0 ? _am$B : am.default, angleAt(B, C, A), at.B, "B");
+  const Cres = parseAnglePointMode((_am$C = am.C) !== null && _am$C !== void 0 ? _am$C : am.default, angleAt(C, A, B), at.C, "C");
+  renderAngle(g, A, B, C, angleRadius(A, B, C), {
+    mark: Ares.mark,
+    angleText: Ares.angleText,
+    pointLabel: Ares.pointLabel
+  });
+  renderAngle(g, B, C, A, angleRadius(B, C, A), {
+    mark: Bres.mark,
+    angleText: Bres.angleText,
+    pointLabel: Bres.pointLabel
+  });
+  renderAngle(g, C, A, B, angleRadius(C, A, B), {
+    mark: Cres.mark,
+    angleText: Cres.angleText,
+    pointLabel: Cres.pointLabel
+  });
+  add(g, "polygon", {
+    points: ptsTo(poly),
+    fill: "none",
+    stroke: STYLE.edgeStroke,
+    "stroke-width": STYLE.edgeWidth,
+    "stroke-linejoin": "round",
+    "stroke-linecap": "round"
+  });
 }
-
-function drawQuadToGroup(g, rect, spec, adv){
-  const s = (typeof spec === 'string') ? parseSpec(spec) : spec;
-  let {a,b,c,d,A:AngA,B:AngB,C:AngC,D:AngD} = s;
-  if(!(a>0 && b>0 && c>0)) throw new Error("Firkant: må ha a, b, c > 0.");
-  const angleKeys = ["A","B","C","D"].filter(k => k in s);
-  if(angleKeys.length===0) throw new Error("Firkant: angi vinkel (minst én).");
-
-  const A0={x:0,y:0}, B0={x:a,y:0}; let C0, D0;
-  
+function drawQuadToGroup(g, rect, spec, adv) {
+  var _m$a2, _m$b2, _m$c2, _m$d, _am$A2, _am$B2, _am$C2, _am$D;
+  const s = typeof spec === 'string' ? parseSpec(spec) : spec;
+  let {
+    a,
+    b,
+    c,
+    d,
+    A: AngA,
+    B: AngB,
+    C: AngC,
+    D: AngD
+  } = s;
+  if (!(a > 0 && b > 0 && c > 0)) throw new Error("Firkant: må ha a, b, c > 0.");
+  const angleKeys = ["A", "B", "C", "D"].filter(k => k in s);
+  if (angleKeys.length === 0) throw new Error("Firkant: angi vinkel (minst én).");
+  const A0 = {
+      x: 0,
+      y: 0
+    },
+    B0 = {
+      x: a,
+      y: 0
+    };
+  let C0, D0;
   const pickCCW_D = (C, D1, D2) => {
-    const area1 = polygonArea([A0,B0,C,D1]);
-    const area2 = polygonArea([A0,B0,C,D2]);
-    if(area1 >= 0 && area2 < 0) return D1;
-    if(area2 >= 0 && area1 < 0) return D2;
-    return (area1 >= area2) ? D1 : D2;
+    const area1 = polygonArea([A0, B0, C, D1]);
+    const area2 = polygonArea([A0, B0, C, D2]);
+    if (area1 >= 0 && area2 < 0) return D1;
+    if (area2 >= 0 && area1 < 0) return D2;
+    return area1 >= area2 ? D1 : D2;
   };
-
-  if(angleKeys.length===1 && d>0){
+  if (angleKeys.length === 1 && d > 0) {
     const angleKey = angleKeys[0];
-    if(angleKey === "A"){
+    if (angleKey === "A") {
       const theta = rad(AngA);
-      D0 = {x: A0.x + d*Math.cos(theta), y: A0.y + d*Math.sin(theta)};
+      D0 = {
+        x: A0.x + d * Math.cos(theta),
+        y: A0.y + d * Math.sin(theta)
+      };
       const Cs = circleCircle(B0, b, D0, c);
-      if(Cs.length===0) throw new Error("Firkant (A): ingen løsning – sjekk mål.");
-      C0 = (Cs.length===1) ? Cs[0] : (polygonArea([A0,B0,Cs[0],D0]) > polygonArea([A0,B0,Cs[1],D0]) ? Cs[0] : Cs[1]);
-    } else if(angleKey === "B"){
+      if (Cs.length === 0) throw new Error("Firkant (A): ingen løsning – sjekk mål.");
+      C0 = Cs.length === 1 ? Cs[0] : polygonArea([A0, B0, Cs[0], D0]) > polygonArea([A0, B0, Cs[1], D0]) ? Cs[0] : Cs[1];
+    } else if (angleKey === "B") {
       const theta = Math.PI - rad(AngB);
-      C0 = {x: B0.x + b*Math.cos(theta), y: B0.y + b*Math.sin(theta)};
+      C0 = {
+        x: B0.x + b * Math.cos(theta),
+        y: B0.y + b * Math.sin(theta)
+      };
       const Ds = circleCircle(A0, d, C0, c);
-      if(Ds.length===0) throw new Error("Firkant (B): ingen løsning – sjekk mål.");
-      D0 = (Ds.length===1) ? Ds[0] : pickCCW_D(C0, Ds[0], Ds[1]);
+      if (Ds.length === 0) throw new Error("Firkant (B): ingen løsning – sjekk mål.");
+      D0 = Ds.length === 1 ? Ds[0] : pickCCW_D(C0, Ds[0], Ds[1]);
     } else {
+      var _Cs$1$y2, _Cs$2;
       const Cs = circleCircle(A0, b, B0, a);
-      if(Cs.length===0) throw new Error(`Firkant (${angleKey}): ingen løsning – sjekk mål.`);
-      C0 = (Cs[0].y >= (Cs[1]?.y ?? -1e9) ? Cs[0] : (Cs[1] || Cs[0]));
+      if (Cs.length === 0) throw new Error(`Firkant (${angleKey}): ingen løsning – sjekk mål.`);
+      C0 = Cs[0].y >= ((_Cs$1$y2 = (_Cs$2 = Cs[1]) === null || _Cs$2 === void 0 ? void 0 : _Cs$2.y) !== null && _Cs$1$y2 !== void 0 ? _Cs$1$y2 : -1e9) ? Cs[0] : Cs[1] || Cs[0];
       const Ds = circleCircle(A0, d, C0, c);
-      if(Ds.length===0) throw new Error(`Firkant (${angleKey}): ingen løsning – sjekk mål.`);
-      if(Ds.length===1){ D0 = Ds[0]; }
-      else{
-        if(angleKey === "C"){
-          const cand = Ds.map(Dc => ({D: Dc, ang: angleAt(C0, B0, Dc)}));
-          cand.sort((u,v)=> Math.abs(u.ang - AngC) - Math.abs(v.ang - AngC));
+      if (Ds.length === 0) throw new Error(`Firkant (${angleKey}): ingen løsning – sjekk mål.`);
+      if (Ds.length === 1) {
+        D0 = Ds[0];
+      } else {
+        if (angleKey === "C") {
+          const cand = Ds.map(Dc => ({
+            D: Dc,
+            ang: angleAt(C0, B0, Dc)
+          }));
+          cand.sort((u, v) => Math.abs(u.ang - AngC) - Math.abs(v.ang - AngC));
           D0 = cand[0].D;
-          if(polygonArea([A0,B0,C0,D0]) < 0) D0 = (Ds[0]===D0 ? Ds[1] : Ds[0]);
-        } else if(angleKey === "D"){
-          const cand = Ds.map(Dc => ({D: Dc, ang: angleAt(Dc, C0, A0)}));
-          cand.sort((u,v)=> Math.abs(u.ang - AngD) - Math.abs(v.ang - AngD));
+          if (polygonArea([A0, B0, C0, D0]) < 0) D0 = Ds[0] === D0 ? Ds[1] : Ds[0];
+        } else if (angleKey === "D") {
+          const cand = Ds.map(Dc => ({
+            D: Dc,
+            ang: angleAt(Dc, C0, A0)
+          }));
+          cand.sort((u, v) => Math.abs(u.ang - AngD) - Math.abs(v.ang - AngD));
           D0 = cand[0].D;
-          if(polygonArea([A0,B0,C0,D0]) < 0) D0 = (Ds[0]===D0 ? Ds[1] : Ds[0]);
+          if (polygonArea([A0, B0, C0, D0]) < 0) D0 = Ds[0] === D0 ? Ds[1] : Ds[0];
         } else {
           D0 = pickCCW_D(C0, Ds[0], Ds[1]);
         }
       }
     }
-  } else if(angleKeys.length===2 && !d){
-    if(angleKeys.includes("B") && angleKeys.includes("D")){
+  } else if (angleKeys.length === 2 && !d) {
+    if (angleKeys.includes("B") && angleKeys.includes("D")) {
       const thetaB = Math.PI - rad(AngB);
-      C0 = {x: B0.x + b*Math.cos(thetaB), y: B0.y + b*Math.sin(thetaB)};
+      C0 = {
+        x: B0.x + b * Math.cos(thetaB),
+        y: B0.y + b * Math.sin(thetaB)
+      };
       const AC = dist(A0, C0);
-      const cosD = Math.cos(rad(AngD)), sinD = Math.sin(rad(AngD));
-      const disc = AC*AC - (c*sinD)*(c*sinD);
-      if(disc < 0) throw new Error("Firkant (B&D): ingen løsning – sjekk mål.");
-      d = c*cosD + Math.sqrt(disc);
+      const cosD = Math.cos(rad(AngD)),
+        sinD = Math.sin(rad(AngD));
+      const disc = AC * AC - c * sinD * (c * sinD);
+      if (disc < 0) throw new Error("Firkant (B&D): ingen løsning – sjekk mål.");
+      d = c * cosD + Math.sqrt(disc);
       const Ds = circleCircle(A0, d, C0, c);
-      if(Ds.length===0) throw new Error("Firkant (B&D): ingen løsning – sjekk mål.");
-      D0 = (Ds.length===1) ? Ds[0] : pickCCW_D(C0, Ds[0], Ds[1]);
+      if (Ds.length === 0) throw new Error("Firkant (B&D): ingen løsning – sjekk mål.");
+      D0 = Ds.length === 1 ? Ds[0] : pickCCW_D(C0, Ds[0], Ds[1]);
     } else {
       throw new Error("Firkant: to vinkler støttes bare for B og D.");
     }
   } else {
     throw new Error("Firkant: støttes med d+1 vinkel eller to vinkler B og D.");
   }
-
-  const base=[A0,B0,C0,D0];
-  const {T} = fitTransformToRect(base, rect.w, rect.h, 46);
-  const A=shift(T(A0),rect), B=shift(T(B0),rect), C=shift(T(C0),rect), D=shift(T(D0),rect);
-  const poly=[A,B,C,D];
-
-  add(g,"polygon",{points:ptsTo(poly), fill:STYLE.faceFill, stroke:"none"});
+  const base = [A0, B0, C0, D0];
+  const {
+    T
+  } = fitTransformToRect(base, rect.w, rect.h, 46);
+  const A = shift(T(A0), rect),
+    B = shift(T(B0), rect),
+    C = shift(T(C0), rect),
+    D = shift(T(D0), rect);
+  const poly = [A, B, C, D];
+  add(g, "polygon", {
+    points: ptsTo(poly),
+    fill: STYLE.faceFill,
+    stroke: "none"
+  });
   const ctr = polygonCentroid(poly);
 
   // sider
-  const m = adv.sides.mode, st = adv.sides.text;
-  sideLabelText(g, A, B, buildSideText(m.a ?? m.default, fmt(a), st.a), true, ctr);
-  sideLabelText(g, B, C, buildSideText(m.b ?? m.default, fmt(b), st.b), true, ctr);
-  sideLabelText(g, C, D, buildSideText(m.c ?? m.default, fmt(c), st.c), true, ctr);
-  sideLabelText(g, D, A, buildSideText(m.d ?? m.default, fmt(d), st.d), true, ctr);
+  const m = adv.sides.mode,
+    st = adv.sides.text;
+  sideLabelText(g, A, B, buildSideText((_m$a2 = m.a) !== null && _m$a2 !== void 0 ? _m$a2 : m.default, fmt(a), st.a), true, ctr);
+  sideLabelText(g, B, C, buildSideText((_m$b2 = m.b) !== null && _m$b2 !== void 0 ? _m$b2 : m.default, fmt(b), st.b), true, ctr);
+  sideLabelText(g, C, D, buildSideText((_m$c2 = m.c) !== null && _m$c2 !== void 0 ? _m$c2 : m.default, fmt(c), st.c), true, ctr);
+  sideLabelText(g, D, A, buildSideText((_m$d = m.d) !== null && _m$d !== void 0 ? _m$d : m.default, fmt(d), st.d), true, ctr);
 
   // vinkler/punkter
-  const am = adv.angles.mode, at = adv.angles.text;
-  const Ares = parseAnglePointMode(am.A ?? am.default, angleAt(A,D,B), at.A, "A");
-  const Bres = parseAnglePointMode(am.B ?? am.default, angleAt(B,A,C), at.B, "B");
-  const Cres = parseAnglePointMode(am.C ?? am.default, angleAt(C,B,D), at.C, "C");
-  const Dres = parseAnglePointMode(am.D ?? am.default, angleAt(D,C,A), at.D, "D");
-
-  renderAngle(g, A, D, B, angleRadius(A,D,B), { mark:Ares.mark, angleText:Ares.angleText, pointLabel:Ares.pointLabel });
-  renderAngle(g, B, A, C, angleRadius(B,A,C), { mark:Bres.mark, angleText:Bres.angleText, pointLabel:Bres.pointLabel });
-  renderAngle(g, C, B, D, angleRadius(C,B,D), { mark:Cres.mark, angleText:Cres.angleText, pointLabel:Cres.pointLabel });
-  renderAngle(g, D, C, A, angleRadius(D,C,A), { mark:Dres.mark, angleText:Dres.angleText, pointLabel:Dres.pointLabel });
-
-  add(g,"polygon",{points:ptsTo(poly), fill:"none", stroke:STYLE.edgeStroke, "stroke-width": STYLE.edgeWidth, "stroke-linejoin":"round","stroke-linecap":"round"});
+  const am = adv.angles.mode,
+    at = adv.angles.text;
+  const Ares = parseAnglePointMode((_am$A2 = am.A) !== null && _am$A2 !== void 0 ? _am$A2 : am.default, angleAt(A, D, B), at.A, "A");
+  const Bres = parseAnglePointMode((_am$B2 = am.B) !== null && _am$B2 !== void 0 ? _am$B2 : am.default, angleAt(B, A, C), at.B, "B");
+  const Cres = parseAnglePointMode((_am$C2 = am.C) !== null && _am$C2 !== void 0 ? _am$C2 : am.default, angleAt(C, B, D), at.C, "C");
+  const Dres = parseAnglePointMode((_am$D = am.D) !== null && _am$D !== void 0 ? _am$D : am.default, angleAt(D, C, A), at.D, "D");
+  renderAngle(g, A, D, B, angleRadius(A, D, B), {
+    mark: Ares.mark,
+    angleText: Ares.angleText,
+    pointLabel: Ares.pointLabel
+  });
+  renderAngle(g, B, A, C, angleRadius(B, A, C), {
+    mark: Bres.mark,
+    angleText: Bres.angleText,
+    pointLabel: Bres.pointLabel
+  });
+  renderAngle(g, C, B, D, angleRadius(C, B, D), {
+    mark: Cres.mark,
+    angleText: Cres.angleText,
+    pointLabel: Cres.pointLabel
+  });
+  renderAngle(g, D, C, A, angleRadius(D, C, A), {
+    mark: Dres.mark,
+    angleText: Dres.angleText,
+    pointLabel: Dres.pointLabel
+  });
+  add(g, "polygon", {
+    points: ptsTo(poly),
+    fill: "none",
+    stroke: STYLE.edgeStroke,
+    "stroke-width": STYLE.edgeWidth,
+    "stroke-linejoin": "round",
+    "stroke-linecap": "round"
+  });
 }
 
 /* ---------- ORKESTRERING ---------- */
-const BASE_W = 600, BASE_H = 420, GAP = 60;
-
-async function collectJobsFromSpecs(text){
+const BASE_W = 600,
+  BASE_H = 420,
+  GAP = 60;
+async function collectJobsFromSpecs(text) {
   const lines = String(text).split(/\n/);
   const jobs = [];
   const newLines = [];
-  for(const raw of lines){
+  for (const raw of lines) {
     const line = raw.trim();
-    if(!line){ newLines.push(""); continue; }
-    if(jobs.length >= 2){ newLines.push(line); continue; }
+    if (!line) {
+      newLines.push("");
+      continue;
+    }
+    if (jobs.length >= 2) {
+      newLines.push(line);
+      continue;
+    }
     const obj = await parseSpecAI(line);
-    if(Object.keys(obj).length===0){ newLines.push(line); continue; }
-    const isQuad = ("d" in obj) || ("D" in obj);
-    jobs.push({type: isQuad ? "quad" : "tri", obj});
+    if (Object.keys(obj).length === 0) {
+      newLines.push(line);
+      continue;
+    }
+    const isQuad = "d" in obj || "D" in obj;
+    jobs.push({
+      type: isQuad ? "quad" : "tri",
+      obj
+    });
     newLines.push(objToSpec(obj));
   }
   const newText = newLines.join("\n");
-  if(newText !== text){
+  if (newText !== text) {
     STATE.specsText = newText;
     const el = document.querySelector("#inpSpecs");
-    if(el) el.value = newText;
+    if (el) el.value = newText;
   }
   return jobs;
 }
-
-function svgToString(svgEl){
+function svgToString(svgEl) {
   const clone = svgEl.cloneNode(true);
   const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
   const style = document.createElement('style');
   style.textContent = css;
   clone.insertBefore(style, clone.firstChild);
-  clone.setAttribute("xmlns","http://www.w3.org/2000/svg");
-  clone.setAttribute("xmlns:xlink","http://www.w3.org/1999/xlink");
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  clone.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
   return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
 }
-function downloadSVG(svgEl, filename){
+function downloadSVG(svgEl, filename) {
   const data = svgToString(svgEl);
-  const blob = new Blob([data], {type:"image/svg+xml;charset=utf-8"});
+  const blob = new Blob([data], {
+    type: "image/svg+xml;charset=utf-8"
+  });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
-  a.href = url; a.download = filename.endsWith(".svg")? filename : filename + ".svg";
-  document.body.appendChild(a); a.click(); a.remove();
-  setTimeout(()=>URL.revokeObjectURL(url), 1000);
+  a.href = url;
+  a.download = filename.endsWith(".svg") ? filename : filename + ".svg";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 /* ---------- PNG-EKSPORT ---------- */
-function downloadPNG(svgEl, filename, scale = 2, bg = "#fff"){
+function downloadPNG(svgEl, filename, scale = 2, bg = "#fff") {
   // hent dimensjoner fra viewBox
   const vb = svgEl.viewBox.baseVal;
-  const w = vb?.width  || svgEl.clientWidth  || 1200;
-  const h = vb?.height || svgEl.clientHeight || 800;
+  const w = (vb === null || vb === void 0 ? void 0 : vb.width) || svgEl.clientWidth || 1200;
+  const h = (vb === null || vb === void 0 ? void 0 : vb.height) || svgEl.clientHeight || 800;
 
   // gjør SVG om til data-URL
   const svgData = svgToString(svgEl);
-  const blob = new Blob([svgData], { type: "image/svg+xml;charset=utf-8" });
-  const url  = URL.createObjectURL(blob);
-
+  const blob = new Blob([svgData], {
+    type: "image/svg+xml;charset=utf-8"
+  });
+  const url = URL.createObjectURL(blob);
   const img = new Image();
   img.onload = () => {
     const canvas = document.createElement("canvas");
-    canvas.width  = Math.round(w * scale);
+    canvas.width = Math.round(w * scale);
     canvas.height = Math.round(h * scale);
     const ctx = canvas.getContext("2d");
     // hvit bakgrunn
@@ -734,99 +1050,144 @@ function downloadPNG(svgEl, filename, scale = 2, bg = "#fff"){
     // tegn svg inn
     ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
     URL.revokeObjectURL(url);
-
-    canvas.toBlob((pngBlob)=>{
+    canvas.toBlob(pngBlob => {
       const urlPng = URL.createObjectURL(pngBlob);
       const a = document.createElement("a");
       a.href = urlPng;
       a.download = filename.endsWith(".png") ? filename : filename + ".png";
-      document.body.appendChild(a); a.click(); a.remove();
-      setTimeout(()=>URL.revokeObjectURL(urlPng), 1000);
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(urlPng), 1000);
     }, "image/png");
   };
   img.src = url;
 }
 
 /* bygg adv fra STATE (sider + vinkler/punkter) */
-function buildAdvForFig(figState){
-  const sidesMode = { default: figState.sides.default };
-  ["a","b","c","d"].forEach(k=>{
+function buildAdvForFig(figState) {
+  const sidesMode = {
+    default: figState.sides.default
+  };
+  ["a", "b", "c", "d"].forEach(k => {
     const mode = figState.sides[k];
-    if(mode && mode !== "inherit") sidesMode[k] = mode;
+    if (mode && mode !== "inherit") sidesMode[k] = mode;
   });
   const sidesText = {
-    a: figState.sides.aText, b: figState.sides.bText, c: figState.sides.cText, d: figState.sides.dText
+    a: figState.sides.aText,
+    b: figState.sides.bText,
+    c: figState.sides.cText,
+    d: figState.sides.dText
   };
-
-  const angMode = { default: figState.angles.default };
-  ["A","B","C","D"].forEach(k=>{
+  const angMode = {
+    default: figState.angles.default
+  };
+  ["A", "B", "C", "D"].forEach(k => {
     const mode = figState.angles[k];
-    if(mode && mode !== "inherit") angMode[k] = mode;
+    if (mode && mode !== "inherit") angMode[k] = mode;
   });
   const angText = {
-    A: figState.angles.AText, B: figState.angles.BText, C: figState.angles.CText, D: figState.angles.DText
+    A: figState.angles.AText,
+    B: figState.angles.BText,
+    C: figState.angles.CText,
+    D: figState.angles.DText
   };
-
-  return { sides: {mode: sidesMode, text: sidesText}, angles: {mode: angMode, text: angText} };
+  return {
+    sides: {
+      mode: sidesMode,
+      text: sidesText
+    },
+    angles: {
+      mode: angMode,
+      text: angText
+    }
+  };
 }
-
-async function renderCombined(){
+async function renderCombined() {
   const svg = document.getElementById("paper");
   svg.innerHTML = "";
-
   const jobs = await collectJobsFromSpecs(STATE.specsText);
   const n = jobs.length;
-
   const fig2Settings = document.getElementById("fig2Settings");
-  if(fig2Settings) fig2Settings.style.display = n >= 2 ? "" : "none";
-
-  if(n===0){
+  if (fig2Settings) fig2Settings.style.display = n >= 2 ? "" : "none";
+  if (n === 0) {
     svg.setAttribute("viewBox", `0 0 ${BASE_W} ${BASE_H}`);
-    add(svg,"text",{x:20,y:40,fill:"#6b7280","font-size":18}).textContent = "Skriv 1–2 SPECS- eller tekstlinjer for å tegne figur(er).";
-    svg.setAttribute("aria-label","");
+    add(svg, "text", {
+      x: 20,
+      y: 40,
+      fill: "#6b7280",
+      "font-size": 18
+    }).textContent = "Skriv 1–2 SPECS- eller tekstlinjer for å tegne figur(er).";
+    svg.setAttribute("aria-label", "");
     return;
   }
-
-  let totalW = BASE_W, totalH = BASE_H;
-  if(n===1){
-    totalW = BASE_W; totalH = BASE_H;
-  } else if(STATE.layout === "row"){
-    totalW = BASE_W*2 + GAP; totalH = BASE_H;
+  let totalW = BASE_W,
+    totalH = BASE_H;
+  if (n === 1) {
+    totalW = BASE_W;
+    totalH = BASE_H;
+  } else if (STATE.layout === "row") {
+    totalW = BASE_W * 2 + GAP;
+    totalH = BASE_H;
   } else {
-    totalW = BASE_W; totalH = BASE_H*2 + GAP;
+    totalW = BASE_W;
+    totalH = BASE_H * 2 + GAP;
   }
   svg.setAttribute("viewBox", `0 0 ${totalW} ${totalH}`);
-
   const groups = [];
-  for(let i=0;i<n;i++) groups.push(add(svg,"g",{}));
-
+  for (let i = 0; i < n; i++) groups.push(add(svg, "g", {}));
   const rects = [];
-  if(n===1){
-    rects.push({x:0, y:0, w:BASE_W, h:BASE_H});
-  } else if(STATE.layout === "row"){
-    rects.push({x:0, y:0, w:BASE_W, h:BASE_H});
-    rects.push({x:BASE_W+GAP, y:0, w:BASE_W, h:BASE_H});
+  if (n === 1) {
+    rects.push({
+      x: 0,
+      y: 0,
+      w: BASE_W,
+      h: BASE_H
+    });
+  } else if (STATE.layout === "row") {
+    rects.push({
+      x: 0,
+      y: 0,
+      w: BASE_W,
+      h: BASE_H
+    });
+    rects.push({
+      x: BASE_W + GAP,
+      y: 0,
+      w: BASE_W,
+      h: BASE_H
+    });
   } else {
-    rects.push({x:0, y:0, w:BASE_W, h:BASE_H});
-    rects.push({x:0, y:BASE_H+GAP, w:BASE_W, h:BASE_H});
+    rects.push({
+      x: 0,
+      y: 0,
+      w: BASE_W,
+      h: BASE_H
+    });
+    rects.push({
+      x: 0,
+      y: BASE_H + GAP,
+      w: BASE_W,
+      h: BASE_H
+    });
   }
-
-  for(let i=0;i<n;i++){
-    const {type, obj} = jobs[i];
-    const adv = buildAdvForFig(i===0 ? STATE.fig1 : STATE.fig2);
-    try{
-      if(type==="tri") drawTriangleToGroup(groups[i], rects[i], obj, adv);
-      else            drawQuadToGroup(groups[i], rects[i], obj, adv);
-    }catch(e){
-      errorBox(groups[i], rects[i], String(e.message||e));
+  for (let i = 0; i < n; i++) {
+    const {
+      type,
+      obj
+    } = jobs[i];
+    const adv = buildAdvForFig(i === 0 ? STATE.fig1 : STATE.fig2);
+    try {
+      if (type === "tri") drawTriangleToGroup(groups[i], rects[i], obj, adv);else drawQuadToGroup(groups[i], rects[i], obj, adv);
+    } catch (e) {
+      errorBox(groups[i], rects[i], String(e.message || e));
     }
   }
-
-  svg.setAttribute("aria-label", n===1 ? "Én figur" : "To figurer i samme bilde");
+  svg.setAttribute("aria-label", n === 1 ? "Én figur" : "To figurer i samme bilde");
 }
 
 /* ---------- UI BIND ---------- */
-function bindUI(){
+function bindUI() {
   ensureStateDefaults();
   const $ = sel => document.querySelector(sel);
   const inpSpecs = $("#inpSpecs");
@@ -834,85 +1195,96 @@ function bindUI(){
   const btnSvg = $("#btnSvg");
   const btnPng = $("#btnPng");
   const btnDraw = $("#btnDraw");
-
-  const f1Sides=$("#f1Sides"), f1Angles=$("#f1Angles");
-  const f2Sides=$("#f2Sides"), f2Angles=$("#f2Angles");
-
-  const sideToggles = [], angToggles = [];
-
-  function wireSide(figKey, key, selId, txtId, placeholder){
-    const sel = $(selId), txt = $(txtId);
+  const f1Sides = $("#f1Sides"),
+    f1Angles = $("#f1Angles");
+  const f2Sides = $("#f2Sides"),
+    f2Angles = $("#f2Angles");
+  const sideToggles = [],
+    angToggles = [];
+  function wireSide(figKey, key, selId, txtId, placeholder) {
+    var _sides$key, _sides$textKey;
+    const sel = $(selId),
+      txt = $(txtId);
     const textKey = key + "Text";
     const getFig = () => STATE[figKey];
-    const getSides = () => getFig()?.sides;
-
+    const getSides = () => {
+      var _getFig;
+      return (_getFig = getFig()) === null || _getFig === void 0 ? void 0 : _getFig.sides;
+    };
     const sides = getSides() || {};
-    sel.value = sides[key] ?? "inherit";
-    txt.value = sides[textKey] ?? placeholder;
-
-    function toggleTxt(){
+    sel.value = (_sides$key = sides[key]) !== null && _sides$key !== void 0 ? _sides$key : "inherit";
+    txt.value = (_sides$textKey = sides[textKey]) !== null && _sides$textKey !== void 0 ? _sides$textKey : placeholder;
+    function toggleTxt() {
+      var _curSides$default;
       const curSides = getSides();
-      const fallback = curSides?.default ?? "";
+      const fallback = (_curSides$default = curSides === null || curSides === void 0 ? void 0 : curSides.default) !== null && _curSides$default !== void 0 ? _curSides$default : "";
       const mode = sel.value === "inherit" ? fallback : sel.value;
       txt.disabled = !String(mode).includes("custom");
     }
-
     toggleTxt();
-    sel.addEventListener("change", ()=>{
+    sel.addEventListener("change", () => {
       const curSides = getSides();
-      if(curSides) curSides[key] = sel.value;
+      if (curSides) curSides[key] = sel.value;
       toggleTxt();
       renderCombined();
     });
-    txt.addEventListener("input", ()=>{
+    txt.addEventListener("input", () => {
       const curSides = getSides();
-      if(curSides) curSides[textKey] = txt.value;
+      if (curSides) curSides[textKey] = txt.value;
       renderCombined();
     });
-    sideToggles.push({figKey, toggleTxt});
+    sideToggles.push({
+      figKey,
+      toggleTxt
+    });
   }
-  function wireAng(figKey, key, selId, txtId, placeholder){
-    const sel = $(selId), txt = $(txtId);
+  function wireAng(figKey, key, selId, txtId, placeholder) {
+    var _angles$key, _angles$textKey;
+    const sel = $(selId),
+      txt = $(txtId);
     const textKey = key + "Text";
     const getFig = () => STATE[figKey];
-    const getAngles = () => getFig()?.angles;
-
+    const getAngles = () => {
+      var _getFig2;
+      return (_getFig2 = getFig()) === null || _getFig2 === void 0 ? void 0 : _getFig2.angles;
+    };
     const angles = getAngles() || {};
-    sel.value = angles[key] ?? "inherit";
-    txt.value = angles[textKey] ?? placeholder;
-
-    function toggleTxt(){
+    sel.value = (_angles$key = angles[key]) !== null && _angles$key !== void 0 ? _angles$key : "inherit";
+    txt.value = (_angles$textKey = angles[textKey]) !== null && _angles$textKey !== void 0 ? _angles$textKey : placeholder;
+    function toggleTxt() {
+      var _curAngles$default;
       const curAngles = getAngles();
-      const rawMode = sel.value === "inherit" ? (curAngles?.default ?? "") : sel.value;
+      const rawMode = sel.value === "inherit" ? (_curAngles$default = curAngles === null || curAngles === void 0 ? void 0 : curAngles.default) !== null && _curAngles$default !== void 0 ? _curAngles$default : "" : sel.value;
       const normalized = String(rawMode);
       txt.disabled = !(normalized.startsWith("custom") || normalized.startsWith("custum"));
     }
-
     toggleTxt();
-    sel.addEventListener("change", ()=>{
+    sel.addEventListener("change", () => {
       const curAngles = getAngles();
-      if(curAngles) curAngles[key] = sel.value;
+      if (curAngles) curAngles[key] = sel.value;
       toggleTxt();
       renderCombined();
     });
-    txt.addEventListener("input", ()=>{
+    txt.addEventListener("input", () => {
       const curAngles = getAngles();
-      if(curAngles) curAngles[textKey] = txt.value;
+      if (curAngles) curAngles[textKey] = txt.value;
       renderCombined();
     });
-    angToggles.push({figKey, toggleTxt});
+    angToggles.push({
+      figKey,
+      toggleTxt
+    });
   }
 
   // init
-  DEFAULT_SPECS = inpSpecs?.value || "";
+  DEFAULT_SPECS = (inpSpecs === null || inpSpecs === void 0 ? void 0 : inpSpecs.value) || "";
   STATE.specsText = DEFAULT_SPECS;
-
   inpSpecs.value = STATE.specsText;
-  f1Sides.value  = STATE.fig1.sides.default;
+  f1Sides.value = STATE.fig1.sides.default;
   f1Angles.value = STATE.fig1.angles.default;
-  f2Sides.value  = STATE.fig2.sides.default;
+  f2Sides.value = STATE.fig2.sides.default;
   f2Angles.value = STATE.fig2.angles.default;
-  layoutRadios.forEach(r => r.checked = (r.value===STATE.layout));
+  layoutRadios.forEach(r => r.checked = r.value === STATE.layout);
 
   // Oppdater lokal STATE mens bruker skriver, slik at lagring av eksempler får med uendrede endringer
   inpSpecs.addEventListener("input", () => {
@@ -926,18 +1298,33 @@ function bindUI(){
       renderCombined();
     }
   });
-  inpSpecs.addEventListener("keyup", (e) => {
+  inpSpecs.addEventListener("keyup", e => {
     if (e.key === "Enter") {
       STATE.specsText = inpSpecs.value;
       renderCombined();
     }
   });
-  f1Sides.addEventListener("change",  ()=>{ STATE.fig1.sides.default  = f1Sides.value;  sideToggles.filter(t=>t.figKey==="fig1").forEach(t=>t.toggleTxt()); renderCombined(); });
-  f1Angles.addEventListener("change", ()=>{ STATE.fig1.angles.default = f1Angles.value; angToggles.filter(t=>t.figKey==="fig1").forEach(t=>t.toggleTxt()); renderCombined(); });
-  f2Sides.addEventListener("change",  ()=>{ STATE.fig2.sides.default  = f2Sides.value;  sideToggles.filter(t=>t.figKey==="fig2").forEach(t=>t.toggleTxt()); renderCombined(); });
-  f2Angles.addEventListener("change", ()=>{ STATE.fig2.angles.default = f2Angles.value; angToggles.filter(t=>t.figKey==="fig2").forEach(t=>t.toggleTxt()); renderCombined(); });
-
-  if(btnDraw){
+  f1Sides.addEventListener("change", () => {
+    STATE.fig1.sides.default = f1Sides.value;
+    sideToggles.filter(t => t.figKey === "fig1").forEach(t => t.toggleTxt());
+    renderCombined();
+  });
+  f1Angles.addEventListener("change", () => {
+    STATE.fig1.angles.default = f1Angles.value;
+    angToggles.filter(t => t.figKey === "fig1").forEach(t => t.toggleTxt());
+    renderCombined();
+  });
+  f2Sides.addEventListener("change", () => {
+    STATE.fig2.sides.default = f2Sides.value;
+    sideToggles.filter(t => t.figKey === "fig2").forEach(t => t.toggleTxt());
+    renderCombined();
+  });
+  f2Angles.addEventListener("change", () => {
+    STATE.fig2.angles.default = f2Angles.value;
+    angToggles.filter(t => t.figKey === "fig2").forEach(t => t.toggleTxt());
+    renderCombined();
+  });
+  if (btnDraw) {
     btnDraw.addEventListener("click", () => {
       STATE.specsText = inpSpecs.value;
       renderCombined();
@@ -945,42 +1332,42 @@ function bindUI(){
   }
 
   // figur 1
-  wireSide("fig1","a","#f1SideA","#f1SideATxt","a");
-  wireSide("fig1","b","#f1SideB","#f1SideBTxt","b");
-  wireSide("fig1","c","#f1SideC","#f1SideCTxt","c");
-  wireSide("fig1","d","#f1SideD","#f1SideDTxt","d");
-  wireAng ("fig1","A","#f1AngA","#f1AngATxt","A");
-  wireAng ("fig1","B","#f1AngB","#f1AngBTxt","B");
-  wireAng ("fig1","C","#f1AngC","#f1AngCTxt","C");
-  wireAng ("fig1","D","#f1AngD","#f1AngDTxt","D");
+  wireSide("fig1", "a", "#f1SideA", "#f1SideATxt", "a");
+  wireSide("fig1", "b", "#f1SideB", "#f1SideBTxt", "b");
+  wireSide("fig1", "c", "#f1SideC", "#f1SideCTxt", "c");
+  wireSide("fig1", "d", "#f1SideD", "#f1SideDTxt", "d");
+  wireAng("fig1", "A", "#f1AngA", "#f1AngATxt", "A");
+  wireAng("fig1", "B", "#f1AngB", "#f1AngBTxt", "B");
+  wireAng("fig1", "C", "#f1AngC", "#f1AngCTxt", "C");
+  wireAng("fig1", "D", "#f1AngD", "#f1AngDTxt", "D");
 
   // figur 2
-  wireSide("fig2","a","#f2SideA","#f2SideATxt","a");
-  wireSide("fig2","b","#f2SideB","#f2SideBTxt","b");
-  wireSide("fig2","c","#f2SideC","#f2SideCTxt","c");
-  wireSide("fig2","d","#f2SideD","#f2SideDTxt","d");
-  wireAng ("fig2","A","#f2AngA","#f2AngATxt","A");
-  wireAng ("fig2","B","#f2AngB","#f2AngBTxt","B");
-  wireAng ("fig2","C","#f2AngC","#f2AngCTxt","C");
-  wireAng ("fig2","D","#f2AngD","#f2AngDTxt","D");
-
-  layoutRadios.forEach(r => r.addEventListener("change", ()=>{
-    if(r.checked){ STATE.layout = r.value; renderCombined(); }
+  wireSide("fig2", "a", "#f2SideA", "#f2SideATxt", "a");
+  wireSide("fig2", "b", "#f2SideB", "#f2SideBTxt", "b");
+  wireSide("fig2", "c", "#f2SideC", "#f2SideCTxt", "c");
+  wireSide("fig2", "d", "#f2SideD", "#f2SideDTxt", "d");
+  wireAng("fig2", "A", "#f2AngA", "#f2AngATxt", "A");
+  wireAng("fig2", "B", "#f2AngB", "#f2AngBTxt", "B");
+  wireAng("fig2", "C", "#f2AngC", "#f2AngCTxt", "C");
+  wireAng("fig2", "D", "#f2AngD", "#f2AngDTxt", "D");
+  layoutRadios.forEach(r => r.addEventListener("change", () => {
+    if (r.checked) {
+      STATE.layout = r.value;
+      renderCombined();
+    }
   }));
-
-  if(btnSvg){
-    btnSvg.addEventListener("click", ()=>{
+  if (btnSvg) {
+    btnSvg.addEventListener("click", () => {
       const svg = document.getElementById("paper");
       downloadSVG(svg, "nkant.svg");
     });
   }
-  if(btnPng){
-    btnPng.addEventListener("click", ()=>{
+  if (btnPng) {
+    btnPng.addEventListener("click", () => {
       const svg = document.getElementById("paper");
       downloadPNG(svg, "nkant.png", 2); // 2× oppløsning
     });
   }
-
 }
 
 /* ---------- INIT ---------- */
@@ -988,76 +1375,72 @@ window.addEventListener("DOMContentLoaded", () => {
   bindUI();
   renderCombined();
 });
-
-function applyStateToUI(){
+function applyStateToUI() {
+  var _STATE$specsText;
   const specInput = document.getElementById("inpSpecs");
-  if(specInput) specInput.value = STATE.specsText ?? "";
-
+  if (specInput) specInput.value = (_STATE$specsText = STATE.specsText) !== null && _STATE$specsText !== void 0 ? _STATE$specsText : "";
   const layout = STATE.layout || "row";
   document.querySelectorAll('input[name="layout"]').forEach(radio => {
-    radio.checked = (radio.value === layout);
+    radio.checked = radio.value === layout;
   });
-
-  const updateFigure = (figState, prefix, sideFallback, angFallback)=>{
-    const sides = figState?.sides || {};
-    const angles = figState?.angles || {};
-
-    const defaultSides = sides.default ?? sideFallback;
-    const defaultAngles = angles.default ?? angFallback;
-
+  const updateFigure = (figState, prefix, sideFallback, angFallback) => {
+    var _sides$default, _angles$default;
+    const sides = (figState === null || figState === void 0 ? void 0 : figState.sides) || {};
+    const angles = (figState === null || figState === void 0 ? void 0 : figState.angles) || {};
+    const defaultSides = (_sides$default = sides.default) !== null && _sides$default !== void 0 ? _sides$default : sideFallback;
+    const defaultAngles = (_angles$default = angles.default) !== null && _angles$default !== void 0 ? _angles$default : angFallback;
     const sidesSel = document.getElementById(`${prefix}Sides`);
-    if(sidesSel) sidesSel.value = defaultSides;
+    if (sidesSel) sidesSel.value = defaultSides;
     const angSel = document.getElementById(`${prefix}Angles`);
-    if(angSel) angSel.value = defaultAngles;
-
-    const sideKeys = ["a","b","c","d"];
+    if (angSel) angSel.value = defaultAngles;
+    const sideKeys = ["a", "b", "c", "d"];
     sideKeys.forEach(letter => {
+      var _sides$letter;
       const upper = letter.toUpperCase();
       const sel = document.getElementById(`${prefix}Side${upper}`);
-      if(sel) sel.value = sides[letter] ?? "inherit";
+      if (sel) sel.value = (_sides$letter = sides[letter]) !== null && _sides$letter !== void 0 ? _sides$letter : "inherit";
       const txt = document.getElementById(`${prefix}Side${upper}Txt`);
-      if(txt){
+      if (txt) {
         const val = sides[`${letter}Text`];
         txt.value = val != null ? val : letter;
       }
-      if(sel && txt){
-        const mode = sel.value === "inherit" ? (defaultSides ?? "") : sel.value;
+      if (sel && txt) {
+        const mode = sel.value === "inherit" ? defaultSides !== null && defaultSides !== void 0 ? defaultSides : "" : sel.value;
         txt.disabled = !String(mode).includes("custom");
       }
     });
-
-    const angKeys = ["A","B","C","D"];
+    const angKeys = ["A", "B", "C", "D"];
     angKeys.forEach(letter => {
+      var _angles$letter;
       const sel = document.getElementById(`${prefix}Ang${letter}`);
-      if(sel) sel.value = angles[letter] ?? "inherit";
+      if (sel) sel.value = (_angles$letter = angles[letter]) !== null && _angles$letter !== void 0 ? _angles$letter : "inherit";
       const txt = document.getElementById(`${prefix}Ang${letter}Txt`);
-      if(txt){
+      if (txt) {
         const val = angles[`${letter}Text`];
         txt.value = val != null ? val : letter;
       }
-      if(sel && txt){
-        const rawMode = sel.value === "inherit" ? (defaultAngles ?? "") : sel.value;
+      if (sel && txt) {
+        const rawMode = sel.value === "inherit" ? defaultAngles !== null && defaultAngles !== void 0 ? defaultAngles : "" : sel.value;
         const normalized = String(rawMode).toLowerCase();
         txt.disabled = !(normalized.startsWith("custom") || normalized.startsWith("custum"));
       }
     });
   };
-
   updateFigure(STATE.fig1, "f1", "value", "custom+mark+value");
   updateFigure(STATE.fig2, "f2", "none", "custom+mark+value");
 }
-
-function applyExamplesConfig(){
+function applyExamplesConfig() {
   ensureStateDefaults();
-  if(document.readyState === "loading"){
-    document.addEventListener("DOMContentLoaded", applyExamplesConfig, {once:true});
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", applyExamplesConfig, {
+      once: true
+    });
     return;
   }
   applyStateToUI();
   renderCombined();
 }
-
-if(typeof window !== "undefined"){
+if (typeof window !== "undefined") {
   window.applyConfig = applyExamplesConfig;
   window.applyState = applyExamplesConfig;
   window.render = applyExamplesConfig;
@@ -1065,37 +1448,37 @@ if(typeof window !== "undefined"){
 }
 
 /* ---------- GEOMETRI ---------- */
-function buildRightAngleVariants(input){
+function buildRightAngleVariants(input) {
   const EPS = 1e-6;
   const isPos = v => typeof v === "number" && isFinite(v) && v > 0;
   const isRight = ang => typeof ang === "number" && isFinite(ang) && Math.abs(ang - 90) < 1e-3;
   const variants = [];
-
   const push = mut => {
-    const clone = {...input};
+    const clone = {
+      ...input
+    };
     mut(clone);
     variants.push(clone);
   };
-
-  const handle = (angVal, oppKey, legKey1, legKey2)=>{
-    if(!isRight(angVal)) return;
+  const handle = (angVal, oppKey, legKey1, legKey2) => {
+    if (!isRight(angVal)) return;
     const oppVal = input[oppKey];
     const leg1 = input[legKey1];
     const leg2 = input[legKey2];
-
-    const suspicious = isPos(oppVal) && ((isPos(leg1) && oppVal <= leg1 + EPS) || (isPos(leg2) && oppVal <= leg2 + EPS));
-    if(suspicious){
-      push(clone => { delete clone[oppKey]; });
+    const suspicious = isPos(oppVal) && (isPos(leg1) && oppVal <= leg1 + EPS || isPos(leg2) && oppVal <= leg2 + EPS);
+    if (suspicious) {
+      push(clone => {
+        delete clone[oppKey];
+      });
     }
-
-    if(isPos(oppVal)){
-      if(!isPos(leg1)){
+    if (isPos(oppVal)) {
+      if (!isPos(leg1)) {
         push(clone => {
           clone[legKey1] = oppVal;
           delete clone[oppKey];
         });
       }
-      if(!isPos(leg2)){
+      if (!isPos(leg2)) {
         push(clone => {
           clone[legKey2] = oppVal;
           delete clone[oppKey];
@@ -1103,78 +1486,147 @@ function buildRightAngleVariants(input){
       }
     }
   };
-
   handle(input.A, "a", "b", "c");
   handle(input.B, "b", "c", "a");
   handle(input.C, "c", "a", "b");
-
   return variants;
 }
-
-function solveTriangle(g){
-  const lawCosSide = (ang, s1, s2) => Math.sqrt(Math.max(0, s1*s1 + s2*s2 - 2*s1*s2*Math.cos(rad(ang))));
-  const lawCosAng  = (opp, s1, s2) => deg(Math.acos(clampCos((s1*s1 + s2*s2 - opp*opp)/(2*s1*s2))));
-  const lawSinAng  = (A0,a0,sx)=> deg(Math.asin(clamp(sx*Math.sin(rad(A0))/a0,-1,1)));
-  const lawSinSide = (A0,a0,Ax)=> a0*Math.sin(rad(Ax))/Math.sin(rad(A0));
-
-  const attempt = (spec)=>{
-    let {a,b,c,A,B,C} = spec;
-
-    if(A && B && !C) C = 180 - A - B;
-    if(A && C && !B) B = 180 - A - C;
-    if(B && C && !A) A = 180 - B - C;
-
-    if(A && b && c && !a){ a = lawCosSide(A,b,c); }
-    if(B && a && c && !b){ b = lawCosSide(B,a,c); }
-    if(C && a && b && !c){ c = lawCosSide(C,a,b); }
-
-    if(a && b && c){
-      if(!A) A = lawCosAng(a,b,c);
-      if(!B) B = lawCosAng(b,a,c);
-      if(!C) C = 180 - A - B;
+function solveTriangle(g) {
+  const lawCosSide = (ang, s1, s2) => Math.sqrt(Math.max(0, s1 * s1 + s2 * s2 - 2 * s1 * s2 * Math.cos(rad(ang))));
+  const lawCosAng = (opp, s1, s2) => deg(Math.acos(clampCos((s1 * s1 + s2 * s2 - opp * opp) / (2 * s1 * s2))));
+  const lawSinAng = (A0, a0, sx) => deg(Math.asin(clamp(sx * Math.sin(rad(A0)) / a0, -1, 1)));
+  const lawSinSide = (A0, a0, Ax) => a0 * Math.sin(rad(Ax)) / Math.sin(rad(A0));
+  const attempt = spec => {
+    let {
+      a,
+      b,
+      c,
+      A,
+      B,
+      C
+    } = spec;
+    if (A && B && !C) C = 180 - A - B;
+    if (A && C && !B) B = 180 - A - C;
+    if (B && C && !A) A = 180 - B - C;
+    if (A && b && c && !a) {
+      a = lawCosSide(A, b, c);
     }
-
-    const fillBySines = ()=>{
-      if(A && B && a && (!b || !c)){ b = b || lawSinSide(A,a,B); c = c || lawSinSide(A,a,180-A-B); }
-      if(A && C && a && (!b || !c)){ b = b || lawSinSide(A,a,180-A-C); c = c || lawSinSide(A,a,C); }
-      if(B && C && b && (!a || !c)){ a = a || lawSinSide(B,b,180-B-C); c = c || lawSinSide(B,b,C); }
-      if(A && B && c && (!a || !b)){ a = a || lawSinSide(180-A-B,c,A); b = b || lawSinSide(180-A-B,c,B); }
+    if (B && a && c && !b) {
+      b = lawCosSide(B, a, c);
+    }
+    if (C && a && b && !c) {
+      c = lawCosSide(C, a, b);
+    }
+    if (a && b && c) {
+      if (!A) A = lawCosAng(a, b, c);
+      if (!B) B = lawCosAng(b, a, c);
+      if (!C) C = 180 - A - B;
+    }
+    const fillBySines = () => {
+      if (A && B && a && (!b || !c)) {
+        b = b || lawSinSide(A, a, B);
+        c = c || lawSinSide(A, a, 180 - A - B);
+      }
+      if (A && C && a && (!b || !c)) {
+        b = b || lawSinSide(A, a, 180 - A - C);
+        c = c || lawSinSide(A, a, C);
+      }
+      if (B && C && b && (!a || !c)) {
+        a = a || lawSinSide(B, b, 180 - B - C);
+        c = c || lawSinSide(B, b, C);
+      }
+      if (A && B && c && (!a || !b)) {
+        a = a || lawSinSide(180 - A - B, c, A);
+        b = b || lawSinSide(180 - A - B, c, B);
+      }
     };
     fillBySines();
-
-    const solveSSA = ()=>{
-      if(A && a && b && !B){ const B1 = lawSinAng(A,a,b); if(isFinite(B1)){ B=B||B1; C=C|| (180-A-B); c=c|| lawSinSide(A,a,C); } }
-      if(A && a && c && !C){ const C1 = lawSinAng(A,a,c); if(isFinite(C1)){ C=C||C1; B=B|| (180-A-C); b=b|| lawSinSide(A,a,B); } }
-      if(B && b && a && !A){ const A1 = lawSinAng(B,b,a); if(isFinite(A1)){ A=A||A1; C=C|| (180-A-B); c=c|| lawSinSide(B,b,C); } }
-      if(B && b && c && !C){ const C1 = lawSinAng(B,b,c); if(isFinite(C1)){ C=C||C1; A=A|| (180-B-C); a=a|| lawSinSide(B,b,A); } }
-      if(C && c && a && !A){ const A1 = lawSinAng(C,c,a); if(isFinite(A1)){ A=A||A1; B=B|| (180-A-C); b=b|| lawSinSide(C,c,B); } }
-      if(C && c && b && !B){ const B1 = lawSinAng(C,c,b); if(isFinite(B1)){ B=B||B1; A=A|| (180-B-C); a=a|| lawSinSide(C,c,A); } }
+    const solveSSA = () => {
+      if (A && a && b && !B) {
+        const B1 = lawSinAng(A, a, b);
+        if (isFinite(B1)) {
+          B = B || B1;
+          C = C || 180 - A - B;
+          c = c || lawSinSide(A, a, C);
+        }
+      }
+      if (A && a && c && !C) {
+        const C1 = lawSinAng(A, a, c);
+        if (isFinite(C1)) {
+          C = C || C1;
+          B = B || 180 - A - C;
+          b = b || lawSinSide(A, a, B);
+        }
+      }
+      if (B && b && a && !A) {
+        const A1 = lawSinAng(B, b, a);
+        if (isFinite(A1)) {
+          A = A || A1;
+          C = C || 180 - A - B;
+          c = c || lawSinSide(B, b, C);
+        }
+      }
+      if (B && b && c && !C) {
+        const C1 = lawSinAng(B, b, c);
+        if (isFinite(C1)) {
+          C = C || C1;
+          A = A || 180 - B - C;
+          a = a || lawSinSide(B, b, A);
+        }
+      }
+      if (C && c && a && !A) {
+        const A1 = lawSinAng(C, c, a);
+        if (isFinite(A1)) {
+          A = A || A1;
+          B = B || 180 - A - C;
+          b = b || lawSinSide(C, c, B);
+        }
+      }
+      if (C && c && b && !B) {
+        const B1 = lawSinAng(C, c, b);
+        if (isFinite(B1)) {
+          B = B || B1;
+          A = A || 180 - B - C;
+          a = a || lawSinSide(C, c, A);
+        }
+      }
     };
     solveSSA();
-
-    if(a>0 && b>0 && c>0 && A>0 && B>0 && C>0)
-      return {a,b,c,A,B,C};
+    if (a > 0 && b > 0 && c > 0 && A > 0 && B > 0 && C > 0) return {
+      a,
+      b,
+      c,
+      A,
+      B,
+      C
+    };
     return null;
   };
-
   const direct = attempt(g);
-  if(direct) return direct;
-
+  if (direct) return direct;
   const variants = buildRightAngleVariants(g);
-  for(const variant of variants){
+  for (const variant of variants) {
     const solved = attempt(variant);
-    if(solved) return solved;
+    if (solved) return solved;
   }
-
   throw new Error("Trekant-spesifikasjonen er ikke tilstrekkelig eller er ugyldig.");
 }
-
-function circleCircle(A, r, B, s){
-  const dx=B.x-A.x, dy=B.y-A.y, d=Math.hypot(dx,dy);
-  if(d===0 || d>r+s || d<Math.abs(r-s)) return [];
-  const a=(r*r - s*s + d*d)/(2*d);
-  const h=Math.sqrt(Math.max(0, r*r - a*a));
-  const xm=A.x + a*dx/d, ym=A.y + a*dy/d;
-  const rx=-dy*(h/d),   ry= dx*(h/d);
-  return [{x:xm+rx,y:ym+ry},{x:xm-rx,y:ym-ry}];
+function circleCircle(A, r, B, s) {
+  const dx = B.x - A.x,
+    dy = B.y - A.y,
+    d = Math.hypot(dx, dy);
+  if (d === 0 || d > r + s || d < Math.abs(r - s)) return [];
+  const a = (r * r - s * s + d * d) / (2 * d);
+  const h = Math.sqrt(Math.max(0, r * r - a * a));
+  const xm = A.x + a * dx / d,
+    ym = A.y + a * dy / d;
+  const rx = -dy * (h / d),
+    ry = dx * (h / d);
+  return [{
+    x: xm + rx,
+    y: ym + ry
+  }, {
+    x: xm - rx,
+    y: ym - ry
+  }];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,397 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@babel/cli": "^7.28.3",
+        "@babel/core": "^7.28.4",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1",
         "http-server": "^14.1.1"
       }
+    },
+    "node_modules/@babel/cli": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.28.3.tgz",
+      "integrity": "sha512-n1RU5vuCX0CsaqaXm9I0KUCNKNQMy5epmzl/xdSSm70bSqhg9GWhgeosypyQLc0bK24+Xpk1WGzZlI9pJtkZdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "commander": "^6.2.0",
+        "convert-source-map": "^2.0.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.2.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0"
+      },
+      "bin": {
+        "babel": "bin/babel.js",
+        "babel-external-helpers": "bin/babel-external-helpers.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "optionalDependencies": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.6.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
+      "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -28,12 +417,44 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
+      "integrity": "sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -46,6 +467,79 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -79,6 +573,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -94,6 +609,32 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/color-convert": {
@@ -113,6 +654,30 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -159,6 +724,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.221",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.221.tgz",
+      "integrity": "sha512-/1hFJ39wkW01ogqSyYoA4goOXOtMRy6B+yvA1u42nnsEGtHzIzmk93aPISumVQeblj47JUHLC9coCjUxb1EvtQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -192,12 +764,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -220,6 +816,35 @@
         }
       }
     },
+    "node_modules/fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -228,6 +853,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -267,6 +902,42 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/gopd": {
@@ -397,6 +1068,142 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -420,6 +1227,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -437,6 +1257,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-releases": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -450,6 +1288,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -458,6 +1306,47 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/portfinder": {
@@ -490,6 +1379,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -517,6 +1420,16 @@
       "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -594,6 +1507,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -607,6 +1530,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/union": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
@@ -617,6 +1554,37 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/url-join": {
@@ -638,6 +1606,20 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "type": "commonjs",
   "private": true,
   "devDependencies": {
+    "@babel/cli": "^7.28.3",
+    "@babel/core": "^7.28.4",
+    "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
+    "@babel/plugin-transform-optional-chaining": "^7.27.1",
     "http-server": "^14.1.1"
   }
 }

--- a/perlesnor.js
+++ b/perlesnor.js
@@ -1,15 +1,20 @@
+var _CFG$a11y;
 /* ============ ENKEL KONFIG (FORFATTER) ============ */
 const SIMPLE = {
-  nBeads: 10,       // totalt antall perler
-  startIndex: 2,    // startposisjon for klypa (antall til venstre)
+  nBeads: 10,
+  // totalt antall perler
+  startIndex: 2,
+  // startposisjon for klypa (antall til venstre)
 
   // Fasit (velg én form):
   // correct: 8, // short-hand: leftCount = 8
-  correct: { mode: "leftCount", value: 8 },
-
+  correct: {
+    mode: "leftCount",
+    value: 8
+  },
   feedback: {
     correct: "Riktig!",
-    wrong:   "Prøv igjen",
+    wrong: "Prøv igjen",
     showLive: true
   }
 };
@@ -20,50 +25,51 @@ const ADV = {
   rBase: 42,
   gapBase: 18,
   wireY: 325,
-
-  kW: 4.2,             // klype-bredde = kW * r
-  kH: 11.5,            // klype-høyde  = kH * r
-  clipGapRatio: 0.39,  // ekstra gap som klypa "krever" i forhold til klype-bredde
+  kW: 4.2,
+  // klype-bredde = kW * r
+  kH: 11.5,
+  // klype-høyde  = kH * r
+  clipGapRatio: 0.39,
+  // ekstra gap som klypa "krever" i forhold til klype-bredde
 
   assets: {
-    rope:     "https://test.kikora.no/img/drive/illustrasjoner/Matteobjekter/Hjelpemidler/snor20.svg",
-    beadRed:  "https://test.kikora.no/img/drive/figures/games/spheres/redDots.svg",
+    rope: "https://test.kikora.no/img/drive/illustrasjoner/Matteobjekter/Hjelpemidler/snor20.svg",
+    beadRed: "https://test.kikora.no/img/drive/figures/games/spheres/redDots.svg",
     beadBlue: "https://test.kikora.no/img/drive/figures/games/spheres/blueWave.svg",
-    clip:     "https://test.kikora.no/img/drive/figures/objects/tools/clothesPin.svg"
+    clip: "https://test.kikora.no/img/drive/figures/objects/tools/clothesPin.svg"
   },
-
   a11y: {
     ariaLabel: "Posisjon for klypa. Bruk piltaster eller dra.",
-    pageJump: "group",   // "group" eller tall (f.eks. 10)
-    fineStep: 3,         // Shift+pil i px (vertikalt)
-    coarseStep: 12       // Pil i px (vertikalt)
+    pageJump: "group",
+    // "group" eller tall (f.eks. 10)
+    fineStep: 3,
+    // Shift+pil i px (vertikalt)
+    coarseStep: 12 // Pil i px (vertikalt)
   },
-
   ui: {
     showGroupTicks: true,
-    leftColorClass: "red",   // samsvarer med CSS-klassene i beadFallback
-    rightColorClass:"blue"
+    leftColorClass: "red",
+    // samsvarer med CSS-klassene i beadFallback
+    rightColorClass: "blue"
   }
 };
 
 /* ============ DERIVERT KONFIG FOR RENDER (IKKE REDIGER) ============ */
-function makeCFG(){
-  const rBase = SIMPLE.beadRadius ?? ADV.rBase;
+function makeCFG() {
+  var _SIMPLE$beadRadius;
+  const rBase = (_SIMPLE$beadRadius = SIMPLE.beadRadius) !== null && _SIMPLE$beadRadius !== void 0 ? _SIMPLE$beadRadius : ADV.rBase;
   const scale = rBase / ADV.rBase;
   const gapBase = ADV.gapBase * scale;
   return {
     nBeads: SIMPLE.nBeads,
     startIndex: clamp(SIMPLE.startIndex, 0, SIMPLE.nBeads),
     groupSize: ADV.groupSize,
-
     rBase,
     gapBase,
     wireY: ADV.wireY,
-
     kW: ADV.kW,
     kH: ADV.kH,
     clipGapRatio: ADV.clipGapRatio,
-
     assets: ADV.assets,
     a11y: ADV.a11y,
     ui: ADV.ui
@@ -72,25 +78,33 @@ function makeCFG(){
 let CFG = makeCFG();
 
 /* ============ DOM & VIEWBOX ============ */
-const svg   = document.getElementById("beadSVG");
-const VB_W  = 1400, VB_H = 460;
-const LM    = 80, RM = 80;   // marger
+const svg = document.getElementById("beadSVG");
+const VB_W = 1400,
+  VB_H = 460;
+const LM = 80,
+  RM = 80; // marger
 const INNER = VB_W - LM - RM;
 
 /* ============ LAG ============ */
-const gRope  = mk("g");
-const gLeft  = mk("g");      // perler til venstre (under klypa)
-const gClip  = mk("g",{class:"clip"});
-const gRight = mk("g");      // perler til høyre (over klypa)
+const gRope = mk("g");
+const gLeft = mk("g"); // perler til venstre (under klypa)
+const gClip = mk("g", {
+  class: "clip"
+});
+const gRight = mk("g"); // perler til høyre (over klypa)
 svg.append(gRope, gLeft, gClip, gRight);
 
 /* Tastatur/drag-overlay (legges FØR hendelser) */
-const overlay = rect(0,0,VB_W,VB_H,{
-  fill:"transparent", class:"slider", tabindex:0, role:"slider",
-  "aria-valuemin":"0", "aria-valuemax":String(CFG.nBeads),
-  "aria-valuenow":"0",
-  "aria-label": CFG.a11y?.ariaLabel || "Posisjon for klypa. Bruk piltastene eller dra.",
-  "aria-describedby":"beadHelp"
+const overlay = rect(0, 0, VB_W, VB_H, {
+  fill: "transparent",
+  class: "slider",
+  tabindex: 0,
+  role: "slider",
+  "aria-valuemin": "0",
+  "aria-valuemax": String(CFG.nBeads),
+  "aria-valuenow": "0",
+  "aria-label": ((_CFG$a11y = CFG.a11y) === null || _CFG$a11y === void 0 ? void 0 : _CFG$a11y.ariaLabel) || "Posisjon for klypa. Bruk piltastene eller dra.",
+  "aria-describedby": "beadHelp"
 });
 overlay.style.cursor = "ew-resize";
 svg.appendChild(overlay);
@@ -101,174 +115,189 @@ let centers = [];
 let gapMids = [];
 let idx = 0; // antall perler til venstre
 let clipY = 0;
-let CLIP_Y_MIN = -100, CLIP_Y_MAX = 100;
-
+let CLIP_Y_MIN = -100,
+  CLIP_Y_MAX = 100;
 const btnSvg = document.getElementById('btnSvg');
 const btnPng = document.getElementById('btnPng');
-btnSvg?.addEventListener('click', ()=> downloadSVG(svg, 'perlesnor.svg'));
-btnPng?.addEventListener('click', ()=> downloadPNG(svg, 'perlesnor.png', 2));
-
+btnSvg === null || btnSvg === void 0 || btnSvg.addEventListener('click', () => downloadSVG(svg, 'perlesnor.svg'));
+btnPng === null || btnPng === void 0 || btnPng.addEventListener('click', () => downloadPNG(svg, 'perlesnor.png', 2));
 setupSettingsUI();
 applyConfig();
 
 /* ============ INTERAKSJON ============ */
 let dragging = false;
-
-overlay.addEventListener("pointerdown", e=>{
-  dragging = true; overlay.setPointerCapture(e.pointerId);
+overlay.addEventListener("pointerdown", e => {
+  dragging = true;
+  overlay.setPointerCapture(e.pointerId);
   const p = pt(e);
   setIndex(nearestIndex(p.x));
   setClipYFromPoint(p.y);
 });
-overlay.addEventListener("pointermove", e=>{
-  if(!dragging) return;
+overlay.addEventListener("pointermove", e => {
+  if (!dragging) return;
   const p = pt(e);
   setIndex(nearestIndex(p.x));
   setClipYFromPoint(p.y);
 });
-overlay.addEventListener("pointerup", e=>{
-  dragging = false; overlay.releasePointerCapture(e.pointerId);
+overlay.addEventListener("pointerup", e => {
+  dragging = false;
+  overlay.releasePointerCapture(e.pointerId);
 });
-overlay.addEventListener("pointercancel", ()=> dragging=false);
-
-overlay.addEventListener("keydown", (e)=>{
+overlay.addEventListener("pointercancel", () => dragging = false);
+overlay.addEventListener("keydown", e => {
+  var _CFG$a11y$fineStep, _CFG$a11y2, _CFG$a11y$coarseStep, _CFG$a11y3, _CFG$a11y4, _CFG$a11y5;
   let used = true;
-  const fine   = (CFG.a11y?.fineStep ?? 3);
-  const coarse = (CFG.a11y?.coarseStep ?? 12);
-  const pageJump = (CFG.a11y?.pageJump === "group") ? CFG.groupSize
-                 : (Number.isFinite(CFG.a11y?.pageJump) ? CFG.a11y.pageJump : CFG.groupSize);
-
-  switch(e.key){
-    case "ArrowRight": setIndex(idx + 1); break;
-    case "ArrowLeft":  setIndex(idx - 1); break;
-    case "ArrowUp":    setClipY(clipY - (e.shiftKey ? fine : coarse)); break;
-    case "ArrowDown":  setClipY(clipY + (e.shiftKey ? fine : coarse)); break;
-    case "Home":       setIndex(0); break;
-    case "End":        setIndex(CFG.nBeads); break;
-    case "PageUp":     setIndex(idx + pageJump); break;
-    case "PageDown":   setIndex(idx - pageJump); break;
-    default: used=false;
+  const fine = (_CFG$a11y$fineStep = (_CFG$a11y2 = CFG.a11y) === null || _CFG$a11y2 === void 0 ? void 0 : _CFG$a11y2.fineStep) !== null && _CFG$a11y$fineStep !== void 0 ? _CFG$a11y$fineStep : 3;
+  const coarse = (_CFG$a11y$coarseStep = (_CFG$a11y3 = CFG.a11y) === null || _CFG$a11y3 === void 0 ? void 0 : _CFG$a11y3.coarseStep) !== null && _CFG$a11y$coarseStep !== void 0 ? _CFG$a11y$coarseStep : 12;
+  const pageJump = ((_CFG$a11y4 = CFG.a11y) === null || _CFG$a11y4 === void 0 ? void 0 : _CFG$a11y4.pageJump) === "group" ? CFG.groupSize : Number.isFinite((_CFG$a11y5 = CFG.a11y) === null || _CFG$a11y5 === void 0 ? void 0 : _CFG$a11y5.pageJump) ? CFG.a11y.pageJump : CFG.groupSize;
+  switch (e.key) {
+    case "ArrowRight":
+      setIndex(idx + 1);
+      break;
+    case "ArrowLeft":
+      setIndex(idx - 1);
+      break;
+    case "ArrowUp":
+      setClipY(clipY - (e.shiftKey ? fine : coarse));
+      break;
+    case "ArrowDown":
+      setClipY(clipY + (e.shiftKey ? fine : coarse));
+      break;
+    case "Home":
+      setIndex(0);
+      break;
+    case "End":
+      setIndex(CFG.nBeads);
+      break;
+    case "PageUp":
+      setIndex(idx + pageJump);
+      break;
+    case "PageDown":
+      setIndex(idx - pageJump);
+      break;
+    default:
+      used = false;
   }
-  if(used){ e.preventDefault(); e.stopPropagation(); }
+  if (used) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
 });
 
 /* ============ FUNKSJONER ============ */
 
-function layout(){
+function layout() {
+  var _CFG$ui;
   // Skala s ≤ 1 som garanterer plass til maks-behov (inkl. klypegap)
-  const R = CFG.rBase, G = CFG.gapBase;
+  const R = CFG.rBase,
+    G = CFG.gapBase;
   const clipExtraBase = CFG.clipGapRatio * (CFG.kW * R);
-  const totalBase = (2*R) + (CFG.nBeads-1)*(2*R + G) + clipExtraBase;
+  const totalBase = 2 * R + (CFG.nBeads - 1) * (2 * R + G) + clipExtraBase;
   const s = Math.min(1, INNER / totalBase);
-
-  r     = R * s;
-  gap   = G * s;
-  pitch = 2*r + gap;
-
-  CLIP_W   = CFG.kW * r;
-  CLIP_H   = CFG.kH * r;
+  r = R * s;
+  gap = G * s;
+  pitch = 2 * r + gap;
+  CLIP_W = CFG.kW * r;
+  CLIP_H = CFG.kH * r;
   CLIP_GAP = CFG.clipGapRatio * CLIP_W;
-
   centers = [];
-  for(let i=0;i<CFG.nBeads;i++){
-    centers.push(LM + r + i*pitch);
+  for (let i = 0; i < CFG.nBeads; i++) {
+    centers.push(LM + r + i * pitch);
   }
 
   // snor
   gRope.innerHTML = "";
   const ropeH = r * 1.6;
-  gRope.appendChild(img(CFG.assets.rope, 20, CFG.wireY - ropeH/2, VB_W - 40, ropeH));
+  gRope.appendChild(img(CFG.assets.rope, 20, CFG.wireY - ropeH / 2, VB_W - 40, ropeH));
 
   // Valgfritt: lette gruppedelere (hver groupSize)
-  if (CFG.ui?.showGroupTicks) {
-    for(let i=CFG.groupSize; i<CFG.nBeads; i+=CFG.groupSize){
-      const x = (centers[i-1] + centers[i]) / 2;
-      gRope.appendChild(
-        mk("line", {
-          x1:x, y1:CFG.wireY - ropeH*0.75,
-          x2:x, y2:CFG.wireY + ropeH*0.75,
-          stroke:"#000", "stroke-opacity":0.08
-        })
-      );
+  if ((_CFG$ui = CFG.ui) !== null && _CFG$ui !== void 0 && _CFG$ui.showGroupTicks) {
+    for (let i = CFG.groupSize; i < CFG.nBeads; i += CFG.groupSize) {
+      const x = (centers[i - 1] + centers[i]) / 2;
+      gRope.appendChild(mk("line", {
+        x1: x,
+        y1: CFG.wireY - ropeH * 0.75,
+        x2: x,
+        y2: CFG.wireY + ropeH * 0.75,
+        stroke: "#000",
+        "stroke-opacity": 0.08
+      }));
     }
   }
 
   // klype (bygges på nytt i riktig størrelse)
   gClip.innerHTML = "";
-  gClip.appendChild(img(CFG.assets.clip, -CLIP_W/2, CFG.wireY-CLIP_H, CLIP_W, CLIP_H));
-  gClip.appendChild(rect(-pitch*1.5/2, CFG.wireY-CLIP_H-60, pitch*1.5, CLIP_H+120, {fill:"transparent"}));
+  gClip.appendChild(img(CFG.assets.clip, -CLIP_W / 2, CFG.wireY - CLIP_H, CLIP_W, CLIP_H));
+  gClip.appendChild(rect(-pitch * 1.5 / 2, CFG.wireY - CLIP_H - 60, pitch * 1.5, CLIP_H + 120, {
+    fill: "transparent"
+  }));
 
   // tillatt Y-område for klypa (synlig i viewBox)
   CLIP_Y_MIN = -(CFG.wireY - 20);
-  CLIP_Y_MAX = (VB_H - (CFG.wireY + 20)) - CLIP_H*0.15;
+  CLIP_Y_MAX = VB_H - (CFG.wireY + 20) - CLIP_H * 0.15;
 
   // eksakte gap-midt for robust snapping
   gapMids = [];
-  gapMids.push(centers[0] - r*0.95); // før første perle
-  for(let i=1; i<CFG.nBeads; i++){
-    gapMids.push((centers[i-1] + centers[i]) / 2);
+  gapMids.push(centers[0] - r * 0.95); // før første perle
+  for (let i = 1; i < CFG.nBeads; i++) {
+    gapMids.push((centers[i - 1] + centers[i]) / 2);
   }
-  gapMids.push(centers[CFG.nBeads-1] + r*0.95); // etter siste perle
+  gapMids.push(centers[CFG.nBeads - 1] + r * 0.95); // etter siste perle
 }
-
-function draw(){
-  gLeft.innerHTML  = "";
+function draw() {
+  gLeft.innerHTML = "";
   gRight.innerHTML = "";
-
-  const shift = (idx < CFG.nBeads) ? CLIP_GAP : 0;
-
-  for(let i=0;i<CFG.nBeads;i++){
-    const colorClass = (Math.floor(i/CFG.groupSize) % 2 === 0)
-      ? (CFG.ui?.leftColorClass || "red")
-      : (CFG.ui?.rightColorClass || "blue");
-
-    const cx = centers[i] + (i>=idx ? shift : 0);
-    const grp = (i<idx) ? gLeft : gRight;
+  const shift = idx < CFG.nBeads ? CLIP_GAP : 0;
+  for (let i = 0; i < CFG.nBeads; i++) {
+    var _CFG$ui2, _CFG$ui3, _CFG$ui4;
+    const colorClass = Math.floor(i / CFG.groupSize) % 2 === 0 ? ((_CFG$ui2 = CFG.ui) === null || _CFG$ui2 === void 0 ? void 0 : _CFG$ui2.leftColorClass) || "red" : ((_CFG$ui3 = CFG.ui) === null || _CFG$ui3 === void 0 ? void 0 : _CFG$ui3.rightColorClass) || "blue";
+    const cx = centers[i] + (i >= idx ? shift : 0);
+    const grp = i < idx ? gLeft : gRight;
 
     // fallback-sirkel vises umiddelbart
     grp.appendChild(circle(cx, CFG.wireY, r, `beadFallback ${colorClass}`));
 
     // svg-bilde oppå (hvis lastet)
-    const href = (colorClass === (CFG.ui?.leftColorClass || "red"))
-      ? CFG.assets.beadRed
-      : CFG.assets.beadBlue;
-
-    grp.appendChild(img(href, cx-r, CFG.wireY-r, r*2, r*2, "beadShadow"));
+    const href = colorClass === (((_CFG$ui4 = CFG.ui) === null || _CFG$ui4 === void 0 ? void 0 : _CFG$ui4.leftColorClass) || "red") ? CFG.assets.beadRed : CFG.assets.beadBlue;
+    grp.appendChild(img(href, cx - r, CFG.wireY - r, r * 2, r * 2, "beadShadow"));
   }
 
   // klypeposisjon i gap-midt, og halvparten av gap-shift til høyre
-  const clipX = gapMids[idx] + (idx===CFG.nBeads ? 0 : shift/2);
+  const clipX = gapMids[idx] + (idx === CFG.nBeads ? 0 : shift / 2);
   gClip.setAttribute("transform", `translate(${clipX},${clipY})`);
-
   overlay.setAttribute("aria-valuenow", String(idx));
   overlay.setAttribute("aria-valuetext", `${idx} til venstre, ${CFG.nBeads - idx} til høyre`);
-
   updateFeedbackUI();
 }
-
-function setIndex(v){
+function setIndex(v) {
   const cl = clamp(v, 0, CFG.nBeads);
-  if(cl !== idx){ idx = cl; draw(); }
+  if (cl !== idx) {
+    idx = cl;
+    draw();
+  }
 }
-function setClipYFromPoint(py){
-  setClipY( clamp(py - CFG.wireY, CLIP_Y_MIN, CLIP_Y_MAX) );
+function setClipYFromPoint(py) {
+  setClipY(clamp(py - CFG.wireY, CLIP_Y_MIN, CLIP_Y_MAX));
 }
-function setClipY(v){
+function setClipY(v) {
   const cl = clamp(v, CLIP_Y_MIN, CLIP_Y_MAX);
-  if(cl !== clipY){ clipY = cl; draw(); }
+  if (cl !== clipY) {
+    clipY = cl;
+    draw();
+  }
 }
 
 /* Bruker gapMids og binærsøk for å finne nærmeste index */
-function nearestIndex(x){
-  let lo = 0, hi = gapMids.length - 1;
-  while(hi - lo > 1){
-    const mid = (lo + hi) >> 1;
-    if(x < gapMids[mid]) hi = mid; else lo = mid;
+function nearestIndex(x) {
+  let lo = 0,
+    hi = gapMids.length - 1;
+  while (hi - lo > 1) {
+    const mid = lo + hi >> 1;
+    if (x < gapMids[mid]) hi = mid;else lo = mid;
   }
-  return (Math.abs(x - gapMids[lo]) <= Math.abs(x - gapMids[hi])) ? lo : hi;
+  return Math.abs(x - gapMids[lo]) <= Math.abs(x - gapMids[hi]) ? lo : hi;
 }
-
-function applyConfig(){
+function applyConfig() {
   CFG = makeCFG();
   idx = clamp(CFG.startIndex, 0, CFG.nBeads);
   clipY = 0;
@@ -277,27 +306,27 @@ function applyConfig(){
   layout();
   draw();
 }
-
-function setupSettingsUI(){
+function setupSettingsUI() {
+  var _SIMPLE$correct;
   const nInput = document.getElementById("cfg-nBeads");
   const startInput = document.getElementById("cfg-startIndex");
   const correctInput = document.getElementById("cfg-correct");
-  if(!nInput || !startInput || !correctInput) return;
-
+  if (!nInput || !startInput || !correctInput) return;
   nInput.value = SIMPLE.nBeads;
   startInput.value = SIMPLE.startIndex;
-  if (SIMPLE.correct?.value != null) correctInput.value = SIMPLE.correct.value;
+  if (((_SIMPLE$correct = SIMPLE.correct) === null || _SIMPLE$correct === void 0 ? void 0 : _SIMPLE$correct.value) != null) correctInput.value = SIMPLE.correct.value;
   startInput.max = correctInput.max = SIMPLE.nBeads;
-
-  function update(){
+  function update() {
     SIMPLE.nBeads = parseInt(nInput.value) || SIMPLE.nBeads;
     startInput.max = correctInput.max = SIMPLE.nBeads;
     SIMPLE.startIndex = parseInt(startInput.value) || 0;
     const c = parseInt(correctInput.value);
-    if(!isNaN(c)) SIMPLE.correct = { mode:"leftCount", value:c };
+    if (!isNaN(c)) SIMPLE.correct = {
+      mode: "leftCount",
+      value: c
+    };
     applyConfig();
   }
-
   nInput.addEventListener("change", update);
   startInput.addEventListener("change", update);
   correctInput.addEventListener("change", update);
@@ -307,91 +336,115 @@ function setupSettingsUI(){
 function normalizeCorrect(simple, nBeads) {
   const c = simple.correct;
   if (typeof c === "number") {
-    return { mode: "leftCount", value: c }; // short-hand
+    return {
+      mode: "leftCount",
+      value: c
+    }; // short-hand
   }
   if (!c || typeof c !== "object") {
     return null;
   }
   const mode = c.mode || "leftCount";
-  const out = { mode };
-
+  const out = {
+    mode
+  };
   if (Array.isArray(c.values)) out.values = [...c.values];
   if (Array.isArray(c.range) && c.range.length === 2) out.range = [c.range[0], c.range[1]];
   if (typeof c.value === "number") out.value = c.value;
-
   const clamp01 = v => Math.max(0, Math.min(nBeads, v));
   if (out.value != null) out.value = clamp01(out.value);
   if (out.values) out.values = out.values.map(clamp01);
   if (out.range) out.range = [clamp01(out.range[0]), clamp01(out.range[1])];
-
   return out;
 }
-
 function evaluateCorrect(idx, simple, nBeads) {
   const rule = normalizeCorrect(simple, nBeads);
-  if (!rule) return { ok:false, reason:"Ingen fasit definert" };
-
-  const left  = idx;
+  if (!rule) return {
+    ok: false,
+    reason: "Ingen fasit definert"
+  };
+  const left = idx;
   const right = nBeads - idx;
-
-  const inSet   = (v, arr) => arr && arr.includes(v);
+  const inSet = (v, arr) => arr && arr.includes(v);
   const inRange = (v, rng) => rng && v >= rng[0] && v <= rng[1];
-
   let ok = false;
-
   switch (rule.mode) {
     case "leftCount":
-      if (rule.value != null) ok = (left === rule.value);
-      else if (rule.values)   ok = inSet(left, rule.values);
-      else if (rule.range)    ok = inRange(left, rule.range);
+      if (rule.value != null) ok = left === rule.value;else if (rule.values) ok = inSet(left, rule.values);else if (rule.range) ok = inRange(left, rule.range);
       break;
-
     case "rightCount":
-      if (rule.value != null) ok = (right === rule.value);
-      else if (rule.values)   ok = inSet(right, rule.values);
-      else if (rule.range)    ok = inRange(right, rule.range);
+      if (rule.value != null) ok = right === rule.value;else if (rule.values) ok = inSet(right, rule.values);else if (rule.range) ok = inRange(right, rule.range);
       break;
-
     case "index":
-      if (rule.value != null) ok = (idx === rule.value);
-      else if (rule.values)   ok = inSet(idx, rule.values);
-      else if (rule.range)    ok = inRange(idx, rule.range);
+      if (rule.value != null) ok = idx === rule.value;else if (rule.values) ok = inSet(idx, rule.values);else if (rule.range) ok = inRange(idx, rule.range);
       break;
-
     case "indexSet":
       ok = inSet(idx, rule.values || []);
       break;
-
     default:
       ok = false;
   }
-
   const fb = simple.feedback || {};
-  const reason = ok ? (fb.correct || "Riktig!") : (fb.wrong || "Prøv igjen");
-  return { ok, reason };
+  const reason = ok ? fb.correct || "Riktig!" : fb.wrong || "Prøv igjen";
+  return {
+    ok,
+    reason
+  };
 }
 
 /* Minimal UI-hook: marker korrekthet + a11y-tekst */
-function updateFeedbackUI(){
+function updateFeedbackUI() {
+  var _SIMPLE$feedback;
   const res = evaluateCorrect(idx, SIMPLE, SIMPLE.nBeads);
-  if (SIMPLE.feedback?.showLive) {
+  if ((_SIMPLE$feedback = SIMPLE.feedback) !== null && _SIMPLE$feedback !== void 0 && _SIMPLE$feedback.showLive) {
     svg.setAttribute("data-correct", res.ok ? "true" : "false");
-    overlay.setAttribute("aria-valuetext",
-      `${idx} til venstre, ${SIMPLE.nBeads - idx} til høyre – ${res.reason}`
-    );
+    overlay.setAttribute("aria-valuetext", `${idx} til venstre, ${SIMPLE.nBeads - idx} til høyre – ${res.reason}`);
   }
 }
 
 /* ===== helpers ===== */
-function mk(n,attrs={}){ const e=document.createElementNS("http://www.w3.org/2000/svg",n);
-  for(const[k,v] of Object.entries(attrs)) e.setAttribute(k,v); return e; }
-function img(href,x,y,w,h,cls=""){ return mk("image",{href,x,y,width:w,height:h, class:cls}); }
-function rect(x,y,w,h,attrs){ return mk("rect",{x,y,width:w,height:h, ...attrs}); }
-function circle(cx,cy,r,cls){ return mk("circle",{cx,cy,r, class:cls}); }
-function clamp(v,a,b){ return Math.max(a, Math.min(b,v)); }
-function pt(e){ const p=svg.createSVGPoint(); p.x=e.clientX; p.y=e.clientY; return p.matrixTransform(svg.getScreenCTM().inverse()); }
-
-function svgToString(svgEl){
+function mk(n, attrs = {}) {
+  const e = document.createElementNS("http://www.w3.org/2000/svg", n);
+  for (const [k, v] of Object.entries(attrs)) e.setAttribute(k, v);
+  return e;
+}
+function img(href, x, y, w, h, cls = "") {
+  return mk("image", {
+    href,
+    x,
+    y,
+    width: w,
+    height: h,
+    class: cls
+  });
+}
+function rect(x, y, w, h, attrs) {
+  return mk("rect", {
+    x,
+    y,
+    width: w,
+    height: h,
+    ...attrs
+  });
+}
+function circle(cx, cy, r, cls) {
+  return mk("circle", {
+    cx,
+    cy,
+    r,
+    class: cls
+  });
+}
+function clamp(v, a, b) {
+  return Math.max(a, Math.min(b, v));
+}
+function pt(e) {
+  const p = svg.createSVGPoint();
+  p.x = e.clientX;
+  p.y = e.clientY;
+  return p.matrixTransform(svg.getScreenCTM().inverse());
+}
+function svgToString(svgEl) {
   const clone = svgEl.cloneNode(true);
   const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
   const style = document.createElement('style');
@@ -401,59 +454,65 @@ function svgToString(svgEl){
   // Kopier beskrivelser referert av aria-describedby inn i SVG-en
   const ids = new Set();
   clone.querySelectorAll('[aria-describedby]').forEach(el => {
-    el.getAttribute('aria-describedby')
-      ?.split(/\s+/)
-      .forEach(id => ids.add(id));
+    var _el$getAttribute;
+    (_el$getAttribute = el.getAttribute('aria-describedby')) === null || _el$getAttribute === void 0 || _el$getAttribute.split(/\s+/).forEach(id => ids.add(id));
   });
   ids.forEach(id => {
-    if(!id || clone.getElementById(id)) return;
+    if (!id || clone.getElementById(id)) return;
     const src = document.getElementById(id);
-    if(src){
-      const desc = document.createElementNS('http://www.w3.org/2000/svg','desc');
+    if (src) {
+      const desc = document.createElementNS('http://www.w3.org/2000/svg', 'desc');
       desc.setAttribute('id', id);
       desc.textContent = src.textContent;
       clone.insertBefore(desc, style.nextSibling);
     }
   });
-
-  clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
-  clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
+  clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
   return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
 }
-function downloadSVG(svgEl, filename){
+function downloadSVG(svgEl, filename) {
   const data = svgToString(svgEl);
-  const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+  const blob = new Blob([data], {
+    type: 'image/svg+xml;charset=utf-8'
+  });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
   a.download = filename.endsWith('.svg') ? filename : filename + '.svg';
-  document.body.appendChild(a); a.click(); a.remove();
-  setTimeout(()=>URL.revokeObjectURL(url), 1000);
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
-function downloadPNG(svgEl, filename, scale=2, bg='#fff'){
+function downloadPNG(svgEl, filename, scale = 2, bg = '#fff') {
   const vb = svgEl.viewBox.baseVal;
-  const w = vb?.width  || svgEl.clientWidth  || VB_W;
-  const h = vb?.height || svgEl.clientHeight || VB_H;
+  const w = (vb === null || vb === void 0 ? void 0 : vb.width) || svgEl.clientWidth || VB_W;
+  const h = (vb === null || vb === void 0 ? void 0 : vb.height) || svgEl.clientHeight || VB_H;
   const data = svgToString(svgEl);
-  const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
-  const url  = URL.createObjectURL(blob);
+  const blob = new Blob([data], {
+    type: 'image/svg+xml;charset=utf-8'
+  });
+  const url = URL.createObjectURL(blob);
   const img = new Image();
-  img.onload = ()=>{
+  img.onload = () => {
     const canvas = document.createElement('canvas');
-    canvas.width  = Math.round(w * scale);
+    canvas.width = Math.round(w * scale);
     canvas.height = Math.round(h * scale);
     const ctx = canvas.getContext('2d');
     ctx.fillStyle = bg;
-    ctx.fillRect(0,0,canvas.width,canvas.height);
-    ctx.drawImage(img,0,0,canvas.width,canvas.height);
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
     URL.revokeObjectURL(url);
-    canvas.toBlob(blob=>{
+    canvas.toBlob(blob => {
       const urlPng = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = urlPng;
       a.download = filename.endsWith('.png') ? filename : filename + '.png';
-      document.body.appendChild(a); a.click(); a.remove();
-      setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(urlPng), 1000);
     }, 'image/png');
   };
   img.src = url;

--- a/split.js
+++ b/split.js
@@ -6,18 +6,14 @@ document.addEventListener('DOMContentLoaded', () => {
     // mål startbredden før splitteren legges til slik at vi bevarer
     // sidens opprinnelige bredde på ulike sider
     const initialWidth = side.getBoundingClientRect().width;
-
     const splitter = document.createElement('div');
     splitter.className = 'splitter';
     grid.insertBefore(splitter, side);
     grid.classList.add('split-enabled');
-
     grid.style.setProperty('--side-width', `${initialWidth}px`);
-
     let startX = 0;
     let startWidth = 0;
     const minWidth = 200;
-
     const onMove = e => {
       const dx = e.clientX - startX;
       let newWidth = startWidth - dx;
@@ -27,12 +23,10 @@ document.addEventListener('DOMContentLoaded', () => {
       grid.style.setProperty('--side-width', `${newWidth}px`);
       window.dispatchEvent(new Event('resize'));
     };
-
     const stopDrag = () => {
       document.removeEventListener('pointermove', onMove);
       document.removeEventListener('pointerup', stopDrag);
     };
-
     const startDrag = e => {
       e.preventDefault();
       startX = e.clientX;
@@ -40,7 +34,6 @@ document.addEventListener('DOMContentLoaded', () => {
       document.addEventListener('pointermove', onMove);
       document.addEventListener('pointerup', stopDrag);
     };
-
     splitter.addEventListener('pointerdown', startDrag);
   });
 });

--- a/tenkeblokker-stepper.js
+++ b/tenkeblokker-stepper.js
@@ -4,11 +4,9 @@ class ThinkBlock {
     this.parts = 1;
     this.root = document.createElement('div');
     this.root.className = 'tb-block-wrapper';
-
     this.block = document.createElement('div');
     this.block.className = 'tb-block';
     this.root.appendChild(this.block);
-
     this.stepper = document.createElement('div');
     this.stepper.className = 'tb-stepper';
     this.minus = document.createElement('button');
@@ -19,18 +17,14 @@ class ThinkBlock {
     this.plus.textContent = '+';
     this.stepper.append(this.minus, this.plus);
     this.root.appendChild(this.stepper);
-
     this.minus.addEventListener('click', () => this.setParts(this.parts - 1));
     this.plus.addEventListener('click', () => this.setParts(this.parts + 1));
-
     this.render();
   }
-
   setParts(p) {
     this.parts = Math.max(1, p);
     this.render();
   }
-
   render() {
     this.block.innerHTML = '';
     const value = this.total / this.parts;
@@ -42,13 +36,10 @@ class ThinkBlock {
     }
   }
 }
-
 const container = document.getElementById('blocks');
-
 function addBlock() {
   const tb = new ThinkBlock();
   container.appendChild(tb.root);
 }
-
 document.getElementById('addBlock').addEventListener('click', addBlock);
 addBlock();

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -1,76 +1,64 @@
+var _combinedWholeControl;
 /* Tenkeblokker – grid layout */
 
-const DEFAULT_BLOCKS = [
-  {
-    total: 1,
-    n: 1,
-    k: 1,
-    showWhole: false,
-    lockDenominator: true,
-    lockNumerator: true,
-    hideNValue: false,
-    valueDisplay: 'number',
-    showCustomText: false,
-    customText: ''
-  },
-  {
-    total: 1,
-    n: 1,
-    k: 1,
-    showWhole: false,
-    lockDenominator: true,
-    lockNumerator: true,
-    hideNValue: false,
-    valueDisplay: 'number',
-    showCustomText: false,
-    customText: ''
-  }
-];
-
-const DEFAULT_TENKEBLOKKER_EXAMPLES = [
-  {
-    id: 'tenkeblokker-example-1',
-    exampleNumber: '1',
-    title: 'Brøk av en hel',
-    isDefault: true,
-    config: {
-      CONFIG: {
-        minN: 1,
-        maxN: 12,
-        rows: 1,
-        cols: 1,
-        blocks: [
-          [
-            {
-              total: 12,
-              n: 4,
-              k: 3,
-              showWhole: false,
-              lockDenominator: false,
-              lockNumerator: false,
-              hideNValue: false,
-              valueDisplay: 'fraction',
-              showCustomText: false,
-              customText: '',
-              showFraction: true,
-              showPercent: false
-            }
-          ]
-        ],
-        showCombinedWhole: false
-      }
+const DEFAULT_BLOCKS = [{
+  total: 1,
+  n: 1,
+  k: 1,
+  showWhole: false,
+  lockDenominator: true,
+  lockNumerator: true,
+  hideNValue: false,
+  valueDisplay: 'number',
+  showCustomText: false,
+  customText: ''
+}, {
+  total: 1,
+  n: 1,
+  k: 1,
+  showWhole: false,
+  lockDenominator: true,
+  lockNumerator: true,
+  hideNValue: false,
+  valueDisplay: 'number',
+  showCustomText: false,
+  customText: ''
+}];
+const DEFAULT_TENKEBLOKKER_EXAMPLES = [{
+  id: 'tenkeblokker-example-1',
+  exampleNumber: '1',
+  title: 'Brøk av en hel',
+  isDefault: true,
+  config: {
+    CONFIG: {
+      minN: 1,
+      maxN: 12,
+      rows: 1,
+      cols: 1,
+      blocks: [[{
+        total: 12,
+        n: 4,
+        k: 3,
+        showWhole: false,
+        lockDenominator: false,
+        lockNumerator: false,
+        hideNValue: false,
+        valueDisplay: 'fraction',
+        showCustomText: false,
+        customText: '',
+        showFraction: true,
+        showPercent: false
+      }]],
+      showCombinedWhole: false
     }
   }
-];
-
+}];
 const DISPLAY_OPTIONS = ['number', 'fraction', 'percent'];
-
 function sanitizeDisplayMode(value) {
   if (typeof value !== 'string') return null;
   const normalized = value.trim().toLowerCase();
   return DISPLAY_OPTIONS.includes(normalized) ? normalized : null;
 }
-
 function applyDisplayMode(cfg, mode, fallback = 'number') {
   if (!cfg) return 'number';
   const normalizedFallback = sanitizeDisplayMode(fallback) || 'number';
@@ -80,7 +68,6 @@ function applyDisplayMode(cfg, mode, fallback = 'number') {
   cfg.showPercent = normalized === 'percent';
   return normalized;
 }
-
 function parseGridDimension(value, fallback = 1) {
   if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
     return Math.round(value);
@@ -93,7 +80,6 @@ function parseGridDimension(value, fallback = 1) {
   }
   return fallback;
 }
-
 function cloneExampleConfig(config) {
   if (!config) return config;
   if (typeof structuredClone === 'function') {
@@ -105,13 +91,11 @@ function cloneExampleConfig(config) {
   }
   return JSON.parse(JSON.stringify(config));
 }
-
 function getHiddenNumber(target, key) {
   if (!target || typeof target !== 'object') return null;
   const value = target[key];
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
-
 function setHiddenNumber(target, key, value) {
   if (!target || typeof target !== 'object') return;
   Object.defineProperty(target, key, {
@@ -121,12 +105,10 @@ function setHiddenNumber(target, key, value) {
     enumerable: false
   });
 }
-
 function getHiddenBoolean(target, key) {
   if (!target || typeof target !== 'object') return false;
   return target[key] === true;
 }
-
 function setHiddenFlag(target, key, value) {
   if (!target || typeof target !== 'object') return;
   Object.defineProperty(target, key, {
@@ -136,7 +118,6 @@ function setHiddenFlag(target, key, value) {
     enumerable: false
   });
 }
-
 function isMeaningfulBlockCell(cell) {
   if (cell == null) return false;
   if (typeof cell === 'object') {
@@ -148,7 +129,6 @@ function isMeaningfulBlockCell(cell) {
   }
   return true;
 }
-
 function countMeaningfulColumns(row) {
   if (!Array.isArray(row)) return 0;
   for (let i = row.length - 1; i >= 0; i--) {
@@ -156,12 +136,12 @@ function countMeaningfulColumns(row) {
   }
   return 0;
 }
-
 function getDefaultBlock(index = 0) {
   const base = DEFAULT_BLOCKS[index] || DEFAULT_BLOCKS[DEFAULT_BLOCKS.length - 1];
-  return { ...base };
+  return {
+    ...base
+  };
 }
-
 const CONFIG = {
   minN: 1,
   maxN: 12,
@@ -170,7 +150,6 @@ const CONFIG = {
   blocks: [],
   showCombinedWhole: false
 };
-
 const VBW = 900;
 const VBH = 420;
 const SIDE_MARGIN_RATIO = 0;
@@ -182,10 +161,8 @@ const LABEL_OFFSET_RATIO = 14 / VBH;
 const DEFAULT_SVG_HEIGHT = 260;
 const ROW_GAP = 18;
 const DEFAULT_FRAME_INSET = 3;
-
 const BLOCKS = [];
 let multipleBlocksActive = false;
-
 const board = document.getElementById('tbBoard');
 const grid = document.getElementById('tbGrid');
 const addColumnBtn = document.getElementById('tbAddColumn');
@@ -193,47 +170,43 @@ const addRowBtn = document.getElementById('tbAddRow');
 const removeColumnBtn = document.getElementById('tbRemoveColumn');
 const removeRowBtn = document.getElementById('tbRemoveRow');
 const settingsContainer = document.getElementById('tbSettings');
-
 const combinedWholeControls = {
   row: document.getElementById('cfg-show-combined-row'),
   checkbox: document.getElementById('cfg-show-combined-whole')
 };
-
 const btnSvg = document.getElementById('btnSvg');
 const btnPng = document.getElementById('btnPng');
-
 if (typeof window !== 'undefined') {
-  window.DEFAULT_EXAMPLES = DEFAULT_TENKEBLOKKER_EXAMPLES.map(example => ({
-    ...example,
-    config: {
-      ...example.config,
-      CONFIG: cloneExampleConfig(example.config?.CONFIG)
-    }
-  }));
+  window.DEFAULT_EXAMPLES = DEFAULT_TENKEBLOKKER_EXAMPLES.map(example => {
+    var _example$config;
+    return {
+      ...example,
+      config: {
+        ...example.config,
+        CONFIG: cloneExampleConfig((_example$config = example.config) === null || _example$config === void 0 ? void 0 : _example$config.CONFIG)
+      }
+    };
+  });
 }
-
 const combinedWholeOverlay = createCombinedWholeOverlay();
 if (typeof window !== 'undefined') {
   window.addEventListener('resize', () => draw(true));
 }
-
-addColumnBtn?.addEventListener('click', () => {
+addColumnBtn === null || addColumnBtn === void 0 || addColumnBtn.addEventListener('click', () => {
   const current = parseGridDimension(CONFIG.cols, 1);
   if (current >= 3) return;
   setHiddenFlag(CONFIG, '__colsDirty', true);
   CONFIG.cols = Math.min(3, current + 1);
   draw();
 });
-
-addRowBtn?.addEventListener('click', () => {
+addRowBtn === null || addRowBtn === void 0 || addRowBtn.addEventListener('click', () => {
   const current = parseGridDimension(CONFIG.rows, 1);
   if (current >= 3) return;
   setHiddenFlag(CONFIG, '__rowsDirty', true);
   CONFIG.rows = Math.min(3, current + 1);
   draw();
 });
-
-removeColumnBtn?.addEventListener('click', () => {
+removeColumnBtn === null || removeColumnBtn === void 0 || removeColumnBtn.addEventListener('click', () => {
   const current = parseGridDimension(CONFIG.cols, 1);
   if (current <= 1) return;
   const next = Math.max(1, current - 1);
@@ -248,8 +221,7 @@ removeColumnBtn?.addEventListener('click', () => {
   }
   draw();
 });
-
-removeRowBtn?.addEventListener('click', () => {
+removeRowBtn === null || removeRowBtn === void 0 || removeRowBtn.addEventListener('click', () => {
   const current = parseGridDimension(CONFIG.rows, 1);
   if (current <= 1) return;
   const next = Math.max(1, current - 1);
@@ -260,55 +232,52 @@ removeRowBtn?.addEventListener('click', () => {
   }
   draw();
 });
-
-combinedWholeControls.checkbox?.addEventListener('change', () => {
+(_combinedWholeControl = combinedWholeControls.checkbox) === null || _combinedWholeControl === void 0 || _combinedWholeControl.addEventListener('change', () => {
   CONFIG.showCombinedWhole = !!combinedWholeControls.checkbox.checked;
   draw(true);
 });
-
-btnSvg?.addEventListener('click', () => {
+btnSvg === null || btnSvg === void 0 || btnSvg.addEventListener('click', () => {
   const exportSvg = getExportSvg();
   if (exportSvg) downloadSVG(exportSvg, 'tenkeblokker.svg');
 });
-
-btnPng?.addEventListener('click', () => {
+btnPng === null || btnPng === void 0 || btnPng.addEventListener('click', () => {
   const exportSvg = getExportSvg();
   if (exportSvg) downloadPNG(exportSvg, 'tenkeblokker.png', 2);
 });
-
 normalizeConfig(true);
 rebuildStructure();
-
 draw(true);
-
 window.CONFIG = CONFIG;
 window.draw = draw;
-
 function getSvgViewport(block) {
-  const svg = block?.svg;
-  const panelRect = block?.panel?.getBoundingClientRect?.();
-  const svgRect = svg?.getBoundingClientRect?.();
-
-  let width = panelRect?.width;
-  if (!(width > 0)) width = svgRect?.width;
+  var _block$panel, _block$panel$getBound, _svg$getBoundingClien;
+  const svg = block === null || block === void 0 ? void 0 : block.svg;
+  const panelRect = block === null || block === void 0 || (_block$panel = block.panel) === null || _block$panel === void 0 || (_block$panel$getBound = _block$panel.getBoundingClientRect) === null || _block$panel$getBound === void 0 ? void 0 : _block$panel$getBound.call(_block$panel);
+  const svgRect = svg === null || svg === void 0 || (_svg$getBoundingClien = svg.getBoundingClientRect) === null || _svg$getBoundingClien === void 0 ? void 0 : _svg$getBoundingClien.call(svg);
+  let width = panelRect === null || panelRect === void 0 ? void 0 : panelRect.width;
+  if (!(width > 0)) width = svgRect === null || svgRect === void 0 ? void 0 : svgRect.width;
   if (!(width > 0)) width = VBW;
-
-  let height = svgRect?.height;
+  let height = svgRect === null || svgRect === void 0 ? void 0 : svgRect.height;
   if (!(height > 0) && svg) {
-    const owner = svg.ownerDocument?.defaultView;
-    if (owner?.getComputedStyle) {
+    var _svg$ownerDocument;
+    const owner = (_svg$ownerDocument = svg.ownerDocument) === null || _svg$ownerDocument === void 0 ? void 0 : _svg$ownerDocument.defaultView;
+    if (owner !== null && owner !== void 0 && owner.getComputedStyle) {
       const computedHeight = owner.getComputedStyle(svg).getPropertyValue('height');
       const parsed = Number.parseFloat(String(computedHeight).replace(',', '.'));
       if (Number.isFinite(parsed) && parsed > 0) height = parsed;
     }
   }
   if (!(height > 0)) height = DEFAULT_SVG_HEIGHT;
-
-  return { width, height };
+  return {
+    width,
+    height
+  };
 }
-
 function getBlockMetrics(block) {
-  const { width, height } = getSvgViewport(block);
+  const {
+    width,
+    height
+  } = getSvgViewport(block);
   const left = width * SIDE_MARGIN_RATIO;
   const right = width - left;
   const top = height * TOP_RATIO;
@@ -347,7 +316,6 @@ function getBlockMetrics(block) {
     outerBottom: bottom
   };
 }
-
 function toBoolean(value, fallback = false) {
   if (typeof value === 'boolean') return value;
   if (typeof value === 'string') {
@@ -357,16 +325,17 @@ function toBoolean(value, fallback = false) {
   }
   return fallback;
 }
-
 function normalizeBlockConfig(raw, index, existing, previous) {
+  var _defaults$customText;
   const defaults = getDefaultBlock(index);
-  const target = existing && typeof existing === 'object' ? existing : { ...defaults };
+  const target = existing && typeof existing === 'object' ? existing : {
+    ...defaults
+  };
   const source = raw && typeof raw === 'object' ? raw : {};
   const isNew = raw == null;
-
   let total = Number(source.total);
   if (!Number.isFinite(total) || total < 1) {
-    const prevTotal = Number(previous?.total);
+    const prevTotal = Number(previous === null || previous === void 0 ? void 0 : previous.total);
     if (isNew && Number.isFinite(prevTotal) && prevTotal > 0) {
       total = prevTotal;
     } else {
@@ -374,50 +343,38 @@ function normalizeBlockConfig(raw, index, existing, previous) {
     }
   }
   target.total = total;
-
   let n = Number(source.n);
   if (!Number.isFinite(n)) n = Number(defaults.n) || 1;
   target.n = Math.round(n);
-
   let k = Number(source.k);
   if (!Number.isFinite(k)) k = Number(defaults.k) || 0;
   target.k = Math.round(k);
-
   target.showWhole = toBoolean(source.showWhole, toBoolean(defaults.showWhole, true));
   target.lockDenominator = toBoolean(source.lockDenominator, toBoolean(defaults.lockDenominator, false));
   target.lockNumerator = toBoolean(source.lockNumerator, toBoolean(defaults.lockNumerator, false));
   target.hideNValue = toBoolean(source.hideNValue, toBoolean(defaults.hideNValue, false));
   target.showCustomText = toBoolean(source.showCustomText, toBoolean(defaults.showCustomText, false));
-  const textSource = typeof source.customText === 'string' ? source.customText : defaults.customText ?? '';
+  const textSource = typeof source.customText === 'string' ? source.customText : (_defaults$customText = defaults.customText) !== null && _defaults$customText !== void 0 ? _defaults$customText : '';
   target.customText = textSource;
-
   let desiredDisplay = sanitizeDisplayMode(source.valueDisplay);
   if (!desiredDisplay) {
-    if (toBoolean(source.showPercent)) desiredDisplay = 'percent';
-    else if (toBoolean(source.showFraction)) desiredDisplay = 'fraction';
-    else desiredDisplay = sanitizeDisplayMode(defaults.valueDisplay) || 'number';
+    if (toBoolean(source.showPercent)) desiredDisplay = 'percent';else if (toBoolean(source.showFraction)) desiredDisplay = 'fraction';else desiredDisplay = sanitizeDisplayMode(defaults.valueDisplay) || 'number';
   }
   applyDisplayMode(target, desiredDisplay, defaults.valueDisplay);
-
   return target;
 }
-
 function normalizeConfig(initial = false) {
   let structureChanged = false;
-
   const previousRows = getHiddenNumber(CONFIG, '__lastNormalizedRows');
   const previousCols = getHiddenNumber(CONFIG, '__lastNormalizedCols');
-
   if (typeof CONFIG.minN !== 'number' || Number.isNaN(CONFIG.minN)) CONFIG.minN = 1;
   if (typeof CONFIG.maxN !== 'number' || Number.isNaN(CONFIG.maxN)) CONFIG.maxN = 12;
   CONFIG.minN = Math.max(1, Math.floor(CONFIG.minN));
   CONFIG.maxN = Math.max(CONFIG.minN, Math.floor(CONFIG.maxN));
-
   if (!Array.isArray(CONFIG.blocks)) {
     CONFIG.blocks = [];
     structureChanged = true;
   }
-
   let usedRows = 0;
   let usedCols = 0;
   if (Array.isArray(CONFIG.blocks)) {
@@ -431,14 +388,12 @@ function normalizeConfig(initial = false) {
   }
   usedRows = clamp(usedRows, 0, 3);
   usedCols = clamp(usedCols, 0, 3);
-
   const rowsDirty = getHiddenBoolean(CONFIG, '__rowsDirty');
   const colsDirty = getHiddenBoolean(CONFIG, '__colsDirty');
-
   const hasNested = CONFIG.blocks.some(item => Array.isArray(item));
   if (!hasNested) {
     const flat = CONFIG.blocks;
-    const activeRaw = Number.isFinite(CONFIG.activeBlocks) ? Math.round(CONFIG.activeBlocks) : (flat?.length || 1);
+    const activeRaw = Number.isFinite(CONFIG.activeBlocks) ? Math.round(CONFIG.activeBlocks) : (flat === null || flat === void 0 ? void 0 : flat.length) || 1;
     const active = clamp(activeRaw, 1, 9);
     let rows = Number.isFinite(CONFIG.rows) ? Math.round(CONFIG.rows) : 0;
     let cols = Number.isFinite(CONFIG.cols) ? Math.round(CONFIG.cols) : 0;
@@ -447,20 +402,17 @@ function normalizeConfig(initial = false) {
     rows = clamp(rows, 1, 3);
     cols = clamp(cols, 1, 3);
     while (rows * cols < active) {
-      if (cols < 3) cols += 1;
-      else if (rows < 3) rows += 1;
-      else break;
+      if (cols < 3) cols += 1;else if (rows < 3) rows += 1;else break;
     }
     const gridData = [];
     let index = 0;
     for (let r = 0; r < rows; r++) {
       const row = [];
       for (let c = 0; c < cols; c++) {
-        const raw = flat?.[index] || null;
+        const raw = (flat === null || flat === void 0 ? void 0 : flat[index]) || null;
         let previous = null;
         if (index > 0) {
-          if (c > 0) previous = row[c - 1];
-          else if (r > 0) {
+          if (c > 0) previous = row[c - 1];else if (r > 0) {
             const prevRow = gridData[r - 1];
             previous = Array.isArray(prevRow) ? prevRow[cols - 1] : null;
           }
@@ -484,7 +436,6 @@ function normalizeConfig(initial = false) {
         rows = usedRows;
       }
     }
-
     let cols = Number.isFinite(CONFIG.cols) ? Math.round(CONFIG.cols) : 0;
     if (!(cols >= 1)) {
       cols = usedCols > 0 ? usedCols : 1;
@@ -497,10 +448,8 @@ function normalizeConfig(initial = false) {
         cols = usedCols;
       }
     }
-
     if (CONFIG.blocks.length !== rows) structureChanged = true;
     CONFIG.blocks.length = rows;
-
     for (let r = 0; r < rows; r++) {
       let row = CONFIG.blocks[r];
       if (!Array.isArray(row)) {
@@ -528,7 +477,6 @@ function normalizeConfig(initial = false) {
     CONFIG.rows = rows;
     CONFIG.cols = cols;
   }
-
   const rows = CONFIG.rows;
   const cols = CONFIG.cols;
   for (let r = 0; r < rows; r++) {
@@ -544,36 +492,28 @@ function normalizeConfig(initial = false) {
       cfg.hideNValue = !!cfg.hideNValue;
     }
   }
-
   CONFIG.activeBlocks = rows * cols;
   CONFIG.showCombinedWhole = toBoolean(CONFIG.showCombinedWhole, false);
-
   const rowsChanged = Number.isFinite(previousRows) && previousRows !== rows;
   const colsChanged = Number.isFinite(previousCols) && previousCols !== cols;
   if (rowsChanged || colsChanged) structureChanged = true;
-
   setHiddenNumber(CONFIG, '__lastNormalizedRows', rows);
   setHiddenNumber(CONFIG, '__lastNormalizedCols', cols);
   setHiddenFlag(CONFIG, '__rowsDirty', false);
   setHiddenFlag(CONFIG, '__colsDirty', false);
-
   if (!initial && CONFIG.stackBlocks !== undefined) {
     delete CONFIG.stackBlocks;
     structureChanged = true;
   }
-
   return structureChanged;
 }
 function rebuildStructure() {
   if (!grid) return;
-
   const panelsFragment = document.createDocumentFragment();
   const settingsFragment = document.createDocumentFragment();
-
   BLOCKS.length = 0;
   grid.innerHTML = '';
   if (settingsContainer) settingsContainer.innerHTML = '';
-
   const rowElements = [];
   for (let r = 0; r < CONFIG.rows; r++) {
     const rowEl = document.createElement('div');
@@ -581,7 +521,6 @@ function rebuildStructure() {
     rowEl.dataset.row = String(r);
     rowElements.push(rowEl);
     panelsFragment.appendChild(rowEl);
-
     for (let c = 0; c < CONFIG.cols; c++) {
       const cfg = CONFIG.blocks[r][c];
       const block = createBlock(r, c, cfg);
@@ -590,14 +529,11 @@ function rebuildStructure() {
       if (block.fieldset) settingsFragment.appendChild(block.fieldset);
     }
   }
-
   grid.setAttribute('data-cols', String(CONFIG.cols));
   grid.appendChild(panelsFragment);
   if (settingsContainer) settingsContainer.appendChild(settingsFragment);
-
   updateAddButtons();
 }
-
 function draw(skipNormalization = false) {
   if (!skipNormalization) {
     const structureChanged = normalizeConfig();
@@ -607,10 +543,8 @@ function draw(skipNormalization = false) {
       return;
     }
   }
-
   if (grid) grid.setAttribute('data-cols', String(CONFIG.cols));
   updateAddButtons();
-
   const multiple = CONFIG.activeBlocks > 1;
   multipleBlocksActive = multiple;
   if (combinedWholeControls.row) combinedWholeControls.row.style.display = multiple ? '' : 'none';
@@ -623,29 +557,27 @@ function draw(skipNormalization = false) {
       combinedWholeControls.checkbox.checked = !!CONFIG.showCombinedWhole;
     }
   }
-
-  const rowTotals = Array.from({ length: CONFIG.rows }, () => 0);
+  const rowTotals = Array.from({
+    length: CONFIG.rows
+  }, () => 0);
   const visibleBlocks = [];
-
   for (const block of BLOCKS) {
-    const cfg = CONFIG.blocks?.[block.row]?.[block.col];
+    var _CONFIG$blocks;
+    const cfg = (_CONFIG$blocks = CONFIG.blocks) === null || _CONFIG$blocks === void 0 || (_CONFIG$blocks = _CONFIG$blocks[block.row]) === null || _CONFIG$blocks === void 0 ? void 0 : _CONFIG$blocks[block.col];
     if (!cfg) continue;
     block.cfg = cfg;
     block.index = block.row * CONFIG.cols + block.col;
     visibleBlocks.push(block);
-
     const totalValue = Number(cfg.total);
     if (Number.isFinite(totalValue) && totalValue > 0 && rowTotals[block.row] !== undefined) {
       rowTotals[block.row] += totalValue;
     }
   }
-
   const maxRowTotal = rowTotals.reduce((max, value) => {
     const numeric = Number(value);
     if (!Number.isFinite(numeric) || numeric <= max) return max;
     return numeric;
   }, 0);
-
   if (grid) {
     const rowElements = grid.querySelectorAll('.tb-row');
     rowElements.forEach((rowEl, index) => {
@@ -662,59 +594,50 @@ function draw(skipNormalization = false) {
       }
     });
   }
-
   for (const block of visibleBlocks) {
     const rowTotal = rowTotals[block.row];
     updateBlockPanelLayout(block, rowTotal);
   }
-
   for (const block of visibleBlocks) {
     drawBlock(block);
   }
-
   drawCombinedWholeOverlay();
   syncLegacyConfig();
 }
-
 function updateAddButtons() {
   const parsedCols = Number(CONFIG.cols);
   const parsedRows = Number(CONFIG.rows);
   const cols = Number.isFinite(parsedCols) ? parsedCols : 1;
   const rows = Number.isFinite(parsedRows) ? parsedRows : 1;
-
   if (addColumnBtn) addColumnBtn.style.display = cols >= 3 ? 'none' : '';
   if (addRowBtn) addRowBtn.style.display = rows >= 3 ? 'none' : '';
   if (removeColumnBtn) removeColumnBtn.style.display = cols <= 1 ? 'none' : '';
   if (removeRowBtn) removeRowBtn.style.display = rows <= 1 ? 'none' : '';
 }
-
 function createBlock(row, col, cfg) {
+  var _cfg$total, _cfg$n, _cfg$k;
   const block = {
     row,
     col,
     cfg,
     uid: `tb-${row}-${col}-${Math.random().toString(36).slice(2, 8)}`
   };
-
   const panel = document.createElement('div');
   panel.className = 'tb-panel';
   panel.dataset.row = String(row);
   panel.dataset.col = String(col);
   block.panel = panel;
-
   const header = document.createElement('div');
   header.className = 'tb-header';
   header.style.display = 'none';
   block.header = header;
   panel.appendChild(header);
-
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   svg.setAttribute('class', 'tb-svg');
   svg.setAttribute('viewBox', `0 0 ${VBW} ${VBH}`);
   svg.setAttribute('preserveAspectRatio', 'none');
   block.svg = svg;
   panel.appendChild(svg);
-
   block.gBase = createSvgElement(svg, 'g');
   block.gFill = createSvgElement(svg, 'g');
   block.gSep = createSvgElement(svg, 'g');
@@ -722,61 +645,78 @@ function createBlock(row, col, cfg) {
   block.gFrame = createSvgElement(svg, 'g');
   block.gHandle = createSvgElement(svg, 'g');
   block.gBrace = createSvgElement(svg, 'g');
-
-  block.rectEmpty = createSvgElement(block.gBase, 'rect', { x: 0, y: 0, width: 0, height: 0, class: 'tb-rect-empty' });
-  block.rectFrame = createSvgElement(block.gFrame, 'rect', { x: 0, y: 0, width: 0, height: 0, class: 'tb-frame' });
+  block.rectEmpty = createSvgElement(block.gBase, 'rect', {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    class: 'tb-rect-empty'
+  });
+  block.rectFrame = createSvgElement(block.gFrame, 'rect', {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    class: 'tb-frame'
+  });
   drawBracketSquare(block.gBrace, 0, 0, 0, 0);
-  block.totalText = createSvgElement(block.gBrace, 'text', { x: 0, y: 0, class: 'tb-total' });
-
-  block.handleShadow = createSvgElement(block.gHandle, 'circle', { cx: 0, cy: 0, r: 20, class: 'tb-handle-shadow' });
-  block.handle = createSvgElement(block.gHandle, 'circle', { cx: 0, cy: 0, r: 18, class: 'tb-handle' });
+  block.totalText = createSvgElement(block.gBrace, 'text', {
+    x: 0,
+    y: 0,
+    class: 'tb-total'
+  });
+  block.handleShadow = createSvgElement(block.gHandle, 'circle', {
+    cx: 0,
+    cy: 0,
+    r: 20,
+    class: 'tb-handle-shadow'
+  });
+  block.handle = createSvgElement(block.gHandle, 'circle', {
+    cx: 0,
+    cy: 0,
+    r: 18,
+    class: 'tb-handle'
+  });
   block.handle.addEventListener('pointerdown', event => onDragStart(block, event));
-
   const stepper = document.createElement('div');
   stepper.className = 'tb-stepper';
   block.stepper = stepper;
-
   const minus = document.createElement('button');
   minus.type = 'button';
   minus.textContent = '−';
   minus.setAttribute('aria-label', 'Færre blokker');
   block.minusBtn = minus;
-
   const nVal = document.createElement('span');
   block.nVal = nVal;
-
   const plus = document.createElement('button');
   plus.type = 'button';
   plus.textContent = '+';
   plus.setAttribute('aria-label', 'Flere blokker');
   block.plusBtn = plus;
-
   minus.addEventListener('click', () => {
-    const next = (block.cfg?.n ?? CONFIG.minN) - 1;
+    var _block$cfg$n, _block$cfg;
+    const next = ((_block$cfg$n = (_block$cfg = block.cfg) === null || _block$cfg === void 0 ? void 0 : _block$cfg.n) !== null && _block$cfg$n !== void 0 ? _block$cfg$n : CONFIG.minN) - 1;
     setN(block, next);
   });
   plus.addEventListener('click', () => {
-    const next = (block.cfg?.n ?? CONFIG.minN) + 1;
+    var _block$cfg$n2, _block$cfg2;
+    const next = ((_block$cfg$n2 = (_block$cfg2 = block.cfg) === null || _block$cfg2 === void 0 ? void 0 : _block$cfg2.n) !== null && _block$cfg$n2 !== void 0 ? _block$cfg$n2 : CONFIG.minN) + 1;
     setN(block, next);
   });
-
   stepper.append(minus, nVal, plus);
   panel.appendChild(stepper);
-
   const fieldset = document.createElement('fieldset');
   block.fieldset = fieldset;
-
   const legend = document.createElement('legend');
   block.legend = legend;
   fieldset.appendChild(legend);
-
   const totalLabel = document.createElement('label');
   totalLabel.textContent = 'Total';
   const totalInput = document.createElement('input');
   totalInput.type = 'number';
   totalInput.min = '1';
   totalInput.step = '1';
-  totalInput.value = String(cfg?.total ?? 1);
+  totalInput.value = String((_cfg$total = cfg === null || cfg === void 0 ? void 0 : cfg.total) !== null && _cfg$total !== void 0 ? _cfg$total : 1);
   totalInput.addEventListener('change', () => {
     const parsed = Number.parseFloat(totalInput.value.replace(',', '.'));
     if (Number.isFinite(parsed) && parsed > 0) {
@@ -786,7 +726,6 @@ function createBlock(row, col, cfg) {
   });
   totalLabel.appendChild(totalInput);
   fieldset.appendChild(totalLabel);
-
   const nLabel = document.createElement('label');
   nLabel.textContent = 'Antall blokker';
   const nInput = document.createElement('input');
@@ -794,28 +733,26 @@ function createBlock(row, col, cfg) {
   nInput.min = String(CONFIG.minN);
   nInput.max = String(CONFIG.maxN);
   nInput.step = '1';
-  nInput.value = String(cfg?.n ?? CONFIG.minN);
+  nInput.value = String((_cfg$n = cfg === null || cfg === void 0 ? void 0 : cfg.n) !== null && _cfg$n !== void 0 ? _cfg$n : CONFIG.minN);
   nInput.addEventListener('change', () => {
     const parsed = Number.parseInt(nInput.value, 10);
     if (!Number.isNaN(parsed)) setN(block, parsed);
   });
   nLabel.appendChild(nInput);
   fieldset.appendChild(nLabel);
-
   const kLabel = document.createElement('label');
   kLabel.textContent = 'Fylte blokker';
   const kInput = document.createElement('input');
   kInput.type = 'number';
   kInput.min = '0';
   kInput.step = '1';
-  kInput.value = String(cfg?.k ?? 0);
+  kInput.value = String((_cfg$k = cfg === null || cfg === void 0 ? void 0 : cfg.k) !== null && _cfg$k !== void 0 ? _cfg$k : 0);
   kInput.addEventListener('change', () => {
     const parsed = Number.parseInt(kInput.value, 10);
     if (!Number.isNaN(parsed)) setK(block, parsed);
   });
   kLabel.appendChild(kInput);
   fieldset.appendChild(kLabel);
-
   const showWholeRow = document.createElement('div');
   showWholeRow.className = 'checkbox-row';
   const showWholeInput = document.createElement('input');
@@ -830,7 +767,6 @@ function createBlock(row, col, cfg) {
   showWholeLabel.textContent = 'Vis hele';
   showWholeRow.append(showWholeInput, showWholeLabel);
   fieldset.appendChild(showWholeRow);
-
   const lockNRow = document.createElement('div');
   lockNRow.className = 'checkbox-row';
   const lockNInput = document.createElement('input');
@@ -845,7 +781,6 @@ function createBlock(row, col, cfg) {
   lockNLabel.textContent = 'Lås nevner';
   lockNRow.append(lockNInput, lockNLabel);
   fieldset.appendChild(lockNRow);
-
   const lockKRow = document.createElement('div');
   lockKRow.className = 'checkbox-row';
   const lockKInput = document.createElement('input');
@@ -860,7 +795,6 @@ function createBlock(row, col, cfg) {
   lockKLabel.textContent = 'Lås teller';
   lockKRow.append(lockKInput, lockKLabel);
   fieldset.appendChild(lockKRow);
-
   const hideNRow = document.createElement('div');
   hideNRow.className = 'checkbox-row';
   const hideNInput = document.createElement('input');
@@ -875,7 +809,6 @@ function createBlock(row, col, cfg) {
   hideNLabel.textContent = 'Skjul n-verdi';
   hideNRow.append(hideNInput, hideNLabel);
   fieldset.appendChild(hideNRow);
-
   const displayLabel = document.createElement('label');
   displayLabel.textContent = 'Vis som';
   const displaySelect = document.createElement('select');
@@ -891,7 +824,6 @@ function createBlock(row, col, cfg) {
   });
   displayLabel.appendChild(displaySelect);
   fieldset.appendChild(displayLabel);
-
   const customTextToggleRow = document.createElement('div');
   customTextToggleRow.className = 'checkbox-row';
   customTextToggleRow.style.display = 'none';
@@ -908,7 +840,6 @@ function createBlock(row, col, cfg) {
   customTextToggleRow.append(customTextToggle, customTextToggleLabel);
   fieldset.appendChild(customTextToggleRow);
   block.customTextToggleRow = customTextToggleRow;
-
   const customTextLabel = document.createElement('label');
   customTextLabel.textContent = 'Tekst i blokk';
   customTextLabel.style.display = 'none';
@@ -923,7 +854,6 @@ function createBlock(row, col, cfg) {
   fieldset.appendChild(customTextLabel);
   block.customTextLabel = customTextLabel;
   block.customTextInput = customTextInput;
-
   block.inputs = {
     total: totalInput,
     n: nInput,
@@ -936,20 +866,17 @@ function createBlock(row, col, cfg) {
     showCustomText: customTextToggle,
     customText: customTextInput
   };
-
   return block;
 }
-
 function updateBlockPanelLayout(block, rowTotal) {
-  if (!block?.panel) return;
+  if (!(block !== null && block !== void 0 && block.panel)) return;
   const cfg = block.cfg;
-  const totalValue = Number(cfg?.total);
+  const totalValue = Number(cfg === null || cfg === void 0 ? void 0 : cfg.total);
   const positiveTotal = Number.isFinite(totalValue) && totalValue > 0 ? totalValue : 0;
   const hasRowTotal = Number.isFinite(rowTotal) && rowTotal > 0;
-  const stepperVisible = !cfg?.lockDenominator;
-  const hasBlockBelow = Number.isFinite(CONFIG?.rows) && block.row < CONFIG.rows - 1;
+  const stepperVisible = !(cfg !== null && cfg !== void 0 && cfg.lockDenominator);
+  const hasBlockBelow = Number.isFinite(CONFIG === null || CONFIG === void 0 ? void 0 : CONFIG.rows) && block.row < CONFIG.rows - 1;
   const needsVerticalSpace = stepperVisible && hasBlockBelow;
-
   block.panel.style.flexBasis = '0px';
   block.panel.style.flexShrink = '1';
   if (hasRowTotal && positiveTotal > 0) {
@@ -959,31 +886,39 @@ function updateBlockPanelLayout(block, rowTotal) {
   }
   block.panel.style.marginBottom = needsVerticalSpace ? 'var(--tb-stepper-gap, 18px)' : '0px';
 }
-
 function drawBlock(block) {
-  const cfg = block?.cfg;
+  var _block$rectEmpty, _block$rectEmpty2, _block$rectEmpty3, _block$rectEmpty4, _block$rectFrame, _block$rectFrame2, _block$rectFrame3, _block$rectFrame4, _block$handle, _block$handleShadow, _block$handle2, _block$handleShadow2;
+  const cfg = block === null || block === void 0 ? void 0 : block.cfg;
   if (!block || !cfg) return;
-
   const metrics = getBlockMetrics(block);
   block.metrics = metrics;
-  const { width, height, left, right, top, bottom, braceY, bracketTick, labelOffsetY, innerWidth, innerHeight, centerX } = metrics;
-
+  const {
+    width,
+    height,
+    left,
+    right,
+    top,
+    bottom,
+    braceY,
+    bracketTick,
+    labelOffsetY,
+    innerWidth,
+    innerHeight,
+    centerX
+  } = metrics;
   if (block.svg) {
     block.svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
     block.svg.setAttribute('aria-label', `Tenkeblokk ${block.index + 1}`);
     block.svg.setAttribute('preserveAspectRatio', 'none');
   }
-
-  block.rectEmpty?.setAttribute('x', left);
-  block.rectEmpty?.setAttribute('width', innerWidth);
-  block.rectEmpty?.setAttribute('y', top);
-  block.rectEmpty?.setAttribute('height', innerHeight);
-
-  block.rectFrame?.setAttribute('x', left);
-  block.rectFrame?.setAttribute('width', innerWidth);
-  block.rectFrame?.setAttribute('y', top);
-  block.rectFrame?.setAttribute('height', innerHeight);
-
+  (_block$rectEmpty = block.rectEmpty) === null || _block$rectEmpty === void 0 || _block$rectEmpty.setAttribute('x', left);
+  (_block$rectEmpty2 = block.rectEmpty) === null || _block$rectEmpty2 === void 0 || _block$rectEmpty2.setAttribute('width', innerWidth);
+  (_block$rectEmpty3 = block.rectEmpty) === null || _block$rectEmpty3 === void 0 || _block$rectEmpty3.setAttribute('y', top);
+  (_block$rectEmpty4 = block.rectEmpty) === null || _block$rectEmpty4 === void 0 || _block$rectEmpty4.setAttribute('height', innerHeight);
+  (_block$rectFrame = block.rectFrame) === null || _block$rectFrame === void 0 || _block$rectFrame.setAttribute('x', left);
+  (_block$rectFrame2 = block.rectFrame) === null || _block$rectFrame2 === void 0 || _block$rectFrame2.setAttribute('width', innerWidth);
+  (_block$rectFrame3 = block.rectFrame) === null || _block$rectFrame3 === void 0 || _block$rectFrame3.setAttribute('y', top);
+  (_block$rectFrame4 = block.rectFrame) === null || _block$rectFrame4 === void 0 || _block$rectFrame4.setAttribute('height', innerHeight);
   drawBracketSquare(block.gBrace, left, right, braceY, bracketTick);
   if (block.totalText) {
     block.totalText.setAttribute('x', centerX);
@@ -993,18 +928,15 @@ function drawBlock(block) {
   if (block.legend) {
     block.legend.textContent = `Tenkeblokk ${block.index + 1}`;
   }
-
   const stepperVisible = !cfg.lockDenominator;
   if (block.stepper) {
     block.stepper.setAttribute('aria-label', `Antall blokker i tenkeblokk ${block.index + 1}`);
     block.stepper.style.display = stepperVisible ? '' : 'none';
   }
-
   if (block.nVal) {
     block.nVal.textContent = cfg.n;
     block.nVal.style.display = cfg.hideNValue ? 'none' : '';
   }
-
   const customTextAvailable = cfg.n === 1;
   if (block.customTextToggleRow) {
     block.customTextToggleRow.style.display = customTextAvailable ? '' : 'none';
@@ -1013,12 +945,21 @@ function drawBlock(block) {
   if (block.customTextLabel) {
     block.customTextLabel.style.display = customTextEnabled ? '' : 'none';
   }
-
   if (block.minusBtn) block.minusBtn.disabled = cfg.lockDenominator || cfg.n <= CONFIG.minN;
   if (block.plusBtn) block.plusBtn.disabled = cfg.lockDenominator || cfg.n >= CONFIG.maxN;
-
   if (block.inputs) {
-    const { total, n, k, showWhole, lockN, lockK, hideN, display, showCustomText, customText } = block.inputs;
+    const {
+      total,
+      n,
+      k,
+      showWhole,
+      lockN,
+      lockK,
+      hideN,
+      display,
+      showCustomText,
+      customText
+    } = block.inputs;
     if (total) total.value = cfg.total;
     if (n) {
       n.value = cfg.n;
@@ -1057,32 +998,44 @@ function drawBlock(block) {
       customText.disabled = !customTextEnabled;
     }
   }
-
   block.gFill.innerHTML = '';
   block.gSep.innerHTML = '';
   block.gVals.innerHTML = '';
-
   const cellW = cfg.n ? innerWidth / cfg.n : 0;
   if (cellW > 0) {
     const showCustomText = customTextEnabled;
     const customLabel = typeof cfg.customText === 'string' ? cfg.customText.trim() : '';
     for (let i = 0; i < cfg.k; i++) {
-      createSvgElement(block.gFill, 'rect', { x: left + i * cellW, y: top, width: cellW, height: innerHeight, class: 'tb-rect' });
+      createSvgElement(block.gFill, 'rect', {
+        x: left + i * cellW,
+        y: top,
+        width: cellW,
+        height: innerHeight,
+        class: 'tb-rect'
+      });
     }
     for (let i = 1; i < cfg.n; i++) {
       const x = left + i * cellW;
-      createSvgElement(block.gSep, 'line', { x1: x, y1: top, x2: x, y2: bottom, class: 'tb-sep' });
+      createSvgElement(block.gSep, 'line', {
+        x1: x,
+        y1: top,
+        x2: x,
+        y2: bottom,
+        class: 'tb-sep'
+      });
     }
-
     const displayMode = sanitizeDisplayMode(cfg.valueDisplay) || 'number';
     const per = cfg.n ? cfg.total / cfg.n : 0;
-    const percentValue = cfg.n ? (100 / cfg.n) : 0;
-
+    const percentValue = cfg.n ? 100 / cfg.n : 0;
     for (let i = 0; i < cfg.n; i++) {
       const cx = left + (i + 0.5) * cellW;
       const cy = top + innerHeight / 2;
       if (showCustomText) {
-        const text = createSvgElement(block.gVals, 'text', { x: cx, y: cy, class: 'tb-val' });
+        const text = createSvgElement(block.gVals, 'text', {
+          x: cx,
+          y: cy,
+          class: 'tb-val'
+        });
         text.textContent = customLabel;
         continue;
       }
@@ -1090,25 +1043,26 @@ function drawBlock(block) {
         renderFractionLabel(block.gVals, cx, cy, 1, cfg.n);
         continue;
       }
-      const text = createSvgElement(block.gVals, 'text', { x: cx, y: cy, class: 'tb-val' });
+      const text = createSvgElement(block.gVals, 'text', {
+        x: cx,
+        y: cy,
+        class: 'tb-val'
+      });
       const label = displayMode === 'percent' ? `${fmt(percentValue)} %` : fmt(per);
       text.textContent = label;
     }
   }
-
   const hx = cellW > 0 ? left + cfg.k * cellW : left;
   const hy = top + innerHeight / 2;
-  block.handle?.setAttribute('cx', hx);
-  block.handleShadow?.setAttribute('cx', hx);
-  block.handle?.setAttribute('cy', hy);
-  block.handleShadow?.setAttribute('cy', hy + 2);
+  (_block$handle = block.handle) === null || _block$handle === void 0 || _block$handle.setAttribute('cx', hx);
+  (_block$handleShadow = block.handleShadow) === null || _block$handleShadow === void 0 || _block$handleShadow.setAttribute('cx', hx);
+  (_block$handle2 = block.handle) === null || _block$handle2 === void 0 || _block$handle2.setAttribute('cy', hy);
+  (_block$handleShadow2 = block.handleShadow) === null || _block$handleShadow2 === void 0 || _block$handleShadow2.setAttribute('cy', hy + 2);
   if (block.gHandle) block.gHandle.style.display = cfg.lockNumerator ? 'none' : '';
   if (block.handle) block.handle.style.cursor = cfg.lockNumerator ? 'default' : 'pointer';
-
   const showWholeAllowed = !multipleBlocksActive;
   if (block.gBrace) block.gBrace.style.display = showWholeAllowed && cfg.showWhole ? '' : 'none';
 }
-
 function setN(block, next) {
   if (!block) return;
   const cfg = block.cfg;
@@ -1119,7 +1073,6 @@ function setN(block, next) {
   if (cfg.k > cfg.n) cfg.k = cfg.n;
   draw(true);
 }
-
 function setK(block, next) {
   if (!block) return;
   const cfg = block.cfg;
@@ -1129,7 +1082,6 @@ function setK(block, next) {
   cfg.k = clamped;
   draw(true);
 }
-
 function createCombinedWholeOverlay() {
   if (!board) return null;
   const ns = 'http://www.w3.org/2000/svg';
@@ -1140,27 +1092,35 @@ function createCombinedWholeOverlay() {
   svg.style.width = '0';
   svg.style.height = '0';
   board.appendChild(svg);
-  const group = createSvgElement(svg, 'g', { class: 'tb-combined-brace' });
-  const text = createSvgElement(group, 'text', { class: 'tb-total', 'text-anchor': 'middle' });
-  return { svg, group, text };
+  const group = createSvgElement(svg, 'g', {
+    class: 'tb-combined-brace'
+  });
+  const text = createSvgElement(group, 'text', {
+    class: 'tb-total',
+    'text-anchor': 'middle'
+  });
+  return {
+    svg,
+    group,
+    text
+  };
 }
-
 function getCombinedTotal() {
   let sum = 0;
   for (let r = 0; r < CONFIG.rows; r++) {
     for (let c = 0; c < CONFIG.cols; c++) {
-      const value = Number(CONFIG.blocks?.[r]?.[c]?.total);
+      var _CONFIG$blocks2;
+      const value = Number((_CONFIG$blocks2 = CONFIG.blocks) === null || _CONFIG$blocks2 === void 0 || (_CONFIG$blocks2 = _CONFIG$blocks2[r]) === null || _CONFIG$blocks2 === void 0 || (_CONFIG$blocks2 = _CONFIG$blocks2[c]) === null || _CONFIG$blocks2 === void 0 ? void 0 : _CONFIG$blocks2.total);
       if (!Number.isFinite(value)) return NaN;
       sum += value;
     }
   }
   return sum;
 }
-
 function getBlockClientMetrics(block) {
-  if (!block?.svg) return null;
+  if (!(block !== null && block !== void 0 && block.svg)) return null;
   const rect = block.svg.getBoundingClientRect();
-  if (!(rect?.width > 0) || !(rect?.height > 0)) return null;
+  if (!((rect === null || rect === void 0 ? void 0 : rect.width) > 0) || !((rect === null || rect === void 0 ? void 0 : rect.height) > 0)) return null;
   return {
     left: rect.left,
     right: rect.right,
@@ -1168,22 +1128,19 @@ function getBlockClientMetrics(block) {
     bottom: rect.bottom
   };
 }
-
 function drawCombinedWholeOverlay() {
   const overlay = combinedWholeOverlay;
-  if (!overlay?.svg || !board) return;
+  if (!(overlay !== null && overlay !== void 0 && overlay.svg) || !board) return;
   const multiple = CONFIG.activeBlocks > 1 && CONFIG.showCombinedWhole;
   if (!multiple) {
     overlay.svg.style.display = 'none';
     return;
   }
-
   const metrics = BLOCKS.map(getBlockClientMetrics).filter(Boolean);
   if (!metrics.length) {
     overlay.svg.style.display = 'none';
     return;
   }
-
   const left = Math.min(...metrics.map(m => m.left));
   const right = Math.max(...metrics.map(m => m.right));
   const top = Math.min(...metrics.map(m => m.top));
@@ -1194,24 +1151,19 @@ function drawCombinedWholeOverlay() {
     overlay.svg.style.display = 'none';
     return;
   }
-
   const boardRect = board.getBoundingClientRect();
   const figureWidth = width;
   const figureHeight = height;
   const vertical = shouldShowVerticalCombinedBrace(figureWidth, figureHeight);
-
   let overlayWidth = figureWidth;
   let overlayLeft = left - boardRect.left;
   let bracketX = figureWidth;
   let textX = figureWidth / 2;
-
   let braceStartY = figureHeight * BRACE_Y_RATIO;
   let braceTick = figureHeight * BRACKET_TICK_RATIO;
   const labelOffsetY = LABEL_OFFSET_RATIO * figureHeight;
-
   let textY = braceStartY - labelOffsetY;
   let dominantBaseline = null;
-
   if (vertical) {
     const topInner = figureHeight * TOP_RATIO;
     const bottomInner = figureHeight * BOTTOM_RATIO;
@@ -1225,12 +1177,10 @@ function drawCombinedWholeOverlay() {
     textX = bracketX + labelSpace / 2;
     textY = (topInner + bottomInner) / 2;
     dominantBaseline = 'middle';
-
     drawVerticalBracketSquare(overlay.group, braceStartY, braceEndY, bracketX, braceTick);
   } else {
     drawBracketSquare(overlay.group, 0, figureWidth, braceStartY, braceTick);
   }
-
   overlay.svg.style.display = '';
   overlay.svg.style.left = `${overlayLeft}px`;
   overlay.svg.style.top = `${top - boardRect.top}px`;
@@ -1240,38 +1190,35 @@ function drawCombinedWholeOverlay() {
   overlay.svg.setAttribute('height', figureHeight);
   overlay.svg.setAttribute('viewBox', `0 0 ${overlayWidth} ${figureHeight}`);
   overlay.svg.setAttribute('preserveAspectRatio', 'none');
-
   if (overlay.text) {
     overlay.text.setAttribute('x', textX);
     overlay.text.setAttribute('y', textY);
     overlay.text.setAttribute('text-anchor', 'middle');
-    if (dominantBaseline) overlay.text.setAttribute('dominant-baseline', dominantBaseline);
-    else overlay.text.removeAttribute('dominant-baseline');
+    if (dominantBaseline) overlay.text.setAttribute('dominant-baseline', dominantBaseline);else overlay.text.removeAttribute('dominant-baseline');
     const total = getCombinedTotal();
     overlay.text.textContent = Number.isFinite(total) ? fmt(total) : '';
   }
 }
-
 function shouldShowVerticalCombinedBrace(width, height) {
   if (!(width > 0) || !(height > 0)) return false;
   if (CONFIG.cols === 1 && CONFIG.rows > 1) return true;
   if (CONFIG.cols > 1) return false;
   return height >= width * 1.1;
 }
-
 function onDragStart(block, event) {
-  if (!block?.handle) return;
+  if (!(block !== null && block !== void 0 && block.handle)) return;
   const cfg = block.cfg;
-  if (cfg?.lockNumerator) return;
+  if (cfg !== null && cfg !== void 0 && cfg.lockNumerator) return;
   block.handle.setPointerCapture(event.pointerId);
   const move = ev => {
+    var _ref, _metrics$innerWidth, _metrics$left, _metrics$right;
     const currentCfg = block.cfg;
     if (!currentCfg) return;
     const p = clientToSvg(block.svg, ev.clientX, ev.clientY);
     const metrics = block.metrics || getBlockMetrics(block);
-    const innerWidth = metrics?.innerWidth ?? metrics?.width ?? VBW;
-    const left = metrics?.left ?? 0;
-    const right = metrics?.right ?? (left + innerWidth);
+    const innerWidth = (_ref = (_metrics$innerWidth = metrics === null || metrics === void 0 ? void 0 : metrics.innerWidth) !== null && _metrics$innerWidth !== void 0 ? _metrics$innerWidth : metrics === null || metrics === void 0 ? void 0 : metrics.width) !== null && _ref !== void 0 ? _ref : VBW;
+    const left = (_metrics$left = metrics === null || metrics === void 0 ? void 0 : metrics.left) !== null && _metrics$left !== void 0 ? _metrics$left : 0;
+    const right = (_metrics$right = metrics === null || metrics === void 0 ? void 0 : metrics.right) !== null && _metrics$right !== void 0 ? _metrics$right : left + innerWidth;
     const denom = currentCfg.n || 1;
     const cellW = innerWidth / denom;
     if (!(cellW > 0)) return;
@@ -1287,13 +1234,13 @@ function onDragStart(block, event) {
   window.addEventListener('pointermove', move);
   window.addEventListener('pointerup', up);
 }
-
 function getFrameInset(block) {
   let inset = DEFAULT_FRAME_INSET;
   if (!block) return inset;
   const rectFrame = block.rectFrame;
   if (rectFrame) {
-    const attr = rectFrame.getAttribute?.('stroke-width');
+    var _rectFrame$getAttribu;
+    const attr = (_rectFrame$getAttribu = rectFrame.getAttribute) === null || _rectFrame$getAttribu === void 0 ? void 0 : _rectFrame$getAttribu.call(rectFrame, 'stroke-width');
     if (attr) {
       const parsed = Number.parseFloat(attr);
       if (Number.isFinite(parsed) && parsed >= 0) {
@@ -1313,9 +1260,9 @@ function getFrameInset(block) {
   }
   return inset;
 }
-
 function syncLegacyConfig() {
-  const first = CONFIG.blocks?.[0]?.[0];
+  var _CONFIG$blocks3;
+  const first = (_CONFIG$blocks3 = CONFIG.blocks) === null || _CONFIG$blocks3 === void 0 || (_CONFIG$blocks3 = _CONFIG$blocks3[0]) === null || _CONFIG$blocks3 === void 0 ? void 0 : _CONFIG$blocks3[0];
   if (!first) return;
   CONFIG.total = first.total;
   CONFIG.n = first.n;
@@ -1338,25 +1285,20 @@ function createSvgElement(parent, name, attrs = {}) {
   parent.appendChild(el);
   return el;
 }
-
 function renderFractionLabel(parent, cx, cy, numerator, denominator) {
   if (!parent) return;
-
-  const numText = typeof numerator === 'number' ? numerator.toString() : `${numerator ?? ''}`;
-  const denText = typeof denominator === 'number' ? denominator.toString() : `${denominator ?? ''}`;
+  const numText = typeof numerator === 'number' ? numerator.toString() : `${numerator !== null && numerator !== void 0 ? numerator : ''}`;
+  const denText = typeof denominator === 'number' ? denominator.toString() : `${denominator !== null && denominator !== void 0 ? denominator : ''}`;
   if (!numText || !denText) return;
-
   const numeratorY = -20;
   const denominatorY = 28;
   const fallbackCenter = (numeratorY + denominatorY) / 2;
   const maxLen = Math.max(numText.length, denText.length);
   const charWidth = 20;
-  const halfWidth = Math.max(16, (maxLen * charWidth) / 2);
-
+  const halfWidth = Math.max(16, maxLen * charWidth / 2);
   const group = createSvgElement(parent, 'g', {
     class: 'tb-frac'
   });
-
   const numeratorEl = createSvgElement(group, 'text', {
     x: 0,
     y: numeratorY,
@@ -1364,7 +1306,6 @@ function renderFractionLabel(parent, cx, cy, numerator, denominator) {
     'text-anchor': 'middle'
   });
   numeratorEl.textContent = numText;
-
   const lineEl = createSvgElement(group, 'line', {
     x1: -halfWidth,
     x2: halfWidth,
@@ -1372,7 +1313,6 @@ function renderFractionLabel(parent, cx, cy, numerator, denominator) {
     y2: fallbackCenter,
     class: 'tb-frac-line'
   });
-
   const denominatorEl = createSvgElement(group, 'text', {
     x: 0,
     y: denominatorY,
@@ -1380,10 +1320,8 @@ function renderFractionLabel(parent, cx, cy, numerator, denominator) {
     'text-anchor': 'middle'
   });
   denominatorEl.textContent = denText;
-
   let appliedCenter = fallbackCenter;
   const hasBBox = typeof numeratorEl.getBBox === 'function' && typeof denominatorEl.getBBox === 'function';
-
   if (hasBBox) {
     try {
       const numeratorBBox = numeratorEl.getBBox();
@@ -1393,7 +1331,6 @@ function renderFractionLabel(parent, cx, cy, numerator, denominator) {
       const visualLineY = (numeratorBottom + denominatorTop) / 2;
       lineEl.setAttribute('y1', visualLineY);
       lineEl.setAttribute('y2', visualLineY);
-
       const fractionTop = Math.min(numeratorBBox.y, denominatorBBox.y);
       const fractionBottom = Math.max(numeratorBottom, denominatorBBox.y + denominatorBBox.height);
       appliedCenter = (fractionTop + fractionBottom) / 2;
@@ -1401,26 +1338,26 @@ function renderFractionLabel(parent, cx, cy, numerator, denominator) {
       // ignore measurement errors
     }
   }
-
   group.setAttribute('transform', `translate(${cx}, ${cy - appliedCenter})`);
 }
-
 function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
 }
-
 function fmt(value) {
   return (Math.round(value * 100) / 100).toString().replace('.', ',');
 }
-
 function clientToSvg(svgEl, clientX, clientY) {
+  var _svgEl$viewBox, _vb$width, _vb$height, _vb$x, _vb$y;
   const rect = svgEl.getBoundingClientRect();
-  const vb = svgEl.viewBox?.baseVal;
-  const width = vb?.width ?? VBW;
-  const height = vb?.height ?? VBH;
-  const minX = vb?.x ?? 0;
-  const minY = vb?.y ?? 0;
-  if (!rect.width || !rect.height) return { x: minX, y: minY };
+  const vb = (_svgEl$viewBox = svgEl.viewBox) === null || _svgEl$viewBox === void 0 ? void 0 : _svgEl$viewBox.baseVal;
+  const width = (_vb$width = vb === null || vb === void 0 ? void 0 : vb.width) !== null && _vb$width !== void 0 ? _vb$width : VBW;
+  const height = (_vb$height = vb === null || vb === void 0 ? void 0 : vb.height) !== null && _vb$height !== void 0 ? _vb$height : VBH;
+  const minX = (_vb$x = vb === null || vb === void 0 ? void 0 : vb.x) !== null && _vb$x !== void 0 ? _vb$x : 0;
+  const minY = (_vb$y = vb === null || vb === void 0 ? void 0 : vb.y) !== null && _vb$y !== void 0 ? _vb$y : 0;
+  if (!rect.width || !rect.height) return {
+    x: minX,
+    y: minY
+  };
   const sx = width / rect.width;
   const sy = height / rect.height;
   return {
@@ -1428,44 +1365,32 @@ function clientToSvg(svgEl, clientX, clientY) {
     y: minY + (clientY - rect.top) * sy
   };
 }
-
 function drawBracketSquare(group, x0, x1, y, tick) {
   const path = getOrCreateBracePath(group);
   if (!path) return;
-  const d = [
-    `M ${x0} ${y}`, `v ${tick}`,
-    `M ${x0} ${y}`, `H ${x1}`,
-    `M ${x1} ${y}`, `v ${tick}`
-  ].join(' ');
+  const d = [`M ${x0} ${y}`, `v ${tick}`, `M ${x0} ${y}`, `H ${x1}`, `M ${x1} ${y}`, `v ${tick}`].join(' ');
   path.setAttribute('d', d);
 }
-
 function drawVerticalBracketSquare(group, y0, y1, x, tick) {
   const path = getOrCreateBracePath(group);
   if (!path) return;
   const clampedTick = Math.max(0, Math.min(tick, x));
-  const d = [
-    `M ${x} ${y0}`, `h ${-clampedTick}`,
-    `M ${x} ${y0}`, `V ${y1}`,
-    `M ${x} ${y1}`, `h ${-clampedTick}`
-  ].join(' ');
+  const d = [`M ${x} ${y0}`, `h ${-clampedTick}`, `M ${x} ${y0}`, `V ${y1}`, `M ${x} ${y1}`, `h ${-clampedTick}`].join(' ');
   path.setAttribute('d', d);
 }
-
 function getOrCreateBracePath(group) {
+  var _group$ownerSVGElemen;
   if (!group) return null;
-  const ns = group.ownerSVGElement?.namespaceURI || 'http://www.w3.org/2000/svg';
+  const ns = ((_group$ownerSVGElemen = group.ownerSVGElement) === null || _group$ownerSVGElemen === void 0 ? void 0 : _group$ownerSVGElemen.namespaceURI) || 'http://www.w3.org/2000/svg';
   let path = group.querySelector('path.tb-brace');
   if (!path) {
     path = document.createElementNS(ns, 'path');
     path.setAttribute('class', 'tb-brace');
     const firstChild = group.firstChild;
-    if (firstChild) group.insertBefore(path, firstChild);
-    else group.appendChild(path);
+    if (firstChild) group.insertBefore(path, firstChild);else group.appendChild(path);
   }
   return path;
 }
-
 function svgToString(svgEl) {
   const clone = svgEl.cloneNode(true);
   const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
@@ -1476,10 +1401,11 @@ function svgToString(svgEl) {
   clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
   return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
 }
-
 function downloadSVG(svgEl, filename) {
   const data = svgToString(svgEl);
-  const blob = new Blob([data], { type: 'image/svg+xml;charset=utf-8' });
+  const blob = new Blob([data], {
+    type: 'image/svg+xml;charset=utf-8'
+  });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
@@ -1489,13 +1415,15 @@ function downloadSVG(svgEl, filename) {
   a.remove();
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
-
 function downloadPNG(svgEl, filename, scale = 2, bg = '#fff') {
-  const vb = svgEl.viewBox?.baseVal;
-  const w = vb?.width || svgEl.clientWidth || 420;
-  const h = vb?.height || svgEl.clientHeight || 420;
+  var _svgEl$viewBox2;
+  const vb = (_svgEl$viewBox2 = svgEl.viewBox) === null || _svgEl$viewBox2 === void 0 ? void 0 : _svgEl$viewBox2.baseVal;
+  const w = (vb === null || vb === void 0 ? void 0 : vb.width) || svgEl.clientWidth || 420;
+  const h = (vb === null || vb === void 0 ? void 0 : vb.height) || svgEl.clientHeight || 420;
   const data = svgToString(svgEl);
-  const blob = new Blob([data], { type: 'image/svg+xml;charset=utf-8' });
+  const blob = new Blob([data], {
+    type: 'image/svg+xml;charset=utf-8'
+  });
   const url = URL.createObjectURL(blob);
   const img = new Image();
   img.onload = () => {
@@ -1521,42 +1449,47 @@ function downloadPNG(svgEl, filename, scale = 2, bg = '#fff') {
   };
   img.src = url;
 }
-
 function getExportSvg() {
-  const firstSvg = BLOCKS[0]?.svg;
+  var _BLOCKS$, _rowInfo$find;
+  const firstSvg = (_BLOCKS$ = BLOCKS[0]) === null || _BLOCKS$ === void 0 ? void 0 : _BLOCKS$.svg;
   if (!firstSvg) return null;
   const ns = firstSvg.namespaceURI;
   const rows = CONFIG.rows;
-  const rowInfo = Array.from({ length: rows }, () => ({ blocks: [], width: 0, height: 0 }));
-
+  const rowInfo = Array.from({
+    length: rows
+  }, () => ({
+    blocks: [],
+    width: 0,
+    height: 0
+  }));
   for (const block of BLOCKS) {
     if (!block) continue;
     const metrics = block.metrics || getBlockMetrics(block);
     const row = rowInfo[block.row];
     if (!row) continue;
-    row.blocks.push({ block, metrics });
-    const widthValue = metrics?.width;
-    const heightValue = metrics?.height;
+    row.blocks.push({
+      block,
+      metrics
+    });
+    const widthValue = metrics === null || metrics === void 0 ? void 0 : metrics.width;
+    const heightValue = metrics === null || metrics === void 0 ? void 0 : metrics.height;
     const blockWidth = Number.isFinite(widthValue) && widthValue > 0 ? widthValue : VBW;
     const blockHeight = Number.isFinite(heightValue) && heightValue > 0 ? heightValue : DEFAULT_SVG_HEIGHT;
     row.width += blockWidth;
     if (row.height < blockHeight) row.height = blockHeight;
   }
-
   const exportWidth = rowInfo.reduce((max, row) => Math.max(max, row.width || 0), 0) || VBW;
   const exportHeight = rowInfo.reduce((sum, row, index) => {
     if (!row.blocks.length) return sum;
     const gap = index > 0 ? ROW_GAP : 0;
     return sum + row.height + gap;
   }, 0) || DEFAULT_SVG_HEIGHT;
-
   const exportSvg = document.createElementNS(ns, 'svg');
   exportSvg.setAttribute('viewBox', `0 0 ${exportWidth} ${exportHeight}`);
   exportSvg.setAttribute('width', exportWidth);
   exportSvg.setAttribute('height', exportHeight);
   exportSvg.setAttribute('xmlns', ns);
   exportSvg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
-
   let offsetY = 0;
   rowInfo.forEach((row, rowIndex) => {
     if (!row.blocks.length) return;
@@ -1564,28 +1497,30 @@ function getExportSvg() {
     const rowGroup = document.createElementNS(ns, 'g');
     rowGroup.setAttribute('transform', `translate(0,${offsetY})`);
     exportSvg.appendChild(rowGroup);
-
     let offsetX = 0;
-    row.blocks.forEach(({ block, metrics }) => {
-      if (!block?.svg) return;
+    row.blocks.forEach(({
+      block,
+      metrics
+    }) => {
+      var _metrics$width, _block$svg$viewBox;
+      if (!(block !== null && block !== void 0 && block.svg)) return;
       const g = document.createElementNS(ns, 'g');
       g.setAttribute('transform', `translate(${offsetX},0)`);
       g.innerHTML = block.svg.innerHTML;
       rowGroup.appendChild(g);
-      const widthValue = metrics?.width ?? block.svg.viewBox?.baseVal?.width;
+      const widthValue = (_metrics$width = metrics === null || metrics === void 0 ? void 0 : metrics.width) !== null && _metrics$width !== void 0 ? _metrics$width : (_block$svg$viewBox = block.svg.viewBox) === null || _block$svg$viewBox === void 0 || (_block$svg$viewBox = _block$svg$viewBox.baseVal) === null || _block$svg$viewBox === void 0 ? void 0 : _block$svg$viewBox.width;
       const blockWidth = Number.isFinite(widthValue) && widthValue > 0 ? widthValue : VBW;
       offsetX += blockWidth;
     });
-
     offsetY += row.height;
   });
-
-  const referenceHeight = rowInfo.find(row => row.blocks.length)?.height || DEFAULT_SVG_HEIGHT;
-
+  const referenceHeight = ((_rowInfo$find = rowInfo.find(row => row.blocks.length)) === null || _rowInfo$find === void 0 ? void 0 : _rowInfo$find.height) || DEFAULT_SVG_HEIGHT;
   if (CONFIG.showCombinedWhole && CONFIG.activeBlocks > 1) {
     const startX = 0;
     const endX = exportWidth;
-    const braceGroup = createSvgElement(exportSvg, 'g', { class: 'tb-combined-brace' });
+    const braceGroup = createSvgElement(exportSvg, 'g', {
+      class: 'tb-combined-brace'
+    });
     const braceY = BRACE_Y_RATIO * referenceHeight;
     const tick = BRACKET_TICK_RATIO * referenceHeight;
     drawBracketSquare(braceGroup, startX, endX, braceY, tick);
@@ -1598,6 +1533,5 @@ function getExportSvg() {
     const totalValue = getCombinedTotal();
     totalText.textContent = Number.isFinite(totalValue) ? fmt(totalValue) : '';
   }
-
   return exportSvg;
 }

--- a/trefigurer.js
+++ b/trefigurer.js
@@ -1,9 +1,8 @@
-(function(){
+(function () {
   if (typeof THREE === 'undefined') {
     console.error('THREE.js er ikke lastet inn.');
     return;
   }
-
   const ORBIT_CONTROLS_MODULE_URL = 'https://unpkg.com/three@0.158.0/examples/jsm/controls/OrbitControls.js?module';
   const ORBIT_CONTROLS_SCRIPT_SRC = (() => {
     if (typeof document === 'undefined') {
@@ -20,7 +19,6 @@
     return 'vendor/three/examples/js/controls/OrbitControls.js';
   })();
   let orbitControlsPromise = null;
-
   function ensureOrbitControlsScript() {
     if (typeof document === 'undefined') {
       return Promise.resolve('failed');
@@ -39,11 +37,14 @@
           existing.dataset.loaded = 'false';
           resolve('failed');
         };
-        existing.addEventListener('load', handleLoad, { once: true });
-        existing.addEventListener('error', handleError, { once: true });
+        existing.addEventListener('load', handleLoad, {
+          once: true
+        });
+        existing.addEventListener('error', handleError, {
+          once: true
+        });
       });
     }
-
     return new Promise(resolve => {
       const script = document.createElement('script');
       script.src = ORBIT_CONTROLS_SCRIPT_SRC;
@@ -52,38 +53,35 @@
       script.addEventListener('load', () => {
         script.dataset.loaded = 'true';
         resolve('loaded');
-      }, { once: true });
+      }, {
+        once: true
+      });
       script.addEventListener('error', () => {
         script.dataset.loaded = 'false';
         resolve('failed');
-      }, { once: true });
+      }, {
+        once: true
+      });
       document.head.appendChild(script);
     });
   }
-
   function getGlobalOrbitControls() {
-    return (typeof THREE !== 'undefined' && typeof THREE.OrbitControls === 'function')
-      ? THREE.OrbitControls
-      : null;
+    return typeof THREE !== 'undefined' && typeof THREE.OrbitControls === 'function' ? THREE.OrbitControls : null;
   }
-
   function loadOrbitControls() {
     if (orbitControlsPromise) {
       return orbitControlsPromise;
     }
-
     orbitControlsPromise = (async () => {
       const globalControls = getGlobalOrbitControls();
       if (globalControls) {
         return globalControls;
       }
-
       const scriptStatus = await ensureOrbitControlsScript();
       const scriptedControls = getGlobalOrbitControls();
       if (scriptedControls) {
         return scriptedControls;
       }
-
       if (scriptStatus === 'failed') {
         try {
           const module = await import(ORBIT_CONTROLS_MODULE_URL);
@@ -96,39 +94,34 @@
           console.warn('Klarte ikke laste OrbitControls-modulen.', error);
         }
       }
-
       return getGlobalOrbitControls();
     })();
-
     return orbitControlsPromise;
   }
-
   const controlsPromise = loadOrbitControls();
-
   function normalizeVectorArray(value) {
     if (!Array.isArray(value) || value.length !== 3) return null;
     const normalized = value.map(num => Number(num));
     return normalized.every(Number.isFinite) ? normalized : null;
   }
-
   class ShapeRenderer {
     constructor(container, options = {}) {
       this.container = container;
       this.scene = new THREE.Scene();
       this.scene.background = new THREE.Color(0xf6f7fb);
-
       this.camera = new THREE.PerspectiveCamera(35, 1, 0.1, 100);
       this.camera.position.set(4.2, 3.6, 5.6);
-
-      this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, preserveDrawingBuffer: true });
+      this.renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        alpha: true,
+        preserveDrawingBuffer: true
+      });
       this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
       this.renderer.shadowMap.enabled = false;
       this.container.appendChild(this.renderer.domElement);
-
       if (this.renderer.domElement && this.renderer.domElement.style) {
         this.renderer.domElement.style.touchAction = 'none';
       }
-
       this.controls = null;
       this.materialColorOverride = null;
       this.materialOpacity = 1;
@@ -138,18 +131,14 @@
           this._attachControls(ControlsClass);
         }
       });
-
       const ambient = new THREE.AmbientLight(0xffffff, 0.55);
       this.scene.add(ambient);
-
       const keyLight = new THREE.DirectionalLight(0xffffff, 0.85);
       keyLight.position.set(5, 8, 6);
       this.scene.add(keyLight);
-
       const fillLight = new THREE.DirectionalLight(0xffffff, 0.35);
       fillLight.position.set(-4, 4, -2);
       this.scene.add(fillLight);
-
       const groundMaterial = new THREE.MeshStandardMaterial({
         color: 0xe5e7eb,
         roughness: 1,
@@ -161,29 +150,23 @@
       ground.position.y = -0.02;
       this.scene.add(ground);
       this.ground = ground;
-
       this.shapeGroup = new THREE.Group();
       this.scene.add(this.shapeGroup);
-
       this.currentFrame = null;
       this.rotationLocked = false;
       this.isFloating = false;
       this.fitMargin = 1.2;
-
       this._animate = this._animate.bind(this);
       this._handleResize = this._handleResize.bind(this);
-
       if (typeof ResizeObserver === 'function') {
         this.resizeObserver = new ResizeObserver(() => this._handleResize());
         this.resizeObserver.observe(this.container);
       } else {
         window.addEventListener('resize', this._handleResize);
       }
-
       this._handleResize();
       this.renderer.setAnimationLoop(this._animate);
     }
-
     _attachControls(ControlsClass) {
       if (!ControlsClass || this.controls) return;
       const controls = new ControlsClass(this.camera, this.renderer.domElement);
@@ -202,7 +185,9 @@
       } else {
         controls.target.set(0, 1.1, 0);
       }
-      controls.addEventListener('start', () => { this.userIsInteracting = true; });
+      controls.addEventListener('start', () => {
+        this.userIsInteracting = true;
+      });
       controls.addEventListener('end', () => {
         this.userIsInteracting = false;
         this._syncStateFromControls();
@@ -223,23 +208,19 @@
       }
       this._emitViewChange();
     }
-
     _handleResize() {
       const width = this.container.clientWidth;
       if (!width) return;
-
       const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : null;
       const maxHeight = viewportHeight ? viewportHeight * 0.7 : Infinity;
       const preferred = width * 0.72;
       const height = Math.max(280, Math.min(Math.round(preferred), 560, maxHeight));
-
       this.container.style.height = `${height}px`;
       this.renderer.setSize(width, height, false);
       this.camera.aspect = width / Math.max(height, 1);
       this.camera.updateProjectionMatrix();
       this._ensureFrameFits();
     }
-
     _animate() {
       if (!this.rotationLocked && !this.userIsInteracting && this.shapeGroup.children.length) {
         this.shapeGroup.rotation.y += 0.006;
@@ -247,7 +228,6 @@
       if (this.controls) this.controls.update();
       this.renderer.render(this.scene, this.camera);
     }
-
     _computeFitDistance(size) {
       if (!size) return 0;
       const halfFov = THREE.MathUtils.degToRad((this.camera.fov || 35) / 2);
@@ -261,7 +241,6 @@
       const distanceForWidth = maxHorizontal / Math.tan(safeHalfHorizontal);
       return Math.max(distanceForHeight, distanceForWidth);
     }
-
     _updateControlsDistances(baseDistance, currentDistance = baseDistance) {
       if (!this.controls || !(baseDistance > 0)) return;
       const minDistance = Math.max(0.6, baseDistance * 0.45);
@@ -269,7 +248,6 @@
       this.controls.minDistance = minDistance;
       this.controls.maxDistance = maxDistance;
     }
-
     _syncStateFromControls() {
       if (!this.controls || !this.currentFrame) return;
       if (this.currentFrame.center) {
@@ -280,7 +258,6 @@
       this._updateControlsDistances(baseDistance, this.currentFrame.distance);
       this._emitViewChange();
     }
-
     syncViewState() {
       if (this.controls && this.currentFrame) {
         this._syncStateFromControls();
@@ -288,7 +265,6 @@
       }
       this._emitViewChange();
     }
-
     frameCurrentShape() {
       if (!this.currentShape) return;
       this.currentShape.updateMatrixWorld(true);
@@ -299,9 +275,7 @@
       if (!effectiveBox || effectiveBox.isEmpty()) return;
       const size = new THREE.Vector3();
       effectiveBox.getSize(size);
-      const center = geometryBox && !geometryBox.isEmpty()
-        ? geometryBox.getCenter(new THREE.Vector3())
-        : effectiveBox.getCenter(new THREE.Vector3());
+      const center = geometryBox && !geometryBox.isEmpty() ? geometryBox.getCenter(new THREE.Vector3()) : effectiveBox.getCenter(new THREE.Vector3());
       const direction = this.camera.position.clone().sub(this.controls ? this.controls.target : center);
       if (!direction.lengthSq()) {
         direction.set(0, 0, 1);
@@ -326,7 +300,6 @@
       this.camera.updateProjectionMatrix();
       this._emitViewChange();
     }
-
     _ensureFrameFits() {
       if (!this.currentFrame) return;
       const center = this.currentFrame.center;
@@ -351,7 +324,6 @@
       this._updateControlsDistances(this.currentFrame.baseDistance, this.currentFrame.distance);
       this._emitViewChange();
     }
-
     _computeGeometryBoundingBox(object) {
       if (!object) return null;
       object.updateMatrixWorld(true);
@@ -376,7 +348,6 @@
       });
       return hasBox ? box : null;
     }
-
     _applyFloatingOffset() {
       if (!this.currentShape) return;
       this.currentShape.position.set(0, 0, 0);
@@ -392,7 +363,6 @@
       }
       this.shapeGroup.updateMatrixWorld(true);
     }
-
     setFloating(isFloating) {
       const shouldFloat = Boolean(isFloating);
       const changed = this.isFloating !== shouldFloat;
@@ -406,7 +376,6 @@
       this._applyFloatingOffset();
       this.frameCurrentShape();
     }
-
     setRotationLocked(isLocked) {
       this.rotationLocked = Boolean(isLocked);
       if (this.rotationLocked) {
@@ -417,7 +386,6 @@
         this.controls.update();
       }
     }
-
     disposeCurrentShape() {
       if (!this.currentShape) return;
       this.shapeGroup.remove(this.currentShape);
@@ -441,12 +409,11 @@
       this.shapeGroup.rotation.set(0, 0, 0);
       this.currentFrame = null;
     }
-
     _emitViewChange() {
       if (typeof this.onViewChange !== 'function') return;
       if (!this.camera) return;
       const position = this.camera.position;
-      const targetVec = this.controls ? this.controls.target : (this.currentFrame && this.currentFrame.center);
+      const targetVec = this.controls ? this.controls.target : this.currentFrame && this.currentFrame.center;
       if (!position || !targetVec) return;
       const positionArray = [position.x, position.y, position.z];
       const targetArray = [targetVec.x, targetVec.y, targetVec.z];
@@ -455,21 +422,16 @@
         position: positionArray,
         target: targetArray
       };
-      const currentDistance = this.currentFrame && typeof this.currentFrame.distance === 'number'
-        ? this.currentFrame.distance
-        : position.distanceTo(targetVec);
+      const currentDistance = this.currentFrame && typeof this.currentFrame.distance === 'number' ? this.currentFrame.distance : position.distanceTo(targetVec);
       if (Number.isFinite(currentDistance)) {
         viewData.distance = currentDistance;
       }
-      const baseDistance = this.currentFrame && typeof this.currentFrame.baseDistance === 'number'
-        ? this.currentFrame.baseDistance
-        : undefined;
+      const baseDistance = this.currentFrame && typeof this.currentFrame.baseDistance === 'number' ? this.currentFrame.baseDistance : undefined;
       if (Number.isFinite(baseDistance)) {
         viewData.baseDistance = baseDistance;
       }
       this.onViewChange(viewData);
     }
-
     applyViewState(view) {
       if (!view || typeof view !== 'object') return;
       const positionArray = normalizeVectorArray(view.position);
@@ -494,9 +456,10 @@
       } else if (this.currentFrame && this.currentFrame.center) {
         targetVector = this.currentFrame.center.clone();
       }
-
       if (!this.currentFrame) {
-        this.currentFrame = { center: targetVector ? targetVector.clone() : null };
+        this.currentFrame = {
+          center: targetVector ? targetVector.clone() : null
+        };
       }
       const providedDistance = Number.isFinite(view.distance) ? Number(view.distance) : null;
       if (providedDistance != null) {
@@ -510,11 +473,7 @@
       } else if (this.currentFrame.distance != null && !Number.isFinite(this.currentFrame.baseDistance)) {
         this.currentFrame.baseDistance = this.currentFrame.distance;
       }
-      const base = this.currentFrame && Number.isFinite(this.currentFrame.baseDistance)
-        ? this.currentFrame.baseDistance
-        : this.currentFrame && Number.isFinite(this.currentFrame.distance)
-          ? this.currentFrame.distance
-          : undefined;
+      const base = this.currentFrame && Number.isFinite(this.currentFrame.baseDistance) ? this.currentFrame.baseDistance : this.currentFrame && Number.isFinite(this.currentFrame.distance) ? this.currentFrame.distance : undefined;
       this._updateControlsDistances(base, this.currentFrame ? this.currentFrame.distance : undefined);
       if (this.controls) {
         this.controls.update();
@@ -523,12 +482,10 @@
       }
       this._emitViewChange();
     }
-
     setViewChangeCallback(callback) {
       this.onViewChange = typeof callback === 'function' ? callback : null;
       this._emitViewChange();
     }
-
     _applyMaterialAppearance() {
       if (!this.currentShape) return;
       const override = this.materialColorOverride;
@@ -540,7 +497,7 @@
         materials.forEach(material => {
           if (!material || !material.userData || !material.userData.isShapeMaterial) return;
           const baseColor = material.userData.baseColor;
-          const target = override ?? baseColor;
+          const target = override !== null && override !== void 0 ? override : baseColor;
           if (typeof target === 'number' && material.color) {
             material.color.setHex(target);
           }
@@ -551,7 +508,6 @@
         });
       });
     }
-
     setMaterialColorOverride(color) {
       if (color == null) {
         this.materialColorOverride = null;
@@ -562,7 +518,6 @@
       }
       this._applyMaterialAppearance();
     }
-
     setMaterialOpacity(opacity) {
       if (!(opacity > 0)) {
         this.materialOpacity = 0.05;
@@ -571,14 +526,12 @@
       }
       this._applyMaterialAppearance();
     }
-
     getBackgroundColorHex() {
       if (this.scene && this.scene.background && typeof this.scene.background.getHexString === 'function') {
         return `#${this.scene.background.getHexString()}`;
       }
       return '#ffffff';
     }
-
     captureSnapshot() {
       if (!this.renderer || !this.renderer.domElement) return null;
       const sourceCanvas = this.renderer.domElement;
@@ -597,9 +550,13 @@
       context.fillRect(0, 0, width, height);
       context.restore();
       context.drawImage(sourceCanvas, 0, 0, width, height);
-      return { canvas: exportCanvas, width, height, background };
+      return {
+        canvas: exportCanvas,
+        width,
+        height,
+        background
+      };
     }
-
     createMaterial(color) {
       const override = this.materialColorOverride;
       const opacity = THREE.MathUtils.clamp(this.materialOpacity, 0.05, 1);
@@ -617,14 +574,11 @@
       material.userData.isShapeMaterial = true;
       return material;
     }
-
     createEdges(geometry, color = 0x1f2937) {
-      return new THREE.LineSegments(
-        new THREE.EdgesGeometry(geometry),
-        new THREE.LineBasicMaterial({ color })
-      );
+      return new THREE.LineSegments(new THREE.EdgesGeometry(geometry), new THREE.LineBasicMaterial({
+        color
+      }));
     }
-
     createLabelSprite(text) {
       if (typeof text !== 'string') return null;
       const trimmed = text.trim();
@@ -668,14 +622,11 @@
       context.stroke();
       context.fillStyle = '#111827';
       context.fillText(trimmed, width / 2, height / 2 + 2);
-
       const texture = new THREE.CanvasTexture(canvas);
-      if ('colorSpace' in texture && THREE.SRGBColorSpace) texture.colorSpace = THREE.SRGBColorSpace;
-      else if ('encoding' in texture && THREE.sRGBEncoding) texture.encoding = THREE.sRGBEncoding;
+      if ('colorSpace' in texture && THREE.SRGBColorSpace) texture.colorSpace = THREE.SRGBColorSpace;else if ('encoding' in texture && THREE.sRGBEncoding) texture.encoding = THREE.sRGBEncoding;
       texture.minFilter = THREE.LinearFilter;
       texture.magFilter = THREE.LinearFilter;
       texture.generateMipmaps = false;
-
       const material = new THREE.SpriteMaterial({
         map: texture,
         transparent: true,
@@ -689,15 +640,17 @@
       sprite.userData.isMeasurement = true;
       return sprite;
     }
-
     addMeasurementLine(targetGroup, start, end, options = {}) {
+      var _options$thickness, _options$color;
       if (!targetGroup || !start || !end) return;
       const direction = end.clone().sub(start);
       const length = direction.length();
       if (!(length > 1e-4)) return;
-      const radius = options.thickness ?? 0.05;
+      const radius = (_options$thickness = options.thickness) !== null && _options$thickness !== void 0 ? _options$thickness : 0.05;
       const geometry = new THREE.CylinderGeometry(radius, radius, length, 24, 1, false);
-      const material = new THREE.MeshBasicMaterial({ color: options.color ?? 0x111827 });
+      const material = new THREE.MeshBasicMaterial({
+        color: (_options$color = options.color) !== null && _options$color !== void 0 ? _options$color : 0x111827
+      });
       material.toneMapped = false;
       const rod = new THREE.Mesh(geometry, material);
       rod.userData.isMeasurement = true;
@@ -706,7 +659,6 @@
       const quaternion = new THREE.Quaternion().setFromUnitVectors(up, direction.normalize());
       rod.setRotationFromQuaternion(quaternion);
       targetGroup.add(rod);
-
       const labelText = typeof options.label === 'string' ? options.label.trim() : '';
       if (labelText.length) {
         const sprite = this.createLabelSprite(labelText);
@@ -724,11 +676,10 @@
         }
       }
     }
-
     addRadiusMeasurement(targetGroup, dims, spec, type) {
       const radiusValue = typeof dims.radius === 'number' && Number.isFinite(dims.radius) ? dims.radius : null;
       if (!(radiusValue > 0)) return;
-      const label = typeof spec?.label === 'string' ? spec.label : '';
+      const label = typeof (spec === null || spec === void 0 ? void 0 : spec.label) === 'string' ? spec.label : '';
       const hasLabel = label.trim().length > 0;
       let start;
       let end;
@@ -751,15 +702,17 @@
           labelOffset = new THREE.Vector3(0, 0.22, 0);
         }
       }
-      const options = { color: 0xef4444, label };
+      const options = {
+        color: 0xef4444,
+        label
+      };
       if (labelOffset) options.labelOffset = labelOffset;
       this.addMeasurementLine(targetGroup, start, end, options);
     }
-
     addHeightMeasurement(targetGroup, dims, spec) {
       const heightValue = typeof dims.height === 'number' && Number.isFinite(dims.height) ? dims.height : null;
       if (!(heightValue > 0)) return;
-      const label = typeof spec?.label === 'string' ? spec.label : '';
+      const label = typeof (spec === null || spec === void 0 ? void 0 : spec.label) === 'string' ? spec.label : '';
       const radiusValue = typeof dims.radius === 'number' && Number.isFinite(dims.radius) ? dims.radius : null;
       const halfWidth = typeof dims.width === 'number' && Number.isFinite(dims.width) ? dims.width / 2 : null;
       const halfDepth = typeof dims.depth === 'number' && Number.isFinite(dims.depth) ? dims.depth / 2 : null;
@@ -787,11 +740,13 @@
         away.y = 0.18;
         labelPosition = midpoint.add(away);
       }
-      const options = { color: 0xf97316, label };
+      const options = {
+        color: 0xf97316,
+        label
+      };
       if (labelPosition) options.labelPosition = labelPosition;
       this.addMeasurementLine(targetGroup, start, end, options);
     }
-
     applyMeasurements(group, spec, dims, type) {
       if (!group || !spec || typeof spec !== 'object') return;
       const dimensionSpec = spec.dimensions;
@@ -809,19 +764,20 @@
         group.add(measurementGroup);
       }
     }
-
     createShape(spec) {
       const resolvedType = spec && typeof spec === 'object' && spec.type ? spec.type : spec;
       const type = typeof resolvedType === 'string' ? resolvedType : 'prism';
       const group = new THREE.Group();
-      const dims = { radius: null, height: null, width: null, depth: null };
+      const dims = {
+        radius: null,
+        height: null,
+        width: null,
+        depth: null
+      };
       let geometry;
       let rotationY = 0;
       let materialColor = 0x3b82f6;
-      const dimensionSpec = spec && typeof spec === 'object' && spec.dimensions && typeof spec.dimensions === 'object'
-        ? spec.dimensions
-        : null;
-
+      const dimensionSpec = spec && typeof spec === 'object' && spec.dimensions && typeof spec.dimensions === 'object' ? spec.dimensions : null;
       const extractDimensionValue = key => {
         if (!dimensionSpec || typeof key !== 'string') return null;
         const entry = dimensionSpec[key];
@@ -841,102 +797,102 @@
         }
         return null;
       };
-
       const resolvePositive = (value, fallback) => {
         if (Number.isFinite(value) && value > 0) return value;
         return fallback;
       };
-
       switch (type) {
-        case 'sphere': {
-          const radius = resolvePositive(extractDimensionValue('radius'), 1.35);
-          geometry = new THREE.SphereGeometry(radius, 40, 32);
-          geometry.translate(0, radius, 0);
-          materialColor = 0x6366f1;
-          dims.radius = radius;
-          dims.height = radius * 2;
-          break;
-        }
-        case 'pyramid': {
-          const height = resolvePositive(extractDimensionValue('height'), 2.8);
-          const radius = resolvePositive(extractDimensionValue('radius'), 1.7);
-          geometry = new THREE.ConeGeometry(radius, height, 4, 1);
-          geometry.translate(0, height / 2, 0);
-          rotationY = Math.PI / 4;
-          materialColor = 0xf59e0b;
-          dims.radius = radius;
-          dims.height = height;
-          const baseWidth = Math.sqrt(2) * radius;
-          dims.width = baseWidth;
-          dims.depth = baseWidth;
-          break;
-        }
-        case 'triangular-cylinder': {
-          const height = resolvePositive(extractDimensionValue('height'), 3);
-          const radius = resolvePositive(extractDimensionValue('radius'), 1.6);
-          geometry = new THREE.CylinderGeometry(radius, radius, height, 3, 1, false);
-          geometry.translate(0, height / 2, 0);
-          rotationY = Math.PI / 6;
-          materialColor = 0x0ea5e9;
-          dims.radius = radius;
-          dims.height = height;
-          dims.width = radius * 2;
-          dims.depth = radius * 2;
-          break;
-        }
-        case 'square-cylinder': {
-          const height = resolvePositive(extractDimensionValue('height'), 3.2);
-          const radius = resolvePositive(extractDimensionValue('radius'), 1.55);
-          geometry = new THREE.CylinderGeometry(radius, radius, height, 4, 1, false);
-          geometry.translate(0, height / 2, 0);
-          rotationY = Math.PI / 4;
-          materialColor = 0x10b981;
-          dims.radius = radius;
-          dims.height = height;
-          dims.width = radius * 2;
-          dims.depth = radius * 2;
-          break;
-        }
-        case 'cylinder': {
-          const height = resolvePositive(extractDimensionValue('height'), 3.2);
-          const radius = resolvePositive(extractDimensionValue('radius'), 1.6);
-          geometry = new THREE.CylinderGeometry(radius, radius, height, 32, 1, false);
-          geometry.translate(0, height / 2, 0);
-          materialColor = 0x0ea5e9;
-          dims.radius = radius;
-          dims.height = height;
-          dims.width = radius * 2;
-          dims.depth = radius * 2;
-          break;
-        }
+        case 'sphere':
+          {
+            const radius = resolvePositive(extractDimensionValue('radius'), 1.35);
+            geometry = new THREE.SphereGeometry(radius, 40, 32);
+            geometry.translate(0, radius, 0);
+            materialColor = 0x6366f1;
+            dims.radius = radius;
+            dims.height = radius * 2;
+            break;
+          }
+        case 'pyramid':
+          {
+            const height = resolvePositive(extractDimensionValue('height'), 2.8);
+            const radius = resolvePositive(extractDimensionValue('radius'), 1.7);
+            geometry = new THREE.ConeGeometry(radius, height, 4, 1);
+            geometry.translate(0, height / 2, 0);
+            rotationY = Math.PI / 4;
+            materialColor = 0xf59e0b;
+            dims.radius = radius;
+            dims.height = height;
+            const baseWidth = Math.sqrt(2) * radius;
+            dims.width = baseWidth;
+            dims.depth = baseWidth;
+            break;
+          }
+        case 'triangular-cylinder':
+          {
+            const height = resolvePositive(extractDimensionValue('height'), 3);
+            const radius = resolvePositive(extractDimensionValue('radius'), 1.6);
+            geometry = new THREE.CylinderGeometry(radius, radius, height, 3, 1, false);
+            geometry.translate(0, height / 2, 0);
+            rotationY = Math.PI / 6;
+            materialColor = 0x0ea5e9;
+            dims.radius = radius;
+            dims.height = height;
+            dims.width = radius * 2;
+            dims.depth = radius * 2;
+            break;
+          }
+        case 'square-cylinder':
+          {
+            const height = resolvePositive(extractDimensionValue('height'), 3.2);
+            const radius = resolvePositive(extractDimensionValue('radius'), 1.55);
+            geometry = new THREE.CylinderGeometry(radius, radius, height, 4, 1, false);
+            geometry.translate(0, height / 2, 0);
+            rotationY = Math.PI / 4;
+            materialColor = 0x10b981;
+            dims.radius = radius;
+            dims.height = height;
+            dims.width = radius * 2;
+            dims.depth = radius * 2;
+            break;
+          }
+        case 'cylinder':
+          {
+            const height = resolvePositive(extractDimensionValue('height'), 3.2);
+            const radius = resolvePositive(extractDimensionValue('radius'), 1.6);
+            geometry = new THREE.CylinderGeometry(radius, radius, height, 32, 1, false);
+            geometry.translate(0, height / 2, 0);
+            materialColor = 0x0ea5e9;
+            dims.radius = radius;
+            dims.height = height;
+            dims.width = radius * 2;
+            dims.depth = radius * 2;
+            break;
+          }
         case 'prism':
-        default: {
-          const width = 2.6;
-          const height = resolvePositive(extractDimensionValue('height'), 2.2);
-          const depth = 1.8;
-          geometry = new THREE.BoxGeometry(width, height, depth);
-          geometry.translate(0, height / 2, 0);
-          materialColor = 0x3b82f6;
-          dims.height = height;
-          dims.width = width;
-          dims.depth = depth;
-          break;
-        }
+        default:
+          {
+            const width = 2.6;
+            const height = resolvePositive(extractDimensionValue('height'), 2.2);
+            const depth = 1.8;
+            geometry = new THREE.BoxGeometry(width, height, depth);
+            geometry.translate(0, height / 2, 0);
+            materialColor = 0x3b82f6;
+            dims.height = height;
+            dims.width = width;
+            dims.depth = depth;
+            break;
+          }
       }
-
       const mesh = new THREE.Mesh(geometry, this.createMaterial(materialColor));
       group.add(mesh);
       if (type !== 'sphere') {
         const edges = this.createEdges(geometry);
         group.add(edges);
       }
-
       this.applyMeasurements(group, spec && typeof spec === 'object' ? spec : null, dims, type);
-
       group.rotation.y = rotationY;
       return group;
     }
-
     setShape(spec) {
       this.disposeCurrentShape();
       if (!spec) return;
@@ -946,19 +902,14 @@
       this._applyMaterialAppearance();
       this.frameCurrentShape();
     }
-
     clear() {
       this.disposeCurrentShape();
     }
   }
-
   const grid = document.getElementById('figureGrid');
-  const figureWrappers = Array.from(
-    document.querySelectorAll('#figureGrid > .figure[data-figure-index]')
-  );
+  const figureWrappers = Array.from(document.querySelectorAll('#figureGrid > .figure[data-figure-index]'));
   const rendererCount = figureWrappers.length;
   let activeViewIndex = 0;
-
   function ensureViewStateCapacity() {
     if (!window.STATE || typeof window.STATE !== 'object') {
       window.STATE = {};
@@ -981,7 +932,6 @@
     activeViewIndex = storedIndex;
     window.STATE.lastViewIndex = storedIndex;
   }
-
   function storeViewState(index, view) {
     ensureViewStateCapacity();
     const targetIndex = sanitizeViewIndex(index);
@@ -1011,20 +961,17 @@
       updateViewControlsUI(targetIndex);
     }
   }
-
   const renderers = figureWrappers.map((wrapper, index) => {
     const canvasWrap = wrapper.querySelector('.figureCanvas');
     return new ShapeRenderer(canvasWrap, {
       onViewChange: view => storeViewState(index, view)
     });
   });
-
   figureWrappers.forEach((wrapper, index) => {
     wrapper.addEventListener('pointerdown', () => {
       setActiveViewIndex(index);
     });
   });
-
   function syncAllViewStates() {
     renderers.forEach(renderer => {
       if (renderer && typeof renderer.syncViewState === 'function') {
@@ -1032,7 +979,6 @@
       }
     });
   }
-
   if (typeof window !== 'undefined' && window && typeof window.addEventListener === 'function') {
     window.addEventListener('examples:collect', syncAllViewStates);
     window.addEventListener('examples:loaded', () => {
@@ -1040,7 +986,6 @@
       syncControlsFromState();
     });
   }
-
   function getStoredView(index) {
     ensureViewStateCapacity();
     const stored = window.STATE.views[index];
@@ -1055,7 +1000,6 @@
     if (Number.isFinite(stored.baseDistance)) view.baseDistance = Number(stored.baseDistance);
     return view;
   }
-
   function applyStoredView(index) {
     const renderer = renderers[index];
     if (!renderer || typeof renderer.applyViewState !== 'function') return;
@@ -1063,7 +1007,6 @@
     if (!view) return;
     renderer.applyViewState(view);
   }
-
   const textarea = document.getElementById('inpSpecs');
   const drawBtn = document.getElementById('btnDraw');
   const lockRotationCheckbox = document.getElementById('chkLockRotation');
@@ -1082,29 +1025,24 @@
   const exportCard = document.getElementById('exportCard');
   const exportRows = Array.from(document.querySelectorAll('[data-export-index]'));
   const exportButtons = Array.from(document.querySelectorAll('[data-export-button]'));
-
   function clampTransparency(value) {
     const num = Number(value);
     if (!Number.isFinite(num)) return 0;
     return Math.min(Math.max(num, 0), 95);
   }
-
   function parseColorHex(value) {
     if (typeof value !== 'string') return null;
     const match = value.trim().match(/^#?([0-9a-f]{6})$/i);
     if (!match) return null;
     return parseInt(match[1], 16);
   }
-
   function updateTransparencyLabel(value) {
     if (!transparencyLabel) return;
     const clamped = clampTransparency(value);
     transparencyLabel.textContent = `${clamped}%`;
   }
-
   const ELEVATION_MIN_DEGREES = -80;
   const ELEVATION_MAX_DEGREES = 80;
-
   function clampElevationDegrees(value) {
     const num = Number(value);
     if (!Number.isFinite(num)) return 0;
@@ -1112,7 +1050,6 @@
     if (num > ELEVATION_MAX_DEGREES) return ELEVATION_MAX_DEGREES;
     return num;
   }
-
   function updateElevationLabel(value) {
     if (!elevationLabel) return;
     if (!Number.isFinite(value)) {
@@ -1122,7 +1059,6 @@
     const clamped = clampElevationDegrees(value);
     elevationLabel.textContent = `${Math.round(clamped)}°`;
   }
-
   function clampRotation(value) {
     const num = Number(value);
     if (!Number.isFinite(num)) return 0;
@@ -1131,7 +1067,6 @@
     if (normalized < 0) normalized = 0;
     return normalized;
   }
-
   function updateRotationLabel(value) {
     if (!rotationLabel) return;
     if (!Number.isFinite(value)) {
@@ -1141,13 +1076,11 @@
     const normalized = clampRotation(value);
     rotationLabel.textContent = `${Math.round(normalized)}°`;
   }
-
   function clampZoomPercent(value) {
     const num = Number(value);
     if (!Number.isFinite(num)) return 100;
     return Math.min(Math.max(num, 40), 250);
   }
-
   function updateZoomLabel(value) {
     if (!zoomLabel) return;
     if (!Number.isFinite(value)) {
@@ -1157,7 +1090,6 @@
     const clamped = clampZoomPercent(value);
     zoomLabel.textContent = `${Math.round(clamped)}%`;
   }
-
   function updateViewFigureLabelText(index) {
     if (!viewFigureLabels.length) return;
     const hasIndex = Number.isInteger(index) && index >= 0;
@@ -1166,7 +1098,6 @@
       node.textContent = labelText;
     });
   }
-
   function sanitizeViewIndex(index) {
     if (!Number.isInteger(index)) return 0;
     if (index < 0) return 0;
@@ -1175,13 +1106,11 @@
     }
     return index;
   }
-
   function hasFigureAtIndex(index) {
     const figures = getCurrentFigures();
     if (!Array.isArray(figures)) return false;
     return Boolean(figures[index]);
   }
-
   function findFirstVisibleFigureIndex() {
     const figures = getCurrentFigures();
     if (!Array.isArray(figures)) return null;
@@ -1190,11 +1119,9 @@
     }
     return null;
   }
-
   function getActiveViewIndex() {
     return sanitizeViewIndex(activeViewIndex);
   }
-
   function setActiveViewIndex(index, options = {}) {
     let target = sanitizeViewIndex(index);
     if (!hasFigureAtIndex(target)) {
@@ -1212,16 +1139,11 @@
       updateViewControlsUI(target);
     }
   }
-
   function getRendererCameraView(index) {
     const renderer = renderers[index];
     if (!renderer || !renderer.camera) return null;
     const cameraPosition = renderer.camera.position;
-    const targetVec = renderer.controls
-      ? renderer.controls.target
-      : renderer.currentFrame && renderer.currentFrame.center
-        ? renderer.currentFrame.center
-        : null;
+    const targetVec = renderer.controls ? renderer.controls.target : renderer.currentFrame && renderer.currentFrame.center ? renderer.currentFrame.center : null;
     if (!targetVec) return null;
     const position = [cameraPosition.x, cameraPosition.y, cameraPosition.z];
     const target = [targetVec.x, targetVec.y, targetVec.z];
@@ -1229,19 +1151,20 @@
     const dy = position[1] - target[1];
     const dz = position[2] - target[2];
     const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
-    let baseDistance = renderer.currentFrame && Number.isFinite(renderer.currentFrame.baseDistance)
-      ? renderer.currentFrame.baseDistance
-      : distance;
+    let baseDistance = renderer.currentFrame && Number.isFinite(renderer.currentFrame.baseDistance) ? renderer.currentFrame.baseDistance : distance;
     if (!(baseDistance > 0)) {
       baseDistance = distance > 0 ? distance : 1;
     }
-    return { position, target, distance, baseDistance };
+    return {
+      position,
+      target,
+      distance,
+      baseDistance
+    };
   }
-
   function getEffectiveView(index) {
     return getStoredView(index) || getRendererCameraView(index);
   }
-
   function computeRotationDegreesFromView(view) {
     if (!view) return null;
     const position = normalizeVectorArray(view.position);
@@ -1259,7 +1182,6 @@
     if (degrees < 0) degrees = 0;
     return degrees;
   }
-
   function computeZoomPercentFromView(view, renderer) {
     if (!view) return null;
     const distance = Number.isFinite(view.distance) ? Number(view.distance) : null;
@@ -1272,9 +1194,8 @@
       return null;
     }
     const effectiveDistance = distance && distance > 0 ? distance : base;
-    return (effectiveDistance / base) * 100;
+    return effectiveDistance / base * 100;
   }
-
   function computeElevationFromView(view) {
     if (!view) return 0;
     const position = normalizeVectorArray(view.position);
@@ -1289,13 +1210,11 @@
     if (!Number.isFinite(angle)) return 0;
     return angle;
   }
-
   function computeElevationDegreesFromView(view) {
     const radians = computeElevationFromView(view);
     if (!Number.isFinite(radians)) return 0;
     return THREE.MathUtils.radToDeg(radians);
   }
-
   function applyViewControlChanges(options = {}) {
     const index = getActiveViewIndex();
     const renderer = renderers[index];
@@ -1328,11 +1247,7 @@
     const distance = Math.max(baseDistance * (clampedZoom / 100), 0.2);
     const horizontal = Math.cos(elevation) * distance;
     const yaw = THREE.MathUtils.degToRad(clampedRotation);
-    const newPosition = [
-      target[0] + Math.sin(yaw) * horizontal,
-      target[1] + Math.sin(elevation) * distance,
-      target[2] + Math.cos(yaw) * horizontal
-    ];
+    const newPosition = [target[0] + Math.sin(yaw) * horizontal, target[1] + Math.sin(elevation) * distance, target[2] + Math.cos(yaw) * horizontal];
     const newView = {
       position: newPosition,
       target: target.slice(),
@@ -1341,7 +1256,6 @@
     };
     renderer.applyViewState(newView);
   }
-
   function updateViewControlsUI(index) {
     const target = sanitizeViewIndex(index);
     const renderer = renderers[target];
@@ -1398,7 +1312,6 @@
       updateZoomLabel(zoomValue);
     }
   }
-
   function formatTypeLabel(type) {
     if (typeof type !== 'string' || !type) return '';
     switch (type) {
@@ -1418,14 +1331,12 @@
         return type.replace(/[-_]+/g, ' ');
     }
   }
-
   function getCurrentFigures() {
     if (window.STATE && Array.isArray(window.STATE.figures)) {
       return window.STATE.figures;
     }
     return [];
   }
-
   function getFigureDisplayLabel(info, index) {
     if (!info) return `Figur ${index + 1}`;
     const rawInput = typeof info.input === 'string' ? info.input.trim() : '';
@@ -1438,7 +1349,6 @@
     }
     return `Figur ${index + 1}`;
   }
-
   function getExportFileBase(info, index) {
     if (!info) {
       return `figur-${index + 1}`;
@@ -1453,11 +1363,8 @@
     }
     return `figur-${index + 1}`;
   }
-
   function toSafeFileName(parts) {
-    const usable = parts
-      .filter(part => typeof part === 'string' && part.trim().length)
-      .map(part => part.trim());
+    const usable = parts.filter(part => typeof part === 'string' && part.trim().length).map(part => part.trim());
     if (!usable.length) {
       return 'figur';
     }
@@ -1466,13 +1373,9 @@
       combined = combined.normalize('NFKD');
     }
     combined = combined.replace(/[\u0300-\u036f]/g, '');
-    const sanitized = combined
-      .replace(/[^a-z0-9]+/gi, '-')
-      .replace(/^-+|-+$/g, '')
-      .toLowerCase();
+    const sanitized = combined.replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '').toLowerCase();
     return sanitized || 'figur';
   }
-
   function getExportFileName(index, format) {
     const figures = getCurrentFigures();
     const info = figures[index];
@@ -1483,7 +1386,6 @@
     const extension = typeof format === 'string' ? format.toLowerCase() : 'png';
     return `${safe}.${extension}`;
   }
-
   function canvasToBlob(canvas) {
     return new Promise(resolve => {
       if (!canvas) {
@@ -1506,14 +1408,15 @@
         for (let i = 0; i < len; i += 1) {
           bytes[i] = binary.charCodeAt(i);
         }
-        resolve(new Blob([bytes], { type: 'image/png' }));
+        resolve(new Blob([bytes], {
+          type: 'image/png'
+        }));
       } catch (error) {
         console.warn('Klarte ikke konvertere canvas til PNG.', error);
         resolve(null);
       }
     });
   }
-
   function downloadBlob(blob, filename) {
     if (!blob) return;
     const url = URL.createObjectURL(blob);
@@ -1528,20 +1431,12 @@
       URL.revokeObjectURL(url);
     });
   }
-
   function createSvgFromImage(pngDataUrl, width, height, background) {
     if (typeof pngDataUrl !== 'string' || !pngDataUrl) return null;
     if (!(width > 0) || !(height > 0)) return null;
-    const safeBackground = typeof background === 'string' && background.trim()
-      ? background.trim()
-      : '#ffffff';
-    return `<?xml version="1.0" encoding="UTF-8"?>\n` +
-      `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n` +
-      `  <rect width="100%" height="100%" fill="${safeBackground}" />\n` +
-      `  <image width="${width}" height="${height}" href="${pngDataUrl}" xlink:href="${pngDataUrl}" preserveAspectRatio="none" />\n` +
-      `</svg>`;
+    const safeBackground = typeof background === 'string' && background.trim() ? background.trim() : '#ffffff';
+    return `<?xml version="1.0" encoding="UTF-8"?>\n` + `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n` + `  <rect width="100%" height="100%" fill="${safeBackground}" />\n` + `  <image width="${width}" height="${height}" href="${pngDataUrl}" xlink:href="${pngDataUrl}" preserveAspectRatio="none" />\n` + `</svg>`;
   }
-
   function updateExportControls(figures) {
     if (!exportCard) return;
     const hasAny = Array.isArray(figures) && figures.some(item => Boolean(item));
@@ -1570,7 +1465,6 @@
       }
     });
   }
-
   async function exportFigure(index, format) {
     const renderer = renderers[index];
     if (!renderer || typeof renderer.captureSnapshot !== 'function') return;
@@ -1587,12 +1481,13 @@
       const pngDataUrl = snapshot.canvas.toDataURL('image/png');
       const svgContent = createSvgFromImage(pngDataUrl, snapshot.width, snapshot.height, snapshot.background);
       if (!svgContent) return;
-      const blob = new Blob([svgContent], { type: 'image/svg+xml;charset=utf-8' });
+      const blob = new Blob([svgContent], {
+        type: 'image/svg+xml;charset=utf-8'
+      });
       const filename = getExportFileName(index, 'svg');
       downloadBlob(blob, filename);
     }
   }
-
   function applyColor(useCustom, hex) {
     const parsed = useCustom ? parseColorHex(hex) : null;
     renderers.forEach(renderer => renderer.setMaterialColorOverride(parsed));
@@ -1603,7 +1498,6 @@
       colorResetBtn.disabled = !useCustom;
     }
   }
-
   function applyTransparency(value) {
     const clamped = clampTransparency(value);
     const opacity = 1 - clamped / 100;
@@ -1614,9 +1508,7 @@
     window.STATE.transparency = clamped;
     updateTransparencyLabel(clamped);
   }
-
   const defaultInput = textarea ? textarea.value : 'sylinder radius: r høyde: h';
-
   function ensureStateDefaults() {
     window.STATE = window.STATE || {};
     ensureViewStateCapacity();
@@ -1632,9 +1524,7 @@
     if (typeof window.STATE.freeFigure !== 'boolean') {
       window.STATE.freeFigure = freeFigureCheckbox ? Boolean(freeFigureCheckbox.checked) : false;
     }
-    const fallbackColor = colorInput && typeof colorInput.value === 'string' && colorInput.value
-      ? colorInput.value
-      : '#3b82f6';
+    const fallbackColor = colorInput && typeof colorInput.value === 'string' && colorInput.value ? colorInput.value : '#3b82f6';
     if (typeof window.STATE.customColor !== 'string' || !parseColorHex(window.STATE.customColor)) {
       window.STATE.customColor = fallbackColor;
     }
@@ -1644,15 +1534,12 @@
     const clampedTransparency = clampTransparency(window.STATE.transparency);
     window.STATE.transparency = clampedTransparency;
   }
-
   const applyRotationLock = locked => {
     renderers.forEach(renderer => renderer.setRotationLocked(Boolean(locked)));
   };
-
   const applyFloating = floating => {
     renderers.forEach(renderer => renderer.setFloating(Boolean(floating)));
   };
-
   function syncControlsFromState() {
     if (!window.STATE || typeof window.STATE !== 'object') return;
     if (lockRotationCheckbox) {
@@ -1673,11 +1560,9 @@
     applyColor(Boolean(window.STATE.useCustomColor), window.STATE.customColor);
     applyTransparency(transparencyValue);
   }
-
   ensureStateDefaults();
   syncControlsFromState();
   updateViewControlsUI(getActiveViewIndex());
-
   function detectType(line) {
     const normalized = line.toLowerCase();
     if (normalized.includes('kule')) return 'sphere';
@@ -1689,7 +1574,6 @@
     if (normalized.includes('prism')) return 'prism';
     return 'prism';
   }
-
   function parseDimensions(line) {
     const result = {};
     if (!line) return result;
@@ -1719,10 +1603,13 @@
       label = label.replace(/[,;|]+$/g, '').replace(/\s{2,}/g, ' ').trim();
       let finalLabel = label;
       if (!finalLabel) {
-        finalLabel = hadSeparator ? '' : (normalized === 'radius' ? 'r' : 'h');
+        finalLabel = hadSeparator ? '' : normalized === 'radius' ? 'r' : 'h';
       }
       if (!result[normalized]) {
-        const entry = { requested: true, label: finalLabel };
+        const entry = {
+          requested: true,
+          label: finalLabel
+        };
         const numericSource = typeof finalLabel === 'string' ? finalLabel.replace(/,/g, '.').trim() : '';
         if (numericSource) {
           const matchNumber = numericSource.match(/[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?/);
@@ -1738,25 +1625,26 @@
     }
     return result;
   }
-
   function parseInput(rawInput) {
     const lines = rawInput.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
     const figures = [];
     for (const line of lines) {
       const type = detectType(line);
       const dimensions = parseDimensions(line);
-      figures.push({ input: line, type, dimensions });
+      figures.push({
+        input: line,
+        type,
+        dimensions
+      });
       if (figures.length >= renderers.length) break;
     }
     return figures;
   }
-
   function updateForm(rawInput) {
     if (textarea && textarea.value !== rawInput) {
       textarea.value = rawInput;
     }
   }
-
   function updateFigures(figures) {
     ensureViewStateCapacity();
     const count = Math.max(figures.length, 1);
@@ -1785,22 +1673,29 @@
     });
     updateExportControls(figures);
     if (!Array.isArray(figures) || !figures.some(Boolean)) {
-      setActiveViewIndex(0, { force: true });
+      setActiveViewIndex(0, {
+        force: true
+      });
     } else {
       const active = getActiveViewIndex();
       if (figures[active]) {
-        setActiveViewIndex(active, { force: true });
+        setActiveViewIndex(active, {
+          force: true
+        });
       } else {
         const first = figures.findIndex(info => Boolean(info));
         if (first !== -1) {
-          setActiveViewIndex(first, { force: true });
+          setActiveViewIndex(first, {
+            force: true
+          });
         } else {
-          setActiveViewIndex(0, { force: true });
+          setActiveViewIndex(0, {
+            force: true
+          });
         }
       }
     }
   }
-
   function draw() {
     const rawInput = typeof window.STATE.rawInput === 'string' ? window.STATE.rawInput : defaultInput;
     const figures = parseInput(rawInput);
@@ -1809,7 +1704,6 @@
     updateForm(rawInput);
     updateFigures(figures);
   }
-
   exportButtons.forEach(button => {
     button.addEventListener('click', async evt => {
       evt.preventDefault();
@@ -1832,14 +1726,12 @@
       }
     });
   });
-
   if (drawBtn) {
     drawBtn.addEventListener('click', () => {
       window.STATE.rawInput = textarea ? textarea.value : '';
       draw();
     });
   }
-
   if (lockRotationCheckbox) {
     lockRotationCheckbox.addEventListener('change', evt => {
       const locked = Boolean(evt.target.checked);
@@ -1847,7 +1739,6 @@
       applyRotationLock(locked);
     });
   }
-
   if (freeFigureCheckbox) {
     freeFigureCheckbox.addEventListener('change', evt => {
       const floating = Boolean(evt.target.checked);
@@ -1855,7 +1746,6 @@
       applyFloating(floating);
     });
   }
-
   if (colorInput) {
     colorInput.addEventListener('input', evt => {
       const newValue = typeof evt.target.value === 'string' && evt.target.value ? evt.target.value : '#3b82f6';
@@ -1864,14 +1754,12 @@
       applyColor(true, newValue);
     });
   }
-
   if (colorResetBtn) {
     colorResetBtn.addEventListener('click', () => {
       window.STATE.useCustomColor = false;
       applyColor(false, window.STATE.customColor);
     });
   }
-
   if (rotationRange) {
     rotationRange.addEventListener('input', evt => {
       const value = clampRotation(evt.target.value);
@@ -1879,10 +1767,11 @@
         evt.target.value = String(Math.round(value));
       }
       updateRotationLabel(value);
-      applyViewControlChanges({ rotationDeg: value });
+      applyViewControlChanges({
+        rotationDeg: value
+      });
     });
   }
-
   if (elevationRange) {
     elevationRange.addEventListener('input', evt => {
       const value = clampElevationDegrees(evt.target.value);
@@ -1890,10 +1779,11 @@
         evt.target.value = String(Math.round(value));
       }
       updateElevationLabel(value);
-      applyViewControlChanges({ elevationDeg: value });
+      applyViewControlChanges({
+        elevationDeg: value
+      });
     });
   }
-
   if (zoomRange) {
     zoomRange.addEventListener('input', evt => {
       const value = clampZoomPercent(evt.target.value);
@@ -1901,10 +1791,11 @@
         evt.target.value = String(Math.round(value));
       }
       updateZoomLabel(value);
-      applyViewControlChanges({ zoomPercent: value });
+      applyViewControlChanges({
+        zoomPercent: value
+      });
     });
   }
-
   if (transparencyRange) {
     transparencyRange.addEventListener('input', evt => {
       const value = clampTransparency(evt.target.value);
@@ -1912,7 +1803,6 @@
       applyTransparency(value);
     });
   }
-
   if (textarea) {
     textarea.addEventListener('input', () => {
       if (!window.STATE || typeof window.STATE !== 'object') return;
@@ -1926,8 +1816,6 @@
       }
     });
   }
-
   window.draw = draw;
-
   draw();
 })();


### PR DESCRIPTION
## Summary
- add Babel tooling so we can transpile modern syntax used across the visualisations
- transpile the interactive JavaScript files to eliminate optional chaining and nullish coalescing so Safari can execute them without syntax errors

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cc46de010483248f48d3d0de396c54