### PR TITLE
Shorten single-digit number inputs

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -109,6 +109,7 @@
     .figureSettings fieldset{min-width:0;}
     .colors{display:flex;flex-wrap:wrap;gap:6px;}
     .colors input{flex:0 0 40px;width:40px;height:40px;}
+    .input--digit{width:60px;padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;box-sizing:border-box;text-align:center;}
     .box svg *:focus{outline:none;}
   </style>
   <link rel="stylesheet" href="split.css" />
@@ -141,7 +142,7 @@
             <legend>Farger</legend>
             <label class="checkbox"><input id="allowWrong" type="checkbox" /> <span>Tillat gale illustrasjoner</span></label>
             <label>Antall farger
-              <input id="colorCount" type="number" min="1" max="6" value="1" />
+              <input id="colorCount" class="input--digit" type="number" min="1" max="6" value="1" />
             </label>
             <div class="colors">
               <input id="color_1" type="color" value="#6C1BA2" />

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -61,6 +61,16 @@
       width: 100%;
       box-sizing: border-box;
     }
+    .input--digit {
+      width: 60px;
+      padding: 8px 10px;
+      border: 1px solid #d1d5db;
+      border-radius: 10px;
+      font-size: 14px;
+      background: #fff;
+      box-sizing: border-box;
+      text-align: center;
+    }
     input[type="range"] {
       width: 100%;
       accent-color: #3b82f6;
@@ -236,10 +246,10 @@
             </label>
             <div class="settingsGrid">
               <label for="decimalDigits">Desimaler (desimaltall)
-                <input id="decimalDigits" type="number" min="0" max="4" value="3" />
+                <input id="decimalDigits" class="input--digit" type="number" min="0" max="4" value="3" />
               </label>
               <label for="percentDigits">Desimaler (prosent)
-                <input id="percentDigits" type="number" min="0" max="3" value="1" />
+                <input id="percentDigits" class="input--digit" type="number" min="0" max="3" value="1" />
               </label>
             </div>
             <label class="checkbox"><input type="checkbox" id="trimTrailingZeros" /> <span>Fjern unødige nuller i prosent og desimaltall</span></label>

--- a/figurtall.html
+++ b/figurtall.html
@@ -67,6 +67,7 @@
     .card input[type="color"]{width:40px;height:40px;padding:0;border:none;}
     .colors{display:flex;flex-wrap:wrap;gap:6px;}
     .colors input{flex:0 0 40px;width:40px;height:40px;}
+    .input--digit{width:60px;padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;box-sizing:border-box;text-align:center;}
     .figure{
       border-radius:10px;
       background:#fff;
@@ -188,7 +189,7 @@
           <fieldset>
             <legend>Farger</legend>
             <label>Antall farger
-              <input id="colorCount" type="number" min="1" max="6" value="1" />
+              <input id="colorCount" class="input--digit" type="number" min="1" max="6" value="1" />
             </label>
             <div class="colors">
               <input id="color_1" type="color" value="#6C1BA2" />


### PR DESCRIPTION
## Summary
- add a reusable `.input--digit` style to create compact single-digit number fields
- use the compact input styling for the decimal/percent digit selectors and color-count controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd94610b5c83248fa57d17106bf0b6