### PR TITLE
Format point coordinates with parentheses

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -226,8 +226,9 @@
       box-sizing: border-box;
     }
     .point-input--coord {
-      flex: 0 1 120px;
-      max-width: 130px;
+      flex: 0 0 auto;
+      width: 11ch;
+      max-width: 11ch;
       font-variant-numeric: tabular-nums;
     }
     .point-input--label { flex: 2 1 180px; }

--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -229,8 +229,8 @@
   }
 
   function coordinateString(point) {
-    if (!point) return '0, 0';
-    return `${percentString(point.x)}, ${percentString(point.y)}`;
+    if (!point) return '(0, 0)';
+    return `(${percentString(point.x)}, ${percentString(point.y)})`;
   }
 
   function parseCoordinateInput(value) {
@@ -707,7 +707,7 @@
       coordInput.type = 'text';
       coordInput.inputMode = 'decimal';
       coordInput.className = 'point-input point-input--coord';
-      coordInput.placeholder = '50, 50';
+      coordInput.placeholder = '(50, 50)';
       coordInput.setAttribute('aria-label', 'Koordinat (x,y)');
       coordInput.value = coordinateString(point);
       const commitCoordChange = () => {


### PR DESCRIPTION
## Summary
- format displayed point coordinates with surrounding parentheses to match requested style
- adjust coordinate input placeholders to show the new format
- narrow the coordinate input width so it fits the parenthesized coordinates closely

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdbd3ecb30832491ef3cc64653541b