### PR TITLE
Remove dot spacing setting from numbervisuals

### DIFF
--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -124,9 +124,6 @@
             <label>Punktstørrelse
               <input id="cfg-circleRadius" type="number" min="1" max="60" value="10">
             </label>
-            <label>Punktavstand
-              <input id="cfg-dotSpacing" type="number" min="0" max="60" value="3">
-            </label>
             <label>Gruppeavstand
               <input id="cfg-levelScale" type="number" min="0.1" step="0.1" value="1">
             </label>

--- a/kvikkbilder-monster.js
+++ b/kvikkbilder-monster.js
@@ -4,7 +4,6 @@
   const cfgAntall = document.getElementById('cfg-antall');
   const cfgDuration = document.getElementById('cfg-duration');
   const cfgCircleRadius = document.getElementById('cfg-circleRadius');
-  const cfgDotSpacing = document.getElementById('cfg-dotSpacing');
   const cfgLevelScale = document.getElementById('cfg-levelScale');
   const cfgPatternGap = document.getElementById('cfg-patternGap');
   const cfgShowBtn = document.getElementById('cfg-showBtn');
@@ -16,8 +15,6 @@
   const btnPng = document.getElementById('btnPng');
   const MONSTER_POINT_RADIUS_MIN = 1;
   const MONSTER_POINT_RADIUS_MAX = 60;
-  const MONSTER_POINT_SPACING_MIN = 0;
-  const MONSTER_POINT_SPACING_MAX = 60;
   const DEFAULT_CIRCLE_RADIUS = 10;
   const DEFAULT_DOT_SPACING = 3;
   function primeFactors(n) {
@@ -219,10 +216,8 @@
     const antallY = parseInt(cfgAntallY.value, 10) || 0;
     const circleRadiusRaw = cfgCircleRadius ? parseFloat(cfgCircleRadius.value) : NaN;
     const circleRadius = Number.isFinite(circleRadiusRaw) ? Math.min(MONSTER_POINT_RADIUS_MAX, Math.max(MONSTER_POINT_RADIUS_MIN, circleRadiusRaw)) : DEFAULT_CIRCLE_RADIUS;
-    const dotSpacingRaw = cfgDotSpacing ? parseFloat(cfgDotSpacing.value) : NaN;
-    const dotSpacing = Number.isFinite(dotSpacingRaw) ? Math.min(MONSTER_POINT_SPACING_MAX, Math.max(MONSTER_POINT_SPACING_MIN, dotSpacingRaw)) : DEFAULT_DOT_SPACING;
+    const dotSpacing = DEFAULT_DOT_SPACING;
     if (cfgCircleRadius) cfgCircleRadius.value = String(circleRadius);
-    if (cfgDotSpacing) cfgDotSpacing.value = String(dotSpacing);
     const levelScale = cfgLevelScale ? Math.max(0.1, parseFloat(cfgLevelScale.value) || 0) : 1;
     patternContainer.innerHTML = '';
     const cols = antallX > 0 ? antallX : 1;
@@ -293,7 +288,7 @@
     }
     applyExpressionVisibility();
   }
-  [cfgAntall, cfgAntallX, cfgAntallY, cfgCircleRadius, cfgDotSpacing, cfgLevelScale, cfgPatternGap].forEach(el => {
+  [cfgAntall, cfgAntallX, cfgAntallY, cfgCircleRadius, cfgLevelScale, cfgPatternGap].forEach(el => {
     el === null || el === void 0 || el.addEventListener('input', render);
   });
   cfgShowBtn.addEventListener('change', () => {

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -183,9 +183,6 @@
               <label>Punktstørrelse
                 <input id="cfg-monster-circleRadius" type="number" min="1" max="60" value="10">
               </label>
-              <label>Punktavstand
-                <input id="cfg-monster-dotSpacing" type="number" min="0" max="60" value="3">
-              </label>
               <label>Gruppeavstand
                 <input id="cfg-monster-levelScale" type="number" min="0.1" step="0.1" value="1">
               </label>

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -13,7 +13,6 @@
   const cfgMonsterAntallY = document.getElementById('cfg-monster-antallY');
   const cfgAntall = document.getElementById('cfg-antall');
   const cfgMonsterCircleRadius = document.getElementById('cfg-monster-circleRadius');
-  const cfgMonsterDotSpacing = document.getElementById('cfg-monster-dotSpacing');
   const cfgMonsterLevelScale = document.getElementById('cfg-monster-levelScale');
   const cfgMonsterPatternGap = document.getElementById('cfg-monster-patternGap');
   const brickContainer = document.getElementById('brickContainer');
@@ -634,7 +633,6 @@
     if (cfgMonsterAntallY) cfgMonsterAntallY.value = CFG.monster.antallY;
     if (cfgAntall) cfgAntall.value = CFG.monster.antall;
     if (cfgMonsterCircleRadius) cfgMonsterCircleRadius.value = CFG.monster.circleRadius;
-    if (cfgMonsterDotSpacing) cfgMonsterDotSpacing.value = CFG.monster.dotSpacing;
     if (cfgMonsterLevelScale) cfgMonsterLevelScale.value = CFG.monster.levelScale;
     if (cfgMonsterPatternGap) {
       cfgMonsterPatternGap.value = CFG.monster.patternGap;
@@ -708,7 +706,6 @@
   bindNumberInput(cfgMonsterAntallY, () => CFG.monster, 'antallY', 0);
   bindNumberInput(cfgAntall, () => CFG.monster, 'antall', 0);
   bindFloatInput(cfgMonsterCircleRadius, () => CFG.monster, 'circleRadius', MONSTER_POINT_RADIUS_MIN, DEFAULT_CFG.monster.circleRadius, MONSTER_POINT_RADIUS_MAX);
-  bindFloatInput(cfgMonsterDotSpacing, () => CFG.monster, 'dotSpacing', MONSTER_POINT_SPACING_MIN, DEFAULT_CFG.monster.dotSpacing, MONSTER_POINT_SPACING_MAX);
   bindFloatInput(cfgMonsterLevelScale, () => CFG.monster, 'levelScale', 0.1, DEFAULT_CFG.monster.levelScale);
   bindFloatInput(cfgMonsterPatternGap, () => CFG.monster, 'patternGap', 0, DEFAULT_CFG.monster.patternGap);
   if (cfgVisibility) {


### PR DESCRIPTION
## Summary
- remove the Punktavstand control from the numbervisual settings panels
- simplify the associated scripts to rely on the default dot spacing value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd20ce38848324960b7366a34c25be