### PR TITLE
Update visibility controls for Kvikkbilder

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -127,6 +127,21 @@
               <option value="monster">Numbervisuals</option>
             </select>
           </label>
+          <label>Vis
+            <select id="cfg-visibility">
+              <option value="always">alltid</option>
+              <option value="1">1 sekund</option>
+              <option value="2">2 sekunder</option>
+              <option value="3">3 sekunder</option>
+              <option value="4">4 sekunder</option>
+              <option value="5">5 sekunder</option>
+              <option value="6">6 sekunder</option>
+              <option value="7">7 sekunder</option>
+              <option value="8">8 sekunder</option>
+              <option value="9">9 sekunder</option>
+              <option value="10">10 sekunder</option>
+            </select>
+          </label>
           <div class="checkbox-row">
             <input id="cfg-show-expression" type="checkbox" checked>
             <label for="cfg-show-expression">Vis regnestykke</label>
@@ -150,13 +165,6 @@
               <label>Dybde
                 <input id="cfg-dybde" type="number" min="1" value="2">
               </label>
-            </div>
-            <label>Vis i sekunder
-              <input id="cfg-duration-klosser" type="number" min="1" value="3">
-            </label>
-            <div class="checkbox-row">
-              <input id="cfg-showBtn" type="checkbox">
-              <label for="cfg-showBtn">Vis play-knapp</label>
             </div>
           </div>
           <div id="monsterConfig">
@@ -184,13 +192,6 @@
               <label>Figuravstand
                 <input id="cfg-monster-patternGap" type="number" min="0" value="18">
               </label>
-            </div>
-            <label>Vis i sekunder
-              <input id="cfg-duration-monster" type="number" min="1" value="3">
-            </label>
-            <div class="checkbox-row">
-              <input id="cfg-showBtn-monster" type="checkbox">
-              <label for="cfg-showBtn-monster">Vis play-knapp</label>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the separate play button and duration controls with a single visibility dropdown
- synchronize the new control with both brick and number visual configurations and cap durations to 10 seconds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd17801700832492ac14b47119aadf