### PR TITLE
Align Brøkfigurer settings styling with other visualizations

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -105,9 +105,13 @@
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
     .btn:active{transform:translateY(1px)}
-    .figureSettings{display:grid;gap:var(--gap);grid-template-columns:repeat(var(--figure-settings-cols,1),minmax(0,1fr));align-items:stretch;}
+    .figureSettings{
+      display:grid;
+      gap:var(--gap);
+      grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+      align-items:start;
+    }
     .figureSettings fieldset{min-width:0;}
-    .checkbox-row{display:flex;align-items:center;gap:6px;}
     .colors{display:flex;flex-wrap:wrap;gap:6px;}
     .colors input{flex:0 0 40px;width:40px;height:40px;}
     .box svg *:focus{outline:none;}

--- a/brøkfigurer.js
+++ b/brøkfigurer.js
@@ -341,8 +341,10 @@
           <option value="triangular">trekantsrutenett</option>
         </select>
       </label>
-      <div class="checkbox-row"><input id="allowWrong${id}" type="checkbox" />
-        <label for="allowWrong${id}">Tillat gale illustrasjoner</label></div>
+      <label class="checkbox">
+        <input id="allowWrong${id}" type="checkbox" />
+        <span>Tillat gale illustrasjoner</span>
+      </label>
     `;
     return fieldset;
   }
@@ -353,7 +355,6 @@
       gridEl.dataset.rows = String(rows);
       gridEl.style.setProperty('--figure-rows', String(rows));
     }
-    if (settingsContainer) settingsContainer.style.setProperty('--figure-settings-cols', String(cols));
     if (addRowBtn) addRowBtn.style.display = rows >= MAX_ROWS ? 'none' : '';
     if (removeRowBtn) removeRowBtn.style.display = rows <= MIN_DIMENSION ? 'none' : '';
     if (addColumnBtn) addColumnBtn.style.display = cols >= MAX_COLS ? 'none' : '';


### PR DESCRIPTION
## Summary
- adjust the figure settings grid to use auto-fit columns so the layout matches other visualizations
- swap the wrong illustration checkbox markup to the shared checkbox styling for consistent appearance

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd4cbd24e48324ad5e4d97ccaa0812