### PR TITLE
Rename monster controls to points and add limits

### DIFF
--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Number visuals</title>
+  <title>Numbervisuals</title>
   <style>
     :root { --gap: 18px; }
     html,body{height:100%;}
@@ -89,8 +89,8 @@
     <div class="grid">
       <div class="card">
         <div id="figureArea" class="figure-area">
-          <button id="playBtn" aria-label="Vis number visual">▶</button>
-          <div id="patternContainer" class="figure" aria-label="Number visuals"></div>
+          <button id="playBtn" aria-label="Vis numbervisual">▶</button>
+          <div id="patternContainer" class="figure" aria-label="Numbervisuals"></div>
         </div>
         <div id="expression"></div>
       </div>
@@ -120,11 +120,11 @@
             <input id="cfg-antall" type="number" min="1" value="9">
           </label>
           <div class="field-row">
-            <label>Sirkelstørrelse
-              <input id="cfg-circleRadius" type="number" min="1" value="10">
+            <label>Punktstørrelse
+              <input id="cfg-circleRadius" type="number" min="1" max="60" value="10">
             </label>
-            <label>Prikkavstand
-              <input id="cfg-dotSpacing" type="number" min="0" value="3">
+            <label>Avstand mellom punkter
+              <input id="cfg-dotSpacing" type="number" min="0" max="60" value="3">
             </label>
           </div>
           <div class="field-row">

--- a/kvikkbilder-monster.js
+++ b/kvikkbilder-monster.js
@@ -14,6 +14,12 @@
   const expression = document.getElementById('expression');
   const btnSvg = document.getElementById('btnSvg');
   const btnPng = document.getElementById('btnPng');
+  const MONSTER_POINT_RADIUS_MIN = 1;
+  const MONSTER_POINT_RADIUS_MAX = 60;
+  const MONSTER_POINT_SPACING_MIN = 0;
+  const MONSTER_POINT_SPACING_MAX = 60;
+  const DEFAULT_CIRCLE_RADIUS = 10;
+  const DEFAULT_DOT_SPACING = 3;
   function primeFactors(n) {
     const factors = [];
     let num = n;
@@ -211,17 +217,31 @@
     const n = parseInt(cfgAntall.value, 10) || 0;
     const antallX = parseInt(cfgAntallX.value, 10) || 0;
     const antallY = parseInt(cfgAntallY.value, 10) || 0;
-    const circleRadius = cfgCircleRadius ? Math.max(1, parseFloat(cfgCircleRadius.value) || 0) : 10;
-    const dotSpacing = cfgDotSpacing ? Math.max(0, parseFloat(cfgDotSpacing.value) || 0) : 3;
+    const circleRadiusRaw = cfgCircleRadius ? parseFloat(cfgCircleRadius.value) : NaN;
+    const circleRadius = Number.isFinite(circleRadiusRaw) ? Math.min(MONSTER_POINT_RADIUS_MAX, Math.max(MONSTER_POINT_RADIUS_MIN, circleRadiusRaw)) : DEFAULT_CIRCLE_RADIUS;
+    const dotSpacingRaw = cfgDotSpacing ? parseFloat(cfgDotSpacing.value) : NaN;
+    const dotSpacing = Number.isFinite(dotSpacingRaw) ? Math.min(MONSTER_POINT_SPACING_MAX, Math.max(MONSTER_POINT_SPACING_MIN, dotSpacingRaw)) : DEFAULT_DOT_SPACING;
+    if (cfgCircleRadius) cfgCircleRadius.value = String(circleRadius);
+    if (cfgDotSpacing) cfgDotSpacing.value = String(dotSpacing);
     const levelScale = cfgLevelScale ? Math.max(0.1, parseFloat(cfgLevelScale.value) || 0) : 1;
     patternContainer.innerHTML = '';
     const cols = antallX > 0 ? antallX : 1;
     const rows = antallY > 0 ? antallY : 1;
+    if (cfgPatternGap) {
+      const disableGap = cols <= 1 && rows <= 1;
+      cfgPatternGap.disabled = disableGap;
+      if (disableGap) {
+        cfgPatternGap.setAttribute('title', 'Avstand mellom figurer er tilgjengelig når det er flere figurer.');
+      } else {
+        cfgPatternGap.removeAttribute('title');
+      }
+    }
     patternContainer.style.gridTemplateColumns = `repeat(${cols},minmax(0,1fr))`;
     patternContainer.style.gridTemplateRows = `repeat(${rows},minmax(0,1fr))`;
     const maxDimension = Math.max(cols, rows);
     const gapInput = cfgPatternGap ? parseFloat(cfgPatternGap.value) : NaN;
-    const gapOverride = Number.isFinite(gapInput) && gapInput >= 0 ? gapInput : null;
+    const allowGapOverride = !(cols <= 1 && rows <= 1);
+    const gapOverride = allowGapOverride && Number.isFinite(gapInput) && gapInput >= 0 ? gapInput : null;
     const gapPx = gapOverride !== null ? gapOverride : maxDimension <= 1 ? 64 : maxDimension === 2 ? 56 : maxDimension === 3 ? 44 : maxDimension === 4 ? 36 : 28;
     const itemPaddingPx = gapOverride !== null ? Math.max(0, Math.round(gapPx * 0.5)) : Math.min(72, Math.max(18, Math.round(gapPx * 0.65)));
     const containerPaddingPx = gapOverride !== null ? Math.max(0, Math.round(gapPx * 0.3)) : Math.min(48, Math.max(12, Math.round(gapPx * 0.4)));
@@ -244,7 +264,7 @@
       return;
     }
     const totalFigures = antallX * antallY;
