### PR TITLE
Add combined arealmodell beta variant with menu updates

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="no">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Arealmodell (beta)</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <style>
+    :root { --gap: 18px; }
+    html,body { height: 100%; }
+    body {
+      margin: 0;
+      font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+      color: #111827;
+      background: #f7f8fb;
+      padding: 20px;
+    }
+    .wrap { max-width: 1200px; margin: 0 auto; display: flex; flex-direction: column; gap: var(--gap); }
+    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 360px; align-items: start; }
+    .side { display:flex; flex-direction:column; gap:var(--gap); }
+    @media (max-width:980px){ .grid { grid-template-columns: 1fr; } }
+    .card {
+      background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
+      box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 14px;
+      display: flex; flex-direction: column; gap: 10px;
+    }
+    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+    svg { width: 100%; height: auto; background: #fff; display: block; }
+    .settings { display: flex; flex-direction: column; gap: 10px; }
+    .toolbar { display:flex; gap:10px; justify-content:flex-start; align-items:center; flex-wrap:wrap; }
+    .btn { appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px; padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s; }
+    .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
+    .btn:active { transform:translateY(1px); }
+    .settings label { font-size: 13px; color: #4b5563; display: flex; flex-direction: column; }
+    .settings input,
+    .settings select { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; }
+    .settings .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
+    .settings .row label { flex: 0; }
+    .settings .row label input[type="number"] { width: 80px; }
+    .settings .row label.chk { flex: 0; flex-direction: row; align-items: center; }
+    .settings .row label.chk input { margin-right: 6px; }
+    .page-header { display: flex; flex-direction: column; gap: 6px; padding: 0 4px; }
+    .page-header h1 { margin: 0; font-size: 1.65rem; font-weight: 650; color: #1f2937; display: flex; align-items: center; gap: 10px; }
+    .page-header .tag { display: inline-flex; align-items: center; justify-content: center; padding: 2px 10px; border-radius: 999px; background: #f97316; color: #fff; font-size: 0.75rem; letter-spacing: 0.05em; text-transform: uppercase; font-weight: 600; }
+    .page-header p { margin: 0; font-size: 0.95rem; color: #4b5563; }
+  </style>
+  <link rel="stylesheet" href="split.css" />
+</head>
+<body>
+  <div class="wrap">
+    <header class="page-header">
+      <h1>Arealmodell <span class="tag">beta</span></h1>
+      <p>Velg hvor mange deler rektangelet skal ha, og tilpass lengde og høyde etter behov.</p>
+    </header>
+    <div class="grid">
+      <div class="card">
+        <svg id="area" preserveAspectRatio="xMidYMid meet" aria-label="Arealmodell"></svg>
+      </div>
+      <div class="side">
+        <div class="card card--examples">
+          <div class="toolbar">
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+          </div>
+        </div>
+        <div class="card card--settings">
+          <div class="settings">
+            <div class="row">
+              <label>Lengde
+                <input id="length" type="number" value="12" min="1">
+              </label>
+              <label>Startposisjon
+                <input id="lengthStart" type="number" value="6" min="0">
+              </label>
+              <label class="chk"><input id="showLengthHandle" type="checkbox" checked> Vis håndtak</label>
+            </div>
+            <div class="row">
+              <label>Høyde
+                <input id="height" type="number" value="12" min="1">
+              </label>
+              <label>Startposisjon
+                <input id="heightStart" type="number" value="6" min="0">
+              </label>
+              <label class="chk"><input id="showHeightHandle" type="checkbox" checked> Vis håndtak</label>
+            </div>
+            <div class="row">
+              <label>Oppdeling
+                <select id="layoutMode">
+                  <option value="single">1 rektangel</option>
+                  <option value="horizontal">2 ved siden av hverandre</option>
+                  <option value="vertical">2 over hverandre</option>
+                  <option value="quad">4 rektangler (2 × 2)</option>
+                </select>
+              </label>
+            </div>
+            <div class="row">
+              <label class="chk"><input id="grid" type="checkbox" checked> Vis rutenett</label>
+              <label class="chk"><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
+            </div>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Eksporter</h2>
+          <div class="toolbar">
+            <button id="btnSvgStatic" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSvg" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="arealmodellen1.js"></script>
+  <script src="examples.js"></script>
+  <script src="split.js"></script>
+</body>
+</html>

--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -113,10 +113,30 @@ function ensureCfgDefaults() {
 }
 function normalizeLayout(value) {
   if (typeof value !== "string") return "quad";
-  return value === "horizontal" || value === "vertical" ? value : "quad";
+  if (value === "single" || value === "horizontal" || value === "vertical" || value === "quad") {
+    return value;
+  }
+  return "quad";
 }
 function computeLayoutState(layout, width, height, cols, rows, sx, sy, unit) {
   const mode = normalizeLayout(layout);
+  if (mode === "single") {
+    return {
+      mode,
+      leftWidth: width,
+      rightWidth: 0,
+      bottomHeight: 0,
+      topHeight: height,
+      leftCols: cols,
+      rightCols: 0,
+      bottomRows: 0,
+      topRows: rows,
+      showTopLeft: true,
+      showTopRight: false,
+      showBottomLeft: false,
+      showBottomRight: false
+    };
+  }
   const effectiveSx = mode === "vertical" ? width : sx;
   const effectiveSy = mode === "horizontal" ? 0 : sy;
   const leftWidth = Math.max(0, Math.min(width, effectiveSx));
@@ -211,19 +231,19 @@ function draw() {
   const clickToMove = ADV.clickToMove !== false;
   const showHeightAxis = layoutMode !== "horizontal" && ROWS > 1 && ((_SV$height2 = SV.height) === null || _SV$height2 === void 0 ? void 0 : _SV$height2.show) !== false;
   const showLengthAxis = layoutMode !== "vertical" && COLS > 1 && ((_SV$length2 = SV.length) === null || _SV$length2 === void 0 ? void 0 : _SV$length2.show) !== false;
-  const dragVertical = showHeightAxis && ((_ADV$drag = ADV.drag) === null || _ADV$drag === void 0 ? void 0 : _ADV$drag.vertical) !== false;
-  const dragHorizontal = showLengthAxis && ((_ADV$drag2 = ADV.drag) === null || _ADV$drag2 === void 0 ? void 0 : _ADV$drag2.horizontal) !== false;
+  const dragVertical = layoutMode !== "single" && showHeightAxis && ((_ADV$drag = ADV.drag) === null || _ADV$drag === void 0 ? void 0 : _ADV$drag.vertical) !== false;
+  const dragHorizontal = layoutMode !== "single" && showLengthAxis && ((_ADV$drag2 = ADV.drag) === null || _ADV$drag2 === void 0 ? void 0 : _ADV$drag2.horizontal) !== false;
   const splitLinesOn = ADV.splitLines !== false;
-  const showHLine = splitLinesOn && showHeightAxis;
-  const showVLine = splitLinesOn && showLengthAxis;
+  const showHLine = layoutMode !== "single" && splitLinesOn && showHeightAxis;
+  const showVLine = layoutMode !== "single" && splitLinesOn && showLengthAxis;
   const rawMinColsEachSide = (_ADV$limits$minColsEa = (_ADV$limits = ADV.limits) === null || _ADV$limits === void 0 ? void 0 : _ADV$limits.minColsEachSide) !== null && _ADV$limits$minColsEa !== void 0 ? _ADV$limits$minColsEa : 0;
   const rawMinRowsEachSide = (_ADV$limits$minRowsEa = (_ADV$limits2 = ADV.limits) === null || _ADV$limits2 === void 0 ? void 0 : _ADV$limits2.minRowsEachSide) !== null && _ADV$limits$minRowsEa !== void 0 ? _ADV$limits$minRowsEa : 0;
   const minColsEachSide = Math.max(0, Math.min(Math.floor(COLS / 2), Math.round(rawMinColsEachSide) || 0));
   const minRowsEachSide = Math.max(0, Math.min(Math.floor(ROWS / 2), Math.round(rawMinRowsEachSide) || 0));
   const initLeftCols = (_SV$length$handle = (_SV$length3 = SV.length) === null || _SV$length3 === void 0 ? void 0 : _SV$length3.handle) !== null && _SV$length$handle !== void 0 ? _SV$length$handle : Math.floor(COLS / 2);
   const initBottomRows = (_SV$height$handle = (_SV$height3 = SV.height) === null || _SV$height3 === void 0 ? void 0 : _SV$height3.handle) !== null && _SV$height$handle !== void 0 ? _SV$height$handle : Math.floor(ROWS / 2);
-  const showLeftHandle = showHeightAxis && ((_SV$height4 = SV.height) === null || _SV$height4 === void 0 ? void 0 : _SV$height4.showHandle) !== false;
-  const showBottomHandle = showLengthAxis && ((_SV$length4 = SV.length) === null || _SV$length4 === void 0 ? void 0 : _SV$length4.showHandle) !== false;
+  const showLeftHandle = layoutMode !== "single" && showHeightAxis && ((_SV$height4 = SV.height) === null || _SV$height4 === void 0 ? void 0 : _SV$height4.showHandle) !== false;
+  const showBottomHandle = layoutMode !== "single" && showLengthAxis && ((_SV$length4 = SV.length) === null || _SV$length4 === void 0 ? void 0 : _SV$length4.showHandle) !== false;
 
   // helpers
   const NS = "http://www.w3.org/2000/svg";
@@ -254,8 +274,8 @@ function draw() {
   function syncSimpleHandles() {
     const leftCols = Math.round(sx / UNIT);
     const bottomRows = Math.round(sy / UNIT);
-    const syncLength = layoutMode !== "vertical";
-    const syncHeight = layoutMode !== "horizontal";
+    const syncLength = layoutMode !== "vertical" && layoutMode !== "single";
+    const syncHeight = layoutMode !== "horizontal" && layoutMode !== "single";
     if (syncLength) {
       if (leftCols !== lastSyncedLeft) {
         lastSyncedLeft = leftCols;
@@ -1329,6 +1349,8 @@ function setSimpleConfig(o = {}) {
   render();
 }
 window.setArealmodellBConfig = setSimpleConfig;
+window.setArealmodellConfig = setSimpleConfig;
+window.setArealmodellBetaConfig = setSimpleConfig;
 function applyConfigToInputs() {
   var _simple$length, _simple$length2, _simple$length3, _simple$height, _simple$height2, _simple$height3;
   ensureCfgDefaults();

--- a/index.html
+++ b/index.html
@@ -204,27 +204,6 @@
         </a>
       </li>
       <li>
-        <a href="arealmodell0.html" target="content" title="Arealmodell A" aria-label="Arealmodell A">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <rect x="3" y="6" width="18" height="12" />
-            <path stroke-linecap="round" d="M9 6v12M15 6v12M3 12h18" />
-            <circle cx="21" cy="5" r="1.5" />
-          </svg>
-          <span class="sr-only">Arealmodell A</span>
-        </a>
-      </li>
-      <li>
-        <a href="arealmodellen1.html" target="content" title="Arealmodell B" aria-label="Arealmodell B">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <rect x="3" y="4" width="18" height="15" />
-            <path d="M4.5 4v15M6 4v15M7.5 4v15M9 4v15M10.5 4v15M12 4v15M13.5 4v15M15 4v15M16.5 4v15M18 4v15M19.5 4v15" />
-            <path d="M3 5h18M3 6h18M3 7h18M3 8h18M3 9h18M3 10h18M3 11h18M3 12h18M3 13h18M3 14h18M3 15h18M3 16h18M3 17h18M3 18h18" />
-            <path stroke-linecap="round" stroke-linejoin="round" d="M21 11.5l2 1.5-2 1.5" />
-          </svg>
-          <span class="sr-only">Arealmodell B</span>
-        </a>
-      </li>
-      <li>
         <a href="perlesnor.html" target="content" title="Perlesnor" aria-label="Perlesnor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M2 12h20" />
@@ -303,6 +282,42 @@
           </svg>
           <span class="sr-only">Fortegnsskjema</span>
           <span class="nav-badge" aria-hidden="true">Beta</span>
+        </a>
+      </li>
+      <li>
+        <a href="arealmodell.html" target="content" title="Arealmodell (beta)" aria-label="Arealmodell (beta)">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <rect x="4" y="5" width="16" height="14" rx="1.8" stroke="currentColor" stroke-width="1.4" />
+            <rect x="4.5" y="5.5" width="7" height="6" fill="currentColor" fill-opacity=".15" stroke="none" />
+            <rect x="12.5" y="5.5" width="7" height="6" fill="currentColor" fill-opacity=".28" stroke="none" />
+            <rect x="4.5" y="12.5" width="7" height="6" fill="currentColor" fill-opacity=".4" stroke="none" />
+            <rect x="12.5" y="12.5" width="7" height="6" fill="currentColor" fill-opacity=".55" stroke="none" />
+            <line x1="12" y1="5" x2="12" y2="19" stroke-linecap="round" stroke-width="1.2" />
+            <line x1="4" y1="12" x2="20" y2="12" stroke-linecap="round" stroke-width="1.2" />
+          </svg>
+          <span class="sr-only">Arealmodell (beta)</span>
+          <span class="nav-badge" aria-hidden="true">Beta</span>
+        </a>
+      </li>
+      <li>
+        <a href="arealmodell0.html" target="content" title="Arealmodell A" aria-label="Arealmodell A">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <rect x="3" y="6" width="18" height="12" />
+            <path stroke-linecap="round" d="M9 6v12M15 6v12M3 12h18" />
+            <circle cx="21" cy="5" r="1.5" />
+          </svg>
+          <span class="sr-only">Arealmodell A</span>
+        </a>
+      </li>
+      <li>
+        <a href="arealmodellen1.html" target="content" title="Arealmodell B" aria-label="Arealmodell B">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <rect x="3" y="4" width="18" height="15" />
+            <path d="M4.5 4v15M6 4v15M7.5 4v15M9 4v15M10.5 4v15M12 4v15M13.5 4v15M15 4v15M16.5 4v15M18 4v15M19.5 4v15" />
+            <path d="M3 5h18M3 6h18M3 7h18M3 8h18M3 9h18M3 10h18M3 11h18M3 12h18M3 13h18M3 14h18M3 15h18M3 16h18M3 17h18M3 18h18" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21 11.5l2 1.5-2 1.5" />
+          </svg>
+          <span class="sr-only">Arealmodell B</span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
## Summary
- add a new Arealmodell (beta) page that lets users pick between 1, 2 or 4 delinger while reusing the existing controls and export tools
- extend the shared Arealmodell script to support the new "single" layout and hide split handles when they are not needed
- move the Arealmodell links to the end of the main menu and add an entry for the beta variant

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd5c46d7108324855139381044497d