### PR TITLE
Use shared add button style in graftegner

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -33,8 +33,8 @@
     .settings{ display:flex; flex-direction:column; gap:8px; }
     .settings label{ display:flex; flex-direction:column; gap:6px; font-size:13px; color:#4b5563; white-space:normal; }
     .settings input[type="text"], .settings input[type="number"], .settings select{ padding:8px 10px; border:1px solid #d1d5db; border-radius:10px; font-size:14px; background:#fff; width:100%; }
-    .function-controls{ display:grid; grid-template-columns:auto 1fr; gap:16px; align-items:start; }
-    .function-controls #addFunc{ align-self:flex-start; }
+    .function-controls{ display:flex; flex-direction:column; gap:16px; align-items:stretch; }
+    .function-controls #addFunc{ align-self:center; }
     .func-groups{ display:flex; flex-direction:column; gap:12px; width:100%; }
     .func-group{ gap:14px; }
     .func-group .func-fields{ display:flex; flex-wrap:wrap; gap:12px; }
@@ -43,11 +43,13 @@
     .func-group .glider-controls label{ flex:0 1 180px; }
     .func-group .glider-controls label.startx-label{ flex:1 1 220px; }
     @media (max-width:680px){
-      .function-controls{ grid-template-columns:1fr; }
-      .function-controls #addFunc{ justify-self:flex-start; }
+      .function-controls{ align-items:stretch; }
       .func-group .func-fields label,
       .func-group .glider-controls label{ max-width:100%; flex:1 1 100%; }
     }
+    .addFigureBtn{ width:clamp(36px,8vw,56px); aspect-ratio:1; border:2px dashed #cfcfcf; border-radius:10px; background:#fff; display:flex; align-items:center; justify-content:center; font-size:20px; color:#6b7280; cursor:pointer; transition:box-shadow .2s, transform .02s; }
+    .addFigureBtn:hover{ box-shadow:0 2px 8px rgba(0,0,0,.06); }
+    .addFigureBtn:active{ transform:translateY(1px); }
     .settings fieldset{ border:1px solid #e5e7eb; border-radius:12px; padding:16px; background:#fafbfc; }
     .settings fieldset legend{ padding:0 6px; font-size:12px; font-weight:600; letter-spacing:.04em; text-transform:uppercase; color:#6b7280; }
     .settings-group{ display:flex; flex-direction:column; gap:16px; }
@@ -100,8 +102,8 @@
         <div class="card card--settings">
           <div class="settings">
             <div class="function-controls">
-              <button id="addFunc" class="btn" type="button" aria-label="Legg til funksjon">Legg til</button>
               <div id="funcRows" class="func-groups"></div>
+              <button id="addFunc" class="addFigureBtn" type="button" aria-label="Legg til funksjon">+</button>
             </div>
             <fieldset>
               <legend>Koordinatsystem</legend>

--- a/graftegner.js
+++ b/graftegner.js
@@ -1981,19 +1981,15 @@ function setupSettingsForm() {
   if (!addBtn) {
     addBtn = document.createElement('button');
     addBtn.id = 'addFunc';
-    addBtn.type = 'button';
-    addBtn.className = 'btn';
-    addBtn.textContent = 'Legg til';
-    addBtn.setAttribute('aria-label', 'Legg til funksjon');
-    const functionsHost = document.querySelector('.function-controls');
-    if (functionsHost) {
-      functionsHost.insertAdjacentElement('afterbegin', addBtn);
-    }
-  } else {
-    addBtn.type = 'button';
-    addBtn.classList.add('btn');
-    addBtn.textContent = 'Legg til';
-    addBtn.setAttribute('aria-label', 'Legg til funksjon');
+  }
+  addBtn.type = 'button';
+  addBtn.textContent = '+';
+  addBtn.setAttribute('aria-label', 'Legg til funksjon');
+  addBtn.classList.remove('btn');
+  addBtn.classList.add('addFigureBtn');
+  const functionsHost = document.querySelector('.function-controls');
+  if (functionsHost && addBtn.parentElement !== functionsHost) {
+    functionsHost.appendChild(addBtn);
   }
   const g = id => document.getElementById(id);
   const showNamesInput = g('cfgShowNames');


### PR DESCRIPTION
## Summary
- restyle the function add button in Graftegner to reuse the shared dashed-square “Legg til” appearance
- move the button below the function fields for consistency with other visualizations
- update initialization code to keep the new button styling when the form is rebuilt

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd1d248b4483248e7fdfc9c2a618c2