### PR TITLE
Adjust area model settings layout

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -35,7 +35,12 @@
     .settings input,
     .settings select { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; }
     .settings .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
+    .settings .row.row--global { align-items: center; justify-content: space-between; }
+    .settings .row.row--handles,
+    .settings .row.row--checkboxes { align-items: center; }
     .settings .row label { flex: 0; }
+    .settings .row label.label--grow { flex: 1 1 220px; min-width: 200px; }
+    .settings .row label.label--grow select { width: 100%; }
     .settings .row label input[type="number"] { width: 80px; }
     .settings .row label.chk { flex: 0; flex-direction: row; align-items: center; }
     .settings .row label.chk input { margin-right: 6px; }
@@ -65,45 +70,45 @@
         </div>
         <div class="card card--settings">
           <div class="settings">
-            <div class="row">
-              <label>Oppdeling
+            <div class="row row--global">
+              <label class="label--grow">Type
                 <select id="layoutMode">
                   <option value="single">1 rektangel</option>
-                  <option value="horizontal">2 ved siden av hverandre</option>
-                  <option value="vertical">2 over hverandre</option>
-                  <option value="quad">4 rektangler (2 × 2)</option>
+                  <option value="vertical">2 rektangler horisontaldelt</option>
+                  <option value="horizontal">2 rektangler vertikaldelt</option>
+                  <option value="quad">4 rektangler</option>
                 </select>
               </label>
+              <label class="chk"><input id="grid" type="checkbox" checked> Vis rutenett</label>
             </div>
             <div class="row">
               <label>Lengde
                 <input id="length" type="number" value="12" min="1">
               </label>
-              <label>Startposisjon
+              <label id="lengthStartWrap">Startposisjon
                 <input id="lengthStart" type="number" value="6" min="0">
               </label>
-              <label>Maks lengde
+              <label id="lengthMaxWrap" hidden>Maks lengde
                 <input id="lengthMax" type="number" value="30" min="1">
               </label>
-              <label class="chk"><input id="showLengthHandle" type="checkbox" checked> Vis håndtak</label>
             </div>
             <div class="row">
               <label>Høyde
                 <input id="height" type="number" value="12" min="1">
               </label>
-              <label>Startposisjon
+              <label id="heightStartWrap">Startposisjon
                 <input id="heightStart" type="number" value="6" min="0">
               </label>
-              <label>Maks høyde
+              <label id="heightMaxWrap" hidden>Maks høyde
                 <input id="heightMax" type="number" value="30" min="1">
               </label>
-              <label class="chk"><input id="showHeightHandle" type="checkbox" checked> Vis håndtak</label>
             </div>
-            <div class="row">
-              <label class="chk"><input id="grid" type="checkbox" checked> Vis rutenett</label>
+            <div class="row row--handles">
+              <label class="chk"><input id="showLengthHandle" type="checkbox" checked> Lengde-håndtak</label>
+              <label class="chk"><input id="showHeightHandle" type="checkbox" checked> Høyde-håndtak</label>
+            </div>
+            <div class="row row--checkboxes">
               <label class="chk"><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
-            </div>
-            <div class="row">
               <label class="chk"><input id="showTotalHandle" type="checkbox"> Totalareal-håndtak</label>
             </div>
           </div>

--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -173,6 +173,32 @@ function computeLayoutState(layout, width, height, cols, rows, sx, sy, unit) {
     showBottomRight: mode === "quad" && hasRight && hasBottom
   };
 }
+function updateLayoutUi() {
+  if (typeof document === "undefined") return;
+  const layoutSelect = document.getElementById("layoutMode");
+  if (!layoutSelect) return;
+  const layout = normalizeLayout(layoutSelect.value);
+  const isSingle = layout === "single";
+  const startWrapIds = ["lengthStartWrap", "heightStartWrap"];
+  const maxWrapIds = ["lengthMaxWrap", "heightMaxWrap"];
+  startWrapIds.forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.hidden = isSingle;
+  });
+  maxWrapIds.forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.hidden = !isSingle;
+  });
+}
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", updateLayoutUi, {
+      once: true
+    });
+  } else {
+    updateLayoutUi();
+  }
+}
 /* ========================================================= */
 
 function readConfigFromHtml() {
@@ -211,6 +237,7 @@ function readConfigFromHtml() {
   if (layoutSelect && layoutSelect.value) {
     CFG.SIMPLE.layout = normalizeLayout(layoutSelect.value);
   }
+  updateLayoutUi();
 }
 function draw() {
   var _SV$height$cells, _SV$height, _SV$length$cells, _SV$length, _ADV$check$ten, _ADV$check, _ADV$handleIcons$size, _ADV$handleIcons, _ADV$margins$l, _ADV$margins, _ADV$margins$r, _ADV$margins2, _ADV$margins$t, _ADV$margins3, _ADV$margins$b, _ADV$margins4, _ADV$classes$outer, _ADV$classes, _ADV$classes$grid, _ADV$classes2, _ADV$classes$split, _ADV$classes3, _ADV$classes$handle, _ADV$classes4, _ADV$classes$labelCel, _ADV$classes5, _ADV$classes$labelEdg, _ADV$classes6, _ADV$classes$cells, _ADV$classes7, _SV$height2, _SV$length2, _ADV$drag, _ADV$drag2, _ADV$limits$minColsEa, _ADV$limits, _ADV$limits$minRowsEa, _ADV$limits2, _SV$length$handle, _SV$length3, _SV$height$handle, _SV$height3, _SV$height4, _SV$length4, _ADV$handleIcons$hori, _ADV$handleIcons2, _ADV$handleIcons$vert, _ADV$handleIcons3, _ADV$fit$maxVh, _ADV$fit, _ADV$labels$dot, _ADV$labels, _ADV$labels$equals, _ADV$labels2, _ADV$labels$edgeMode, _ADV$labels3, _ADV$labels$cellMode, _ADV$labels4, _SV$totalHandle;
@@ -1773,6 +1800,7 @@ function applyConfigToInputs() {
   setChk('grid', !!adv.grid);
   setChk('splitLines', adv.splitLines !== false);
   setSelect('layoutMode', normalizeLayout(simple.layout));
+  updateLayoutUi();
 }
 function applyExamplesConfig() {
   ensureCfgDefaults();


### PR DESCRIPTION
## Summary
- reorganize the settings card so the global type selector and grid toggle sit together and use the requested option labels
- show the appropriate length and height companions (start or max) depending on the selected layout and rename the handle toggles
- add a small helper that keeps the UI in sync with the chosen layout from both user interaction and programmatic updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceb0b7af9883249fa448ff8c0a8904