### PR TITLE
Add decimal places setting for fortegnsskjema

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -322,6 +322,10 @@
               <span>Maks x-verdi</span>
               <input id="domainMax" type="number" step="0.1" autocomplete="off">
             </label>
+            <label>
+              <span>Antall desimaler</span>
+              <input id="decimalPlaces" type="number" min="0" max="6" step="1" value="4" autocomplete="off">
+            </label>
           </div>
           <div class="note">Området settes automatisk ut fra punktene. Skriv egne verdier for å overstyre, eller tøm feltet for å
             bruke auto.</div>


### PR DESCRIPTION
## Summary
- add an "Antall desimaler" control to the fortegnsskjema settings panel
- store the desired precision in component state and format displayed values accordingly
- align number input step sizes with the selected precision for domain and point editors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce8515ca308324bc941b246078f210