### PR TITLE
Reduce sign segment stroke width

### DIFF
--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -753,7 +753,7 @@
           x2: endX,
           y2: y,
           stroke: sign > 0 ? '#111827' : '#dc2626',
-          'stroke-width': 6,
+          'stroke-width': 3,
           'stroke-linecap': 'round',
           'data-row-id': row.id,
           'data-index': i,


### PR DESCRIPTION
## Summary
- halve the stroke width used for sign segments in fortegnsskjema so the lines appear thinner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd70251f2483249470234415f1a852