### PR TITLE
Align Tenkeblokker settings with block grid

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -61,14 +61,16 @@
     .tb-header:empty{display:none;}
     .tb-panel .removeFigureBtn{align-self:center;}
     .tb-settings{
-      display:flex;
-      flex-wrap:wrap;
+      --tb-settings-cols:1;
+      display:grid;
       gap:var(--gap);
       align-items:stretch;
+      grid-template-columns:repeat(var(--tb-settings-cols),minmax(0,1fr));
+      grid-auto-flow:row;
     }
     .tb-settings fieldset{
-      flex:1 1 200px;
-      min-width:120px;
+      min-width:0;
+      width:100%;
     }
     .addFigureBtn{
       width:clamp(30px,7.5vw,60px);

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -573,6 +573,16 @@ function draw(skipNormalization = false) {
     }
   }
   if (grid) grid.setAttribute('data-cols', String(CONFIG.cols));
+  if (settingsContainer) {
+    const parsedCols = Number(CONFIG.cols);
+    const parsedRows = Number(CONFIG.rows);
+    const safeCols = Number.isFinite(parsedCols) && parsedCols > 0 ? Math.floor(parsedCols) : 1;
+    const safeRows = Number.isFinite(parsedRows) && parsedRows > 0 ? Math.floor(parsedRows) : 1;
+    settingsContainer.style.setProperty('--tb-settings-cols', String(safeCols));
+    settingsContainer.style.setProperty('--tb-settings-rows', String(safeRows));
+    settingsContainer.dataset.cols = String(safeCols);
+    settingsContainer.dataset.rows = String(safeRows);
+  }
   updateAddButtons();
   const multiple = CONFIG.activeBlocks > 1;
   multipleBlocksActive = multiple;
@@ -753,6 +763,8 @@ function createBlock(row, col, cfg) {
   panel.appendChild(stepper);
   const fieldset = document.createElement('fieldset');
   block.fieldset = fieldset;
+  fieldset.dataset.row = String(row);
+  fieldset.dataset.col = String(col);
   const legend = document.createElement('legend');
   block.legend = legend;
   fieldset.appendChild(legend);


### PR DESCRIPTION
## Summary
- switch the Tenkeblokker settings container to a CSS grid that mirrors the block layout
- update rendering logic to expose the current row/column counts for the settings grid and tag each fieldset with its position

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccf8be4bf48324a584422c1086b769