### PR TITLE
Oppdater innstillinger for kvikkbilder

### DIFF
--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -59,6 +59,7 @@
     label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     input[type="number"]{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
     .field-row{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));}
+    .field-grid{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));}
     #playBtn{
       position:absolute;
       top:50%;
@@ -119,22 +120,20 @@
           <label>Antall
             <input id="cfg-antall" type="number" min="1" value="9">
           </label>
-          <div class="field-row">
+          <div class="field-grid">
             <label>Punktstørrelse
               <input id="cfg-circleRadius" type="number" min="1" max="60" value="10">
             </label>
-            <label>Avstand mellom punkter
+            <label>Punktavstand
               <input id="cfg-dotSpacing" type="number" min="0" max="60" value="3">
             </label>
-          </div>
-          <div class="field-row">
-            <label>Avstand mellom grupper
+            <label>Gruppeavstand
               <input id="cfg-levelScale" type="number" min="0.1" step="0.1" value="1">
             </label>
+            <label>Figuravstand
+              <input id="cfg-patternGap" type="number" min="0" value="18">
+            </label>
           </div>
-          <label>Avstand mellom figurer
-            <input id="cfg-patternGap" type="number" min="0" value="18">
-          </label>
           <label>Vis i sekunder
             <input id="cfg-duration" type="number" min="1" value="3">
           </label>

--- a/kvikkbilder-monster.js
+++ b/kvikkbilder-monster.js
@@ -231,7 +231,7 @@
       const disableGap = cols <= 1 && rows <= 1;
       cfgPatternGap.disabled = disableGap;
       if (disableGap) {
-        cfgPatternGap.setAttribute('title', 'Avstand mellom figurer er tilgjengelig når det er flere figurer.');
+        cfgPatternGap.setAttribute('title', 'Figuravstand er tilgjengelig når det er flere figurer.');
       } else {
         cfgPatternGap.removeAttribute('title');
       }

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -74,6 +74,7 @@
     .field-row{display:grid;gap:10px;}
     .field-row.field-row--two{grid-template-columns:repeat(auto-fit,minmax(140px,1fr));}
     .field-row.field-row--three{grid-template-columns:repeat(auto-fit,minmax(100px,1fr));}
+    .field-grid{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));}
     .checkbox-row{display:flex;align-items:center;gap:6px;}
     #playBtn{
       position:absolute;
@@ -170,20 +171,20 @@
             <label>Antall
               <input id="cfg-antall" type="number" min="1" value="9">
             </label>
-            <div class="field-row field-row--three">
+            <div class="field-grid">
               <label>Punktstørrelse
                 <input id="cfg-monster-circleRadius" type="number" min="1" max="60" value="10">
               </label>
-              <label>Avstand mellom punkter
+              <label>Punktavstand
                 <input id="cfg-monster-dotSpacing" type="number" min="0" max="60" value="3">
               </label>
-              <label>Avstand mellom grupper
+              <label>Gruppeavstand
                 <input id="cfg-monster-levelScale" type="number" min="0.1" step="0.1" value="1">
               </label>
+              <label>Figuravstand
+                <input id="cfg-monster-patternGap" type="number" min="0" value="18">
+              </label>
             </div>
-            <label>Avstand mellom figurer
-              <input id="cfg-monster-patternGap" type="number" min="0" value="18">
-            </label>
             <label>Vis i sekunder
               <input id="cfg-duration-monster" type="number" min="1" value="3">
             </label>

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -610,7 +610,7 @@
       cfgMonsterPatternGap.value = CFG.monster.patternGap;
       cfgMonsterPatternGap.disabled = disableGap;
       if (disableGap) {
-        cfgMonsterPatternGap.setAttribute('title', 'Avstand mellom figurer er tilgjengelig når det er flere figurer.');
+        cfgMonsterPatternGap.setAttribute('title', 'Figuravstand er tilgjengelig når det er flere figurer.');
       } else {
         cfgMonsterPatternGap.removeAttribute('title');
       }


### PR DESCRIPTION
## Summary
- oppdater begrepsbruk i kvikkbilder for punkt-, gruppe- og figuravstand
- plasser punktinnstillinger i en todelt rutenettlayout for bedre oversikt
- juster hjelpetekster for den nye terminologien

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd0c080d648324bfa1f805ca0e557b