### PR TITLE
Fix brick grid sizing in kvikkbilder

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -42,8 +42,14 @@
       display:grid;
       gap:10px;
       transform:translateY(-12px);
+      align-content:start;
+      grid-auto-rows:auto;
     }
-    #brickContainer svg{width:100%;height:100%;}
+    #brickContainer > svg{
+      width:100%;
+      height:auto;
+      display:block;
+    }
     #patternContainer{
       position:absolute;
       inset:0;

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -277,7 +277,7 @@
     const depth = Math.max(1, Math.trunc(dybde));
     brickContainer.innerHTML = '';
     brickContainer.style.gridTemplateColumns = cols > 0 ? `repeat(${cols}, 1fr)` : '';
-    brickContainer.style.gridTemplateRows = rows > 0 ? `repeat(${rows}, 1fr)` : '';
+    brickContainer.style.gridTemplateRows = rows > 0 ? `repeat(${rows}, auto)` : '';
     const perFig = width * height * depth;
     const total = cols * rows * perFig;
     const firstExpression = formatOuterInnerExpression([cols, rows], [width, height, depth]);


### PR DESCRIPTION
## Summary
- prevent kvikkbilder brick SVGs from stretching by letting the grid track sizing follow their intrinsic aspect ratio
- update the `renderKlosser` grid row sizing so each row auto-sizes to its content height

## Testing
- npm start (manual verification of layout and exports)


------
https://chatgpt.com/codex/tasks/task_e_68cd27d329488324911e73cbe249e7db