### PR TITLE
Fix example viewer compatibility in Safari

### DIFF
--- a/diagram.js
+++ b/diagram.js
@@ -757,7 +757,7 @@ function onDragStart(e) {
     if (target.releasePointerCapture) {
       try {
         target.releasePointerCapture(ev.pointerId);
-      } catch {}
+      } catch (error) {}
     }
   };
   window.addEventListener('pointermove', move, {
@@ -769,7 +769,7 @@ function onDragStart(e) {
   if (target.setPointerCapture) {
     try {
       target.setPointerCapture(e.pointerId);
-    } catch {}
+    } catch (error) {}
   }
 }
 

--- a/examples-viewer.js
+++ b/examples-viewer.js
@@ -160,7 +160,7 @@ function renderExamples() {
     let arr;
     try {
       arr = JSON.parse(safeGetItem(key)) || [];
-    } catch {
+    } catch (error) {
       arr = [];
     }
     if (arr.length === 0) continue;
@@ -178,7 +178,7 @@ function renderExamples() {
         const url = new URL(path, window.location.href);
         url.searchParams.set('example', String(idx + 1));
         iframe.src = url.href;
-      } catch {
+      } catch (error) {
         const sep = path.includes('?') ? '&' : '?';
         iframe.src = `${path}${sep}example=${idx + 1}`;
       }

--- a/examples.js
+++ b/examples.js
@@ -307,7 +307,7 @@
           });
         }
       }
-    } catch {
+    } catch (error) {
       deletedProvidedExamples = new Set();
     }
     return deletedProvidedExamples;
@@ -316,7 +316,7 @@
     if (!deletedProvidedExamples) return;
     try {
       safeSetItem(DELETED_PROVIDED_KEY, JSON.stringify(Array.from(deletedProvidedExamples)));
-    } catch {}
+    } catch (error) {}
   }
   function markProvidedExampleDeleted(value) {
     const key = normalizeKey(value);
@@ -467,7 +467,7 @@
         default:
           return undefined;
       }
-    } catch {
+    } catch (error) {
       return undefined;
     }
   }
@@ -475,7 +475,7 @@
     if (value == null) return value;
     try {
       return JSON.parse(JSON.stringify(value));
-    } catch {
+    } catch (error) {
       return value;
     }
   }
@@ -676,7 +676,7 @@
       if (path === location.pathname) {
         if (loadExample(index)) initialLoadPerformed = true;
       }
-    } catch {}
+    } catch (error) {}
     safeRemoveItem('example_to_load');
   })();
   const saveBtn = document.getElementById('btnSaveExample');
@@ -806,7 +806,7 @@
           const txt = await res.text();
           lines.push(`// Source: ${s.src}`);
           lines.push(txt);
-        } catch {}
+        } catch (error) {}
       }
       const blob = new Blob([lines.join('\n')], {
         type: 'application/javascript'
@@ -821,7 +821,7 @@
         URL.revokeObjectURL(a.href);
         document.body.removeChild(a);
       }, 1000);
-    } catch {}
+    } catch (error) {}
   });
   deleteBtn === null || deleteBtn === void 0 || deleteBtn.addEventListener('click', () => {
     const examples = getExamples();


### PR DESCRIPTION
## Summary
- replace optional catch binding syntax with explicit error parameters in the example storage utilities so Safari can parse them
- update diagram pointer capture handlers to use Safari-compatible try/catch blocks

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc5f326df0832484e925b3f45a0b03