### PR TITLE
Allow manual entry of sign chart zeros

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -96,19 +96,46 @@
     .chart-overlay__value {
       position: absolute;
       transform: translate(-50%, -120%);
-      min-width: 48px;
-      padding: 6px 12px;
-      border-radius: 999px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 0;
+      padding: 4px;
+      border-radius: 10px;
       border: 1px solid rgba(203, 213, 245, 0.7);
       background: rgba(255, 255, 255, 0.95);
       box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
-      font-size: 16px;
-      font-weight: 600;
-      text-align: center;
-      color: #1f2937;
       pointer-events: auto;
       cursor: ew-resize;
-      user-select: none;
+      gap: 4px;
+    }
+    .chart-overlay__value input[type="number"] {
+      width: 3.2ch;
+      min-width: 0;
+    }
+    .chart-overlay__value-input {
+      padding: 2px 4px;
+      border-radius: 6px;
+      border: 1px solid #d1d5db;
+      background: rgba(255, 255, 255, 0.95);
+      font-size: 14px;
+      font-weight: 600;
+      color: #1f2937;
+      text-align: center;
+      box-shadow: none;
+    }
+    .chart-overlay__value-input:focus {
+      outline: 2px solid rgba(59, 130, 246, 0.35);
+      outline-offset: 1px;
+    }
+    .chart-overlay__value-input::-webkit-outer-spin-button,
+    .chart-overlay__value-input::-webkit-inner-spin-button {
+      margin: 0;
+    }
+    .chart-overlay__value-input {
+      -moz-appearance: textfield;
+      appearance: textfield;
+      cursor: text;
     }
     .domain-controls {
       display: flex;

--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -821,16 +821,50 @@
       if (overlay) {
         const valueBadge = document.createElement('div');
         valueBadge.className = 'chart-overlay__value';
-        valueBadge.textContent = formatPointValue(point.value);
         valueBadge.style.left = `${px}px`;
         valueBadge.style.top = `${arrowY}px`;
         valueBadge.dataset.pointId = point.id;
-        valueBadge.setAttribute('aria-label', point.type === 'pole' ? 'x-verdi for pol' : 'x-verdi for nullpunkt');
+        const valueInput = document.createElement('input');
+        valueInput.type = 'number';
+        valueInput.className = 'chart-overlay__value-input';
+        valueInput.step = getNumberStep();
+        valueInput.value = formatPointValue(point.value);
+        valueInput.setAttribute('aria-label', point.type === 'pole' ? 'x-verdi for pol' : 'x-verdi for nullpunkt');
+        valueInput.addEventListener('focus', () => {
+          valueInput.select();
+        });
+        const commitInputValue = () => {
+          const raw = valueInput.value.trim().replace(',', '.');
+          if (raw === '') {
+            valueInput.value = formatPointValue(point.value);
+            return;
+          }
+          const value = Number.parseFloat(raw);
+          if (Number.isFinite(value)) {
+            setPointValue(point.id, value);
+          } else {
+            valueInput.value = formatPointValue(point.value);
+          }
+        };
+        valueInput.addEventListener('change', commitInputValue);
+        valueInput.addEventListener('keydown', event => {
+          if (event.key === 'Enter') {
+            commitInputValue();
+            valueInput.blur();
+          } else if (event.key === 'Escape') {
+            valueInput.value = formatPointValue(point.value);
+            valueInput.blur();
+          }
+        });
         valueBadge.addEventListener('pointerdown', event => {
           if (event.button !== 0) return;
+          if (event.target === valueInput) {
+            return;
+          }
           event.preventDefault();
           startDragging(point.id, event.pointerId, false);
         });
+        valueBadge.appendChild(valueInput);
         overlay.appendChild(valueBadge);
       }
     });


### PR DESCRIPTION
## Summary
- replace the draggable value badge with a compact number input so critical points can be typed in addition to being dragged
- keep the overlay draggable outside the input while synchronising updates across the chart and point list
- tighten the overlay styling to only leave room for a two-digit entry field

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce8909cfa88324a2454ed5cd278ce4