### PR TITLE
Refactor graftegner first function controls layout

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -37,21 +37,33 @@
     .function-controls #addFunc{ align-self:center; }
     .func-groups{ display:flex; flex-direction:column; gap:12px; width:100%; }
     .func-group{ gap:14px; }
-    .func-group .func-fields{ display:flex; flex-wrap:wrap; gap:12px; }
-    .func-group .func-fields label{ flex:1 1 220px; max-width:280px; }
-    .func-group .func-fields.func-fields--table{ display:block; }
-    .func-table{ width:100%; border-collapse:separate; border-spacing:12px 10px; table-layout:fixed; }
-    .func-table td{ width:50%; vertical-align:top; padding:0; }
-    .func-table label{ display:flex; flex-direction:column; gap:6px; width:100%; }
-    .func-table input[type="text"], .func-table select{ width:100%; max-width:100%; }
-    .func-table .glider-row td{ padding-top:4px; }
+    .func-group .func-fields{
+      display:grid;
+      gap:12px;
+      grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+      align-items:start;
+    }
+    .func-group .func-fields label{
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+      width:100%;
+    }
+    .func-fields--first{
+      grid-template-columns:1fr;
+      gap:16px;
+    }
+    .func-fields--first .func-row{
+      display:grid;
+      gap:12px;
+      grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+      align-items:start;
+    }
+    .func-fields--first .func-row label{ width:100%; }
     @media (max-width:680px){
       .function-controls{ align-items:stretch; }
-      .func-group .func-fields label{ max-width:100%; flex:1 1 100%; }
-      .func-group .func-fields.func-fields--table{ display:block; }
-      .func-table, .func-table tbody, .func-table tr, .func-table td{ display:block; width:100%; }
-      .func-table td{ padding:0; }
-      .func-table tr + tr{ margin-top:12px; }
+      .func-group .func-fields{ grid-template-columns:1fr; }
+      .func-fields--first .func-row{ grid-template-columns:1fr; }
     }
     .addFigureBtn{ width:clamp(36px,8vw,56px); aspect-ratio:1; border:2px dashed #cfcfcf; border-radius:10px; background:#fff; display:flex; align-items:center; justify-content:center; font-size:20px; color:#6b7280; cursor:pointer; transition:box-shadow .2s, transform .02s; }
     .addFigureBtn:hover{ box-shadow:0 2px 8px rgba(0,0,0,.06); }

--- a/graftegner.js
+++ b/graftegner.js
@@ -2145,43 +2145,31 @@ function setupSettingsForm() {
     if (index === 1) {
       row.innerHTML = `
         <legend>Funksjon ${index}</legend>
-        <div class="func-fields func-fields--table">
-          <table class="func-table">
-            <tbody>
-              <tr>
-                <td>
-                  <label class="func-input">
-                    <span>${titleLabel}</span>
-                    <input type="text" data-fun>
-                  </label>
-                </td>
-                <td>
-                  <label class="domain">
-                    <span>Avgrensning</span>
-                    <input type="text" data-dom placeholder="[start, stopp]">
-                  </label>
-                </td>
-              </tr>
-              <tr class="glider-row">
-                <td>
-                  <label class="points">
-                    <span>Antall punkter på grafen</span>
-                    <select data-points>
-                      <option value="0">0</option>
-                      <option value="1">1</option>
-                      <option value="2">2</option>
-                    </select>
-                  </label>
-                </td>
-                <td>
-                  <label class="startx-label">
-                    <span>Startposisjon, x</span>
-                    <input type="text" data-startx value="1" placeholder="1">
-                  </label>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+        <div class="func-fields func-fields--first">
+          <div class="func-row func-row--main">
+            <label class="func-input">
+              <span>${titleLabel}</span>
+              <input type="text" data-fun>
+            </label>
+            <label class="domain">
+              <span>Avgrensning</span>
+              <input type="text" data-dom placeholder="[start, stopp]">
+            </label>
+          </div>
+          <div class="func-row func-row--gliders glider-row">
+            <label class="points">
+              <span>Antall punkter på grafen</span>
+              <select data-points>
+                <option value="0">0</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+              </select>
+            </label>
+            <label class="startx-label">
+              <span>Startposisjon, x</span>
+              <input type="text" data-startx value="1" placeholder="1">
+            </label>
+          </div>
         </div>
       `;
     } else {


### PR DESCRIPTION
## Summary
- replace the first function controls markup with a div-based layout and dedicated glider wrapper
- restyle the function control fields with responsive grid utilities that collapse to one column on narrow screens

## Testing
- Manual check in browser

------
https://chatgpt.com/codex/tasks/task_e_68cd48a243e48324920351849b88f23b