### PR TITLE
Allow rendering more than two shapes

### DIFF
--- a/nkant.html
+++ b/nkant.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Nkant – én SVG med 1–2 figurer</title>
+  <title>Nkant – én SVG med flere figurer</title>
   <style>
     :root { --gap: 18px; }
     html,body { height: 100%; }
@@ -57,7 +57,7 @@
 
         <div class="card card--settings">
 
-        <label for="inpSpecs">Skriv spesifikasjoner eller fritekst (1–2 linjer per figur)</label>
+        <label for="inpSpecs">Skriv spesifikasjoner eller fritekst (én linje per figur)</label>
         <div class="specs-row">
           <textarea id="inpSpecs" rows="4" spellcheck="false">a=5, b=5, c=5, d=5, B=90
 Rettvinklet trekant</textarea>
@@ -175,6 +175,7 @@ Rettvinklet trekant</textarea>
 
           <!-- Figur 2 -->
           <div class="legend">Figur 2</div>
+          <div class="small">Figur 3 og videre bruker innstillingene nedenfor.</div>
         <div class="form-row">
           <div>
             <label>Standard sider</label>

--- a/nkant.js
+++ b/nkant.js
@@ -976,10 +976,6 @@ async function collectJobsFromSpecs(text) {
       newLines.push("");
       continue;
     }
-    if (jobs.length >= 2) {
-      newLines.push(line);
-      continue;
-    }
     const obj = await parseSpecAI(line);
     if (Object.keys(obj).length === 0) {
       newLines.push(line);
@@ -1117,60 +1113,29 @@ async function renderCombined() {
       y: 40,
       fill: "#6b7280",
       "font-size": 18
-    }).textContent = "Skriv 1–2 SPECS- eller tekstlinjer for å tegne figur(er).";
+    }).textContent = "Skriv én linje per figur for å tegne.";
     svg.setAttribute("aria-label", "");
     return;
   }
-  let totalW = BASE_W,
-    totalH = BASE_H;
-  if (n === 1) {
-    totalW = BASE_W;
-    totalH = BASE_H;
-  } else if (STATE.layout === "row") {
-    totalW = BASE_W * 2 + GAP;
-    totalH = BASE_H;
-  } else {
-    totalW = BASE_W;
-    totalH = BASE_H * 2 + GAP;
-  }
+  const gapTotal = Math.max(0, n - 1) * GAP;
+  const rowLayout = n === 1 ? true : STATE.layout === "row";
+  const totalW = rowLayout ? BASE_W * n + gapTotal : BASE_W;
+  const totalH = rowLayout ? BASE_H : BASE_H * n + gapTotal;
   svg.setAttribute("viewBox", `0 0 ${totalW} ${totalH}`);
-  const groups = [];
-  for (let i = 0; i < n; i++) groups.push(add(svg, "g", {}));
-  const rects = [];
-  if (n === 1) {
-    rects.push({
-      x: 0,
-      y: 0,
-      w: BASE_W,
-      h: BASE_H
-    });
-  } else if (STATE.layout === "row") {
-    rects.push({
-      x: 0,
-      y: 0,
-      w: BASE_W,
-      h: BASE_H
-    });
-    rects.push({
-      x: BASE_W + GAP,
-      y: 0,
-      w: BASE_W,
-      h: BASE_H
-    });
-  } else {
-    rects.push({
-      x: 0,
-      y: 0,
-      w: BASE_W,
-      h: BASE_H
-    });
-    rects.push({
-      x: 0,
-      y: BASE_H + GAP,
-      w: BASE_W,
-      h: BASE_H
-    });
-  }
+  const groups = Array.from({
+    length: n
+  }, () => add(svg, "g", {}));
+  const rects = groups.map((_, i) => rowLayout ? {
+    x: i * (BASE_W + GAP),
+    y: 0,
+    w: BASE_W,
+    h: BASE_H
+  } : {
+    x: 0,
+    y: i * (BASE_H + GAP),
+    w: BASE_W,
+    h: BASE_H
+  });
   for (let i = 0; i < n; i++) {
     const {
       type,
@@ -1183,7 +1148,7 @@ async function renderCombined() {
       errorBox(groups[i], rects[i], String(e.message || e));
     }
   }
-  svg.setAttribute("aria-label", n === 1 ? "Én figur" : "To figurer i samme bilde");
+  svg.setAttribute("aria-label", n === 1 ? "Én figur" : `${n} figurer i samme bilde`);
 }
 
 /* ---------- UI BIND ---------- */


### PR DESCRIPTION
## Summary
- allow the nkant tool to collect and render an arbitrary number of shape specifications
- generalize SVG layout calculations so any number of figures can be arranged horizontally or vertically
- tweak the UI copy to reflect multi-figure support and explain how later figures reuse the second figure settings

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd66dae0708324aa833d02625b2b0d