### PR TITLE
Tighten koordinatsysteminnstillinger

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -42,9 +42,9 @@
     .settings-group{ display:flex; flex-direction:column; gap:16px; }
     .input-label{ gap:6px; white-space:normal; }
     .input-label span{ font-size:12px; font-weight:600; letter-spacing:.01em; text-transform:uppercase; color:#374151; }
-    .options-grid{ display:grid; gap:8px; grid-template-columns:repeat(auto-fit,minmax(140px,1fr)); }
-    .checkbox-tile{ display:flex; align-items:center; gap:8px; padding:8px 10px; border:1px solid #e5e7eb; border-radius:10px; background:#fff; color:#374151; font-size:13px; line-height:1.2; white-space:normal; transition:background .2s ease,border-color .2s ease; }
-    .checkbox-tile input{ margin-top:0; }
+    .options-grid{ display:grid; gap:6px; grid-template-columns:repeat(auto-fit,minmax(120px,1fr)); }
+    .checkbox-tile{ display:flex; align-items:flex-start; gap:6px; padding:6px 8px; border:1px solid #e5e7eb; border-radius:8px; background:#fff; color:#374151; font-size:12px; line-height:1.35; white-space:normal; transition:background .2s ease,border-color .2s ease; }
+    .checkbox-tile input{ margin-top:3px; }
     .checkbox-tile:hover{ border-color:#d1d5db; background:#f3f4f6; }
     .axis-font-grid{ display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); align-items:start; }
     .axis-group{ display:flex; flex-direction:column; gap:8px; }


### PR DESCRIPTION
## Summary
- reduce the spacing and padding in the koordinatsystem options grid so the settings take up less room
- adjust the checkbox layout to align content at the top for a denser presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc8036ff588324a877c4544e19639e