-    svg.setAttribute('aria-label', `Number visual ${n}`);
+    svg.setAttribute('aria-label', `Numbervisual ${n}`);
     for (let i = 0; i < totalFigures; i++) {
       const wrapper = document.createElement('div');
       wrapper.className = 'pattern-item';
@@ -293,11 +313,11 @@
   });
   btnSvg === null || btnSvg === void 0 || btnSvg.addEventListener('click', () => {
     const svg = patternContainer.querySelector('svg');
-    if (svg) downloadSVG(svg, 'number-visuals.svg');
+    if (svg) downloadSVG(svg, 'numbervisuals.svg');
   });
   btnPng === null || btnPng === void 0 || btnPng.addEventListener('click', () => {
     const svg = patternContainer.querySelector('svg');
-    if (svg) downloadPNG(svg, 'number-visuals.png', 2);
+    if (svg) downloadPNG(svg, 'numbervisuals.png', 2);
   });
   updateVisibility();
   render();

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -108,7 +108,7 @@
         <div id="figureArea" class="figure-area">
           <button id="playBtn" aria-label="Vis kvikkbilde">▶</button>
           <div id="brickContainer" class="figure" aria-label="Kvikkbilder klosser"></div>
-          <div id="patternContainer" class="figure" aria-label="Number visuals"></div>
+          <div id="patternContainer" class="figure" aria-label="Numbervisuals"></div>
         </div>
         <div id="expression"></div>
       </div>
@@ -123,7 +123,7 @@
           <label>Type
             <select id="cfg-type">
               <option value="klosser">Klosser</option>
-              <option value="monster">Number visuals</option>
+              <option value="monster">Numbervisuals</option>
             </select>
           </label>
           <div class="checkbox-row">
@@ -171,11 +171,11 @@
               <input id="cfg-antall" type="number" min="1" value="9">
             </label>
             <div class="field-row field-row--three">
-              <label>Sirkelstørrelse
-                <input id="cfg-monster-circleRadius" type="number" min="1" value="10">
+              <label>Punktstørrelse
+                <input id="cfg-monster-circleRadius" type="number" min="1" max="60" value="10">
               </label>
-              <label>Prikkavstand
-                <input id="cfg-monster-dotSpacing" type="number" min="0" value="3">
+              <label>Avstand mellom punkter
+                <input id="cfg-monster-dotSpacing" type="number" min="0" max="60" value="3">
               </label>
               <label>Avstand mellom grupper
                 <input id="cfg-monster-levelScale" type="number" min="0.1" step="0.1" value="1">


### PR DESCRIPTION
## Summary
- update the Numbervisuals UI text to use the new terminology
- clamp the point size and spacing values with shared limits across the controls
- disable the pattern gap control for a single figure and align download file names

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd087979408324815fa18f5ed35231