### PR TITLE
Reduce vertical spacing between tenkeblokker rows

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -6,7 +6,11 @@
   <title>Tenkeblokker</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <style>
-    :root { --gap:18px; --tb-stepper-gap:18px; }
+    :root {
+      --gap: 18px;
+      --tb-stepper-gap: 0px;
+      --tb-stepper-spacing: 6px;
+    }
     html,body{height:100%;}
     body{
       margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
@@ -44,7 +48,8 @@
       align-items:flex-start;
     }
     .tb-row{display:flex;gap:0;width:100%;}
-    .tb-panel{display:flex;flex-direction:column;align-items:stretch;gap:16px;width:100%;min-width:0;}
+    .tb-panel{display:flex;flex-direction:column;align-items:stretch;gap:0;width:100%;min-width:0;}
+    .tb-panel .tb-header:not(:empty){margin-bottom:var(--tb-stepper-spacing,6px);}
     .tb-panel .tb-stepper{align-self:center;}
     .tb-svg{display:block;width:100%;height:var(--tb-svg-height,260px);background:#fff;overflow:visible;}
     .tb-board .addFigureBtn{align-self:center;justify-self:center;}

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -884,7 +884,8 @@ function updateBlockPanelLayout(block, rowTotal) {
   } else {
     block.panel.style.flexGrow = '1';
   }
-  block.panel.style.marginBottom = needsVerticalSpace ? 'var(--tb-stepper-gap, 18px)' : '0px';
+  block.panel.style.marginBottom = needsVerticalSpace ? 'var(--tb-stepper-gap, 0px)' : '0px';
+  block.panel.style.rowGap = stepperVisible ? 'var(--tb-stepper-spacing, 6px)' : '0px';
 }
 function drawBlock(block) {
   var _block$rectEmpty, _block$rectEmpty2, _block$rectEmpty3, _block$rectEmpty4, _block$rectFrame, _block$rectFrame2, _block$rectFrame3, _block$rectFrame4, _block$handle, _block$handleShadow, _block$handle2, _block$handleShadow2;


### PR DESCRIPTION
## Summary
- tighten the tenkeblokker panel layout by removing default vertical gap variables and only adding space when the denominator stepper is visible
- update the block layout logic to use the new spacing variables so stacked blocks sit flush when controls are hidden

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cc5d8cdb388324a3df0f2eb6efd4be