### PR TITLE
Juster bredde for fortegnslinje-input

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -110,7 +110,7 @@
       gap: 4px;
     }
     .chart-overlay__value input[type="number"] {
-      width: 4.2ch;
+      width: 4.8ch;
       min-width: 0;
     }
     .chart-overlay__value-input {


### PR DESCRIPTION
## Summary
- enlarge the number input for fortegnslinjen markers so two-digit values fit comfortably

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cef7fbddd88324b737376796cf9830