### PR TITLE
Move allow wrong option to global settings

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -140,6 +140,10 @@
         <div class="card card--settings">
           <fieldset>
             <legend>Farger</legend>
+            <div class="checkbox-row">
+              <input id="allowWrong" type="checkbox" />
+              <label for="allowWrong">Tillat gale illustrasjoner</label>
+            </div>
             <label>Antall farger
               <input id="colorCount" type="number" min="1" max="6" value="1" />
             </label>


### PR DESCRIPTION
## Summary
- add the "Tillat gale illustrasjoner" checkbox to the global settings card with the color controls
- make the option a shared state across all figures and keep per-figure settings in sync with the global toggle

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd4b253aa08324a9bc0e343ecaf93d