### PR TITLE
Expose number visual spacing controls in kvikkbilder

### DIFF
--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Kvikkbilder mønster</title>
+  <title>Number visuals</title>
   <style>
     :root { --gap: 18px; }
     html,body{height:100%;}
@@ -89,8 +89,8 @@
     <div class="grid">
       <div class="card">
         <div id="figureArea" class="figure-area">
-          <button id="playBtn" aria-label="Vis kvikkbilde">▶</button>
-          <div id="patternContainer" class="figure" aria-label="Kvikkbilder mønster"></div>
+          <button id="playBtn" aria-label="Vis number visual">▶</button>
+          <div id="patternContainer" class="figure" aria-label="Number visuals"></div>
         </div>
         <div id="expression"></div>
       </div>
@@ -118,6 +118,22 @@
           </div>
           <label>Antall
             <input id="cfg-antall" type="number" min="1" value="9">
+          </label>
+          <div class="field-row">
+            <label>Sirkelstørrelse
+              <input id="cfg-circleRadius" type="number" min="1" value="10">
+            </label>
+            <label>Prikkavstand
+              <input id="cfg-dotSpacing" type="number" min="0" value="3">
+            </label>
+          </div>
+          <div class="field-row">
+            <label>Avstand mellom grupper
+              <input id="cfg-levelScale" type="number" min="0.1" step="0.1" value="1">
+            </label>
+          </div>
+          <label>Avstand mellom figurer
+            <input id="cfg-patternGap" type="number" min="0" value="18">
           </label>
           <label>Vis i sekunder
             <input id="cfg-duration" type="number" min="1" value="3">

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -52,10 +52,20 @@
       justify-content:center;
       align-content:center;
       justify-items:center;
-      gap:18px;
+      gap:var(--pattern-gap, 18px);
+      padding:var(--pattern-padding, 0px);
       grid-template-columns:repeat(1,minmax(0,1fr));
       grid-template-rows:repeat(1,minmax(0,1fr));
       grid-auto-rows:minmax(0,1fr);
+    }
+    #patternContainer .pattern-item{
+      width:100%;
+      height:100%;
+      box-sizing:border-box;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:var(--pattern-item-padding, 12px);
     }
     #patternContainer svg{width:100%;height:100%;display:block;}
     #expression{text-align:center;font-size:24px;font-weight:600;margin-top:var(--gap);}
@@ -98,7 +108,7 @@
         <div id="figureArea" class="figure-area">
           <button id="playBtn" aria-label="Vis kvikkbilde">▶</button>
           <div id="brickContainer" class="figure" aria-label="Kvikkbilder klosser"></div>
-          <div id="patternContainer" class="figure" aria-label="Kvikkbilder mønster"></div>
+          <div id="patternContainer" class="figure" aria-label="Number visuals"></div>
         </div>
         <div id="expression"></div>
       </div>
@@ -113,7 +123,7 @@
           <label>Type
             <select id="cfg-type">
               <option value="klosser">Klosser</option>
-              <option value="monster">Mønster</option>
+              <option value="monster">Number visuals</option>
             </select>
           </label>
           <div class="checkbox-row">
@@ -159,6 +169,20 @@
             </div>
             <label>Antall
               <input id="cfg-antall" type="number" min="1" value="9">
+            </label>
+            <div class="field-row field-row--three">
+              <label>Sirkelstørrelse
+                <input id="cfg-monster-circleRadius" type="number" min="1" value="10">
+              </label>
+              <label>Prikkavstand
+                <input id="cfg-monster-dotSpacing" type="number" min="0" value="3">
+              </label>
+              <label>Avstand mellom grupper
+                <input id="cfg-monster-levelScale" type="number" min="0.1" step="0.1" value="1">
+              </label>
+            </div>
+            <label>Avstand mellom figurer
+              <input id="cfg-monster-patternGap" type="number" min="0" value="18">
             </label>
             <label>Vis i sekunder
               <input id="cfg-duration-monster" type="number" min="1" value="3">


### PR DESCRIPTION
## Summary
- rename the kvikkbilder pattern option and aria label to "Number visuals"
- add circle size, dot spacing, group spacing, and figure gap controls to the number visuals settings card
- update kvikkbilder.js to wire the new inputs into rendering, config persistence, and downloads

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccf4a3cefc83249d97b05d10530b1d