### PR TITLE
Add count label option for figurtall

### DIFF
--- a/figurtall.html
+++ b/figurtall.html
@@ -184,9 +184,9 @@
             <label class="fieldLabel">
               <span>Figurtekst</span>
               <select id="labelMode">
-                <option value="custom">Egendefinert</option>
-                <option value="numbered">Nummerert</option>
                 <option value="hidden">Skjult</option>
+                <option value="count">Antall</option>
+                <option value="custom">Egendefinert</option>
               </select>
             </label>
           </fieldset>


### PR DESCRIPTION
## Summary
- reorder the figure text options to Hidden, Count, Custom
- add a count label mode that shows the number of colored cells
- refresh figure labels when cell colors change so the counts stay updated

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd126f9c548324aff1c3b6b3e5c3bf