### PR TITLE
Arrange function settings fields in table layout

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -39,13 +39,19 @@
     .func-group{ gap:14px; }
     .func-group .func-fields{ display:flex; flex-wrap:wrap; gap:12px; }
     .func-group .func-fields label{ flex:1 1 220px; max-width:280px; }
-    .func-group .glider-controls{ display:flex; flex-wrap:wrap; gap:12px; }
-    .func-group .glider-controls label{ flex:0 1 180px; }
-    .func-group .glider-controls label.startx-label{ flex:1 1 220px; }
+    .func-group .func-fields.func-fields--table{ display:block; }
+    .func-table{ width:100%; border-collapse:separate; border-spacing:12px 10px; table-layout:fixed; }
+    .func-table td{ width:50%; vertical-align:top; padding:0; }
+    .func-table label{ display:flex; flex-direction:column; gap:6px; width:100%; }
+    .func-table input[type="text"], .func-table select{ width:100%; max-width:100%; }
+    .func-table .glider-row td{ padding-top:4px; }
     @media (max-width:680px){
       .function-controls{ align-items:stretch; }
-      .func-group .func-fields label,
-      .func-group .glider-controls label{ max-width:100%; flex:1 1 100%; }
+      .func-group .func-fields label{ max-width:100%; flex:1 1 100%; }
+      .func-group .func-fields.func-fields--table{ display:block; }
+      .func-table, .func-table tbody, .func-table tr, .func-table td{ display:block; width:100%; }
+      .func-table td{ padding:0; }
+      .func-table tr + tr{ margin-top:12px; }
     }
     .addFigureBtn{ width:clamp(36px,8vw,56px); aspect-ratio:1; border:2px dashed #cfcfcf; border-radius:10px; background:#fff; display:flex; align-items:center; justify-content:center; font-size:20px; color:#6b7280; cursor:pointer; transition:box-shadow .2s, transform .02s; }
     .addFigureBtn:hover{ box-shadow:0 2px 8px rgba(0,0,0,.06); }

--- a/graftegner.js
+++ b/graftegner.js
@@ -2142,35 +2142,63 @@ function setupSettingsForm() {
     row.className = 'func-group';
     row.dataset.index = String(index);
     const titleLabel = index === 1 ? 'Funksjon eller punkter' : 'Funksjon ' + index;
-    row.innerHTML = `
-      <legend>Funksjon ${index}</legend>
-      <div class="func-fields">
-        <label class="func-input">
-          <span>${titleLabel}</span>
-          <input type="text" data-fun>
-        </label>
-        <label class="domain">
-          <span>Avgrensning</span>
-          <input type="text" data-dom placeholder="[start, stopp]">
-        </label>
-      </div>
-      ${index === 1 ? `
-      <div class="glider-controls">
-        <label class="points">
-          <span>Antall punkter på grafen</span>
-          <select data-points>
-            <option value="0">0</option>
-            <option value="1">1</option>
-            <option value="2">2</option>
-          </select>
-        </label>
-        <label class="startx-label">
-          <span>Startposisjon, x</span>
-          <input type="text" data-startx value="1" placeholder="1">
-        </label>
-      </div>
-      ` : ''}
-    `;
+    if (index === 1) {
+      row.innerHTML = `
+        <legend>Funksjon ${index}</legend>
+        <div class="func-fields func-fields--table">
+          <table class="func-table">
+            <tbody>
+              <tr>
+                <td>
+                  <label class="func-input">
+                    <span>${titleLabel}</span>
+                    <input type="text" data-fun>
+                  </label>
+                </td>
+                <td>
+                  <label class="domain">
+                    <span>Avgrensning</span>
+                    <input type="text" data-dom placeholder="[start, stopp]">
+                  </label>
+                </td>
+              </tr>
+              <tr class="glider-row">
+                <td>
+                  <label class="points">
+                    <span>Antall punkter på grafen</span>
+                    <select data-points>
+                      <option value="0">0</option>
+                      <option value="1">1</option>
+                      <option value="2">2</option>
+                    </select>
+                  </label>
+                </td>
+                <td>
+                  <label class="startx-label">
+                    <span>Startposisjon, x</span>
+                    <input type="text" data-startx value="1" placeholder="1">
+                  </label>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      `;
+    } else {
+      row.innerHTML = `
+        <legend>Funksjon ${index}</legend>
+        <div class="func-fields">
+          <label class="func-input">
+            <span>${titleLabel}</span>
+            <input type="text" data-fun>
+          </label>
+          <label class="domain">
+            <span>Avgrensning</span>
+            <input type="text" data-dom placeholder="[start, stopp]">
+          </label>
+        </div>
+      `;
+    }
     if (funcRows) {
       funcRows.appendChild(row);
     }
@@ -2188,7 +2216,7 @@ function setupSettingsForm() {
       domInput.addEventListener('input', syncSimpleFromForm);
     }
     if (index === 1) {
-      gliderSection = row.querySelector('.glider-controls');
+      gliderSection = row.querySelector('.glider-row');
       if (gliderSection) {
         gliderSection.style.display = 'none';
       }


### PR DESCRIPTION
## Summary
- replace the first function group's inputs with a 2x2 table so the function, domain, point count, and start position align in rows
- add styling for the new table layout, ensuring inputs stay within their cells and stack on narrow screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd220209588324948037dd27660719