### PR TITLE
Kompakt koordineringsinnstillinger

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -31,7 +31,7 @@
     .status--err{ color:#b91c1c; background:#fef2f2; border-color:#fecaca; }
     .status--info{ color:#1f2937; background:#f3f4f6; border-color:#e5e7eb; }
     .settings{ display:flex; flex-direction:column; gap:8px; }
-    .settings label{ display:flex; flex-direction:column; font-size:13px; color:#4b5563; white-space:normal; }
+    .settings label{ display:flex; flex-direction:column; gap:6px; font-size:13px; color:#4b5563; white-space:normal; }
     .settings input[type="text"], .settings input[type="number"], .settings select{ padding:8px 10px; border:1px solid #d1d5db; border-radius:10px; font-size:14px; background:#fff; width:100%; }
     .settings-row{ display:flex; gap:8px; flex-wrap:wrap; }
     .settings-row label{ flex:1; }
@@ -42,18 +42,21 @@
     .settings-group{ display:flex; flex-direction:column; gap:16px; }
     .input-label{ gap:6px; white-space:normal; }
     .input-label span{ font-size:12px; font-weight:600; letter-spacing:.01em; text-transform:uppercase; color:#374151; }
-    .options-grid{ display:grid; gap:10px; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); }
-    .checkbox-tile{ display:flex; align-items:flex-start; gap:8px; padding:8px 10px; border:1px solid #e5e7eb; border-radius:10px; background:#fff; color:#374151; font-size:13px; line-height:1.3; white-space:normal; transition:background .2s ease,border-color .2s ease; }
-    .checkbox-tile input{ margin-top:2px; }
+    .options-grid{ display:grid; gap:8px; grid-template-columns:repeat(auto-fit,minmax(140px,1fr)); }
+    .checkbox-tile{ display:flex; align-items:center; gap:8px; padding:8px 10px; border:1px solid #e5e7eb; border-radius:10px; background:#fff; color:#374151; font-size:13px; line-height:1.2; white-space:normal; transition:background .2s ease,border-color .2s ease; }
+    .checkbox-tile input{ margin-top:0; }
     .checkbox-tile:hover{ border-color:#d1d5db; background:#f3f4f6; }
+    .axis-font-grid{ display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); align-items:start; }
     .axis-group{ display:flex; flex-direction:column; gap:8px; }
     .axis-title{ font-size:12px; font-weight:600; letter-spacing:.04em; text-transform:uppercase; color:#6b7280; }
     .axis-inputs{ display:flex; gap:12px; flex-wrap:wrap; }
     .axis-inputs label{ flex-direction:row; align-items:center; gap:6px; color:#4b5563; font-size:13px; }
     .axis-inputs label span{ font-size:12px; font-weight:600; letter-spacing:.02em; text-transform:uppercase; color:#374151; }
     .axis-inputs label input{ width:90px; }
-    .font-grid{ display:grid; gap:12px; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); }
-    .font-grid label{ display:flex; flex-direction:column; gap:6px; color:#4b5563; font-size:13px; }
+    .font-grid{ display:grid; gap:12px; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); }
+    .font-grid label{ display:flex; flex-direction:row; align-items:center; gap:10px; color:#4b5563; font-size:13px; }
+    .font-grid label span{ flex:1; font-size:12px; font-weight:600; letter-spacing:.02em; text-transform:uppercase; color:#374151; }
+    .font-grid label input{ width:82px; text-align:right; }
   </style>
   <link rel="stylesheet" href="split.css" />
 </head>
@@ -114,32 +117,34 @@
                     <span>Vis funksjonsuttrykk</span>
                   </label>
                 </div>
-                <div class="axis-group">
-                  <div class="axis-title">Navn på akser</div>
-                  <div class="axis-inputs">
+                <div class="axis-font-grid">
+                  <div class="axis-group">
+                    <div class="axis-title">Navn på akser</div>
+                    <div class="axis-inputs">
+                      <label>
+                        <span>x</span>
+                        <input id="cfgAxisX" type="text" value="x">
+                      </label>
+                      <label>
+                        <span>y</span>
+                        <input id="cfgAxisY" type="text" value="y">
+                      </label>
+                    </div>
+                  </div>
+                  <div class="font-grid">
                     <label>
-                      <span>x</span>
-                      <input id="cfgAxisX" type="text" value="x">
+                      <span>Skriftstørrelse tall på akser</span>
+                      <input id="cfgFontTicks" type="number" min="6" max="72" step="1" value="16">
                     </label>
                     <label>
-                      <span>y</span>
-                      <input id="cfgAxisY" type="text" value="y">
+                      <span>Skriftstørrelse navn på akser</span>
+                      <input id="cfgFontAxes" type="number" min="6" max="72" step="1" value="20">
+                    </label>
+                    <label>
+                      <span>Skriftstørrelse navn på grafen</span>
+                      <input id="cfgFontCurve" type="number" min="6" max="72" step="1" value="16">
                     </label>
                   </div>
-                </div>
-                <div class="font-grid">
-                  <label>
-                    <span>Skriftstørrelse tall på akser</span>
-                    <input id="cfgFontTicks" type="number" min="6" max="72" step="1" value="16">
-                  </label>
-                  <label>
-                    <span>Skriftstørrelse navn på akser</span>
-                    <input id="cfgFontAxes" type="number" min="6" max="72" step="1" value="20">
-                  </label>
-                  <label>
-                    <span>Skriftstørrelse navn på grafen</span>
-                    <input id="cfgFontCurve" type="number" min="6" max="72" step="1" value="16">
-                  </label>
                 </div>
               </div>
             </fieldset>


### PR DESCRIPTION
## Summary
- komprimerte koordineringsfeltet i graftegneren ved å samle akse- og fontvalg i en delt rutenettseksjon
- justerte avkrysningsvalg og fontkontroller for å dele linjer og bruke tettere mellomrom

## Testing
- not run (ikke forespurt)


------
https://chatgpt.com/codex/tasks/task_e_68cc4744a36083249cf532e41e9707a7