### PR TITLE
Improve point list drag responsiveness

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -180,6 +180,17 @@
     .point-item.is-dragging { opacity: .6; }
     .point-item.drop-before { box-shadow: inset 0 3px 0 #2563eb; }
     .point-item.drop-after { box-shadow: inset 0 -3px 0 #2563eb; }
+    .point-placeholder {
+      border-style: dashed;
+      border-color: #93c5fd;
+      background: rgba(37,99,235,.08);
+      color: #2563eb;
+      gap: 0;
+      justify-content: center;
+      font-size: 13px;
+      font-weight: 500;
+    }
+    .point-placeholder-label { pointer-events: none; }
     .point-handle {
       appearance: none;
       border: none;


### PR DESCRIPTION
## Summary
- show a live placeholder while dragging point entries so the list rearranges immediately
- add styling and state handling to keep the drag operation responsive and accessible

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd69a8e0148324827813baf3985df6