### PR TITLE
Ensure splitter fills full height

### DIFF
--- a/split.css
+++ b/split.css
@@ -8,6 +8,8 @@
   position: relative;
   user-select: none;
   touch-action: none;
+  align-self: stretch;
+  min-height: 100%;
 }
 .grid.split-enabled > .splitter::before {
   content: "";


### PR DESCRIPTION
## Summary
- ensure the inserted splitter grid item stretches to fill the grid track vertically

## Testing
- npm start (manual check of perlesnor.html and diagram/index.html splitters)


------
https://chatgpt.com/codex/tasks/task_e_68cd4b987db88324b45aa36366e466b0