### PR TITLE
Shrink label editor in prikk til prikk

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -327,28 +327,11 @@
       font-size: 13px;
       color: #6b7280;
     }
-    .point-label-editor {
-      display: flex;
-      flex-direction: column;
-      flex: 2 1 200px;
-      gap: 6px;
+    .point-input--label {
+      flex: 0 1 200px;
+      width: 100%;
+      max-width: 200px;
     }
-    .point-label-editor .point-input--label { width: 100%; }
-    .point-label-preview {
-      min-height: 20px;
-      font-size: 13px;
-      color: #1f2937;
-      padding: 2px 4px;
-      border-radius: 8px;
-      background: #f9fafb;
-      border: 1px solid #e5e7eb;
-    }
-    .point-label-preview:empty::before {
-      content: 'Forhåndsvisning';
-      color: #9ca3af;
-      font-style: italic;
-    }
-    .point-label-preview .katex { font-size: 1em; }
     .false-point-list {
       display: grid;
       gap: 6px;

--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -510,7 +510,6 @@
     if (!editor || !point) return;
     if (editor.labelInput) editor.labelInput.value = point.label;
     if (editor.coordInput) editor.coordInput.value = coordinateString(point);
-    if (editor.labelPreview) renderLatex(editor.labelPreview, getPointLabelText(point));
   }
 
   function updateLinesForPoint(pointId) {
@@ -901,9 +900,6 @@
       });
       item.appendChild(coordInput);
 
-      const labelWrapper = document.createElement('div');
-      labelWrapper.className = 'point-label-editor';
-
       const labelInput = document.createElement('input');
       labelInput.type = 'text';
       labelInput.className = 'point-input point-input--label';
@@ -917,17 +913,9 @@
           label.setText(getPointLabelText(point));
           label.setVisibility(STATE.showLabels);
         }
-        renderLatex(preview, getPointLabelText(point));
         updateFalsePointEditor(point);
       });
-
-      const preview = document.createElement('div');
-      preview.className = 'point-label-preview';
-      preview.setAttribute('aria-hidden', 'true');
-      renderLatex(preview, getPointLabelText(point));
-
-      labelWrapper.append(labelInput, preview);
-      item.appendChild(labelWrapper);
+      item.appendChild(labelInput);
 
       const removeBtn = document.createElement('button');
       removeBtn.type = 'button';
@@ -954,8 +942,7 @@
       pointEditors.set(point.id, {
         itemEl: item,
         coordInput,
-        labelInput,
-        labelPreview: preview
+        labelInput
       });
     });
     renderFalsePointList();
@@ -1021,7 +1008,6 @@
       if (editor.labelInput) editor.labelInput.value = point.label;
       if (editor.coordInput) editor.coordInput.value = coordinateString(point);
       if (editor.itemEl) editor.itemEl.dataset.pointId = point.id;
-      if (editor.labelPreview) renderLatex(editor.labelPreview, getPointLabelText(point));
     });
     updateFalsePointEditors();
   }


### PR DESCRIPTION
## Summary
- remove the live LaTeX preview from the point editor to reclaim space
- limit the label input width so the editor stays compact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cef86f689083248f2f5d9543934444