### PR TITLE
Update operator labels and hide unused operator inputs in brøkpizza

### DIFF
--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -42,6 +42,7 @@
     .checkbox-row { display:flex; align-items:center; gap:6px; }
     .field-row { display:flex; gap:10px; flex-wrap:wrap; }
     .field-row .field { flex:1 1 140px; display:flex; flex-direction:column; gap:4px; }
+    .input-stack { display:flex; flex-direction:column; gap:4px; }
 
     /* Kontainer for pizzaer og tegn mellom dem */
     .grid2 {
@@ -211,7 +212,7 @@
             <div class="checkbox-row"><input id="p1LockN" type="checkbox"><label for="p1LockN">Lås nevner</label></div>
             <div class="checkbox-row"><input id="p1HideNVal" type="checkbox"><label for="p1HideNVal">Skjul n-verdi</label></div>
             <div class="checkbox-row"><input id="p1LockT" type="checkbox"><label for="p1LockT">Lås teller</label></div>
-            <label for="p1Text">Tekst</label>
+            <label for="p1Text">Tekst over brøk</label>
             <select id="p1Text">
               <option value="none">none</option>
               <option value="frac" selected>frac</option>
@@ -228,13 +229,15 @@
                 <input id="p1MaxN" type="number" value="24" min="1">
               </div>
             </div>
-            <label for="op1">Tegn</label>
-            <select id="op1">
-              <option value="">none</option>
-              <option value="+">+</option>
-              <option value="-">-</option>
-              <option value="=">=</option>
-            </select>
+            <div id="op1Wrapper" class="input-stack">
+              <label for="op1">Operator etter brøksirkel</label>
+              <select id="op1">
+                <option value="">none</option>
+                <option value="+">+</option>
+                <option value="-">-</option>
+                <option value="=">=</option>
+              </select>
+            </div>
           </fieldset>
 
           <fieldset id="fieldset2" style="display:none">
@@ -252,7 +255,7 @@
             <div class="checkbox-row"><input id="p2LockN" type="checkbox" checked><label for="p2LockN">Lås nevner</label></div>
             <div class="checkbox-row"><input id="p2HideNVal" type="checkbox"><label for="p2HideNVal">Skjul n-verdi</label></div>
             <div class="checkbox-row"><input id="p2LockT" type="checkbox"><label for="p2LockT">Lås teller</label></div>
-            <label for="p2Text">Tekst</label>
+            <label for="p2Text">Tekst over brøk</label>
             <select id="p2Text">
               <option value="none">none</option>
               <option value="frac">frac</option>
@@ -269,13 +272,15 @@
                 <input id="p2MaxN" type="number" value="24" min="1">
               </div>
             </div>
-            <label for="op2">Tegn</label>
-            <select id="op2">
-              <option value="">none</option>
-              <option value="+">+</option>
-              <option value="-">-</option>
-              <option value="=">=</option>
-            </select>
+            <div id="op2Wrapper" class="input-stack">
+              <label for="op2">Operator etter brøksirkel</label>
+              <select id="op2">
+                <option value="">none</option>
+                <option value="+">+</option>
+                <option value="-">-</option>
+                <option value="=">=</option>
+              </select>
+            </div>
           </fieldset>
 
           <fieldset id="fieldset3" style="display:none">
@@ -293,7 +298,7 @@
             <div class="checkbox-row"><input id="p3LockN" type="checkbox"><label for="p3LockN">Lås nevner</label></div>
             <div class="checkbox-row"><input id="p3HideNVal" type="checkbox"><label for="p3HideNVal">Skjul n-verdi</label></div>
             <div class="checkbox-row"><input id="p3LockT" type="checkbox"><label for="p3LockT">Lås teller</label></div>
-            <label for="p3Text">Tekst</label>
+            <label for="p3Text">Tekst over brøk</label>
             <select id="p3Text">
               <option value="none">none</option>
               <option value="frac">frac</option>

--- a/brøkpizza.js
+++ b/brøkpizza.js
@@ -32,8 +32,15 @@ function readConfigFromHtml() {
   }
   const ops = [];
   for (let i = 1; i <= 2; i++) {
-    var _document$getElementB11;
-    const op = ((_document$getElementB11 = document.getElementById(`op${i}`)) === null || _document$getElementB11 === void 0 ? void 0 : _document$getElementB11.value) || "";
+    const rightPanel = document.getElementById(`panel${i + 1}`);
+    const hasRightPizza = !!(rightPanel && rightPanel.style.display !== "none");
+    const select = document.getElementById(`op${i}`);
+    let op = "";
+    if (hasRightPizza) {
+      op = (select === null || select === void 0 ? void 0 : select.value) || "";
+    } else if (select) {
+      select.value = "";
+    }
     ops.push(op);
   }
   return {
@@ -1123,14 +1130,19 @@ function initFromHtml() {
     });
   });
   cfg.ops.forEach((op, i) => {
-    const el = document.getElementById(`opDisplay${i + 1}`);
+    const displayEl = document.getElementById(`opDisplay${i + 1}`);
     const nextPanel = document.getElementById(`panel${i + 2}`);
-    if (!el) return;
-    if (op && nextPanel && nextPanel.style.display !== "none") {
-      el.textContent = op;
-      el.style.display = "";
+    const wrapper = document.getElementById(`op${i + 1}Wrapper`);
+    const select = document.getElementById(`op${i + 1}`);
+    const hasRightPizza = !!(nextPanel && nextPanel.style.display !== "none");
+    if (wrapper) wrapper.style.display = hasRightPizza ? "" : "none";
+    if (!hasRightPizza && select) select.value = "";
+    if (!displayEl) return;
+    if (op && hasRightPizza) {
+      displayEl.textContent = op;
+      displayEl.style.display = "";
     } else {
-      el.style.display = "none";
+      displayEl.style.display = "none";
     }
   });
   scheduleCenterAlign();
@@ -1231,7 +1243,17 @@ function applySimpleConfigToInputs() {
     if (textSel && cfg.text) textSel.value = cfg.text;
   }
   ops.forEach((op, idx) => {
-    setVal(`op${idx + 1}`, op !== null && op !== void 0 ? op : "");
+    const wrapper = document.getElementById(`op${idx + 1}Wrapper`);
+    const selectId = `op${idx + 1}`;
+    const select = document.getElementById(selectId);
+    const rightPanel = document.getElementById(`panel${idx + 2}`);
+    const shouldShow = !!(rightPanel && rightPanel.style.display !== "none");
+    if (wrapper) wrapper.style.display = shouldShow ? "" : "none";
+    if (shouldShow) {
+      setVal(selectId, op !== null && op !== void 0 ? op : "");
+    } else if (select) {
+      select.value = "";
+    }
   });
 }
 function applyExamplesConfig() {


### PR DESCRIPTION
## Summary
- rename the fraction text labels to "Tekst over brøk" and operator labels to "Operator etter brøksirkel"
- wrap operator selects in a container that is hidden when no pizza appears to the right
- ensure configuration logic clears hidden operator values and keeps displays in sync

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce8d9894788324ad08f22c5a8150e6