### PR TITLE
Add layer spacing control for Kvikkbilder bricks

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -177,8 +177,8 @@
               </label>
             </div>
             <div class="field-row field-row--two">
-              <label>Radavstand
-                <input id="cfg-klosser-rowGap" type="number" min="0" value="10">
+              <label>Lag-avstand i hver figur
+                <input id="cfg-klosser-layerGap" type="number" min="0" value="0">
               </label>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove the old row spacing configuration for Kvikkbilder bricks and default it to zero
- add a layer gap control for brick figures and update rendering to space layers vertically
- migrate existing configurations so stored rowGap values map to the new layerGap property

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cef9a0c9988324849323f8762ebf14