### PR TITLE
Organize Arealmodell Beta settings

### DIFF
--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -26,20 +26,31 @@
     }
     .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
     svg { width: 100%; height: auto; background: #fff; display: block; }
-    .settings { display: flex; flex-direction: column; gap: 10px; }
+    .settings { display: flex; flex-direction: column; gap: 16px; }
+    .settings-section { display:flex; flex-direction:column; gap:10px; }
+    .settings .section-title { margin: 4px 2px 0; font-size: 12px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: #6b7280; }
     .toolbar { display:flex; gap:10px; justify-content:flex-start; align-items:center; flex-wrap:wrap; }
     .btn { appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px; padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s; }
     .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
     .btn:active { transform:translateY(1px); }
     .settings label { font-size: 13px; color: #4b5563; display: flex; flex-direction: column; }
+    .settings .label--grow { flex: 1; }
+    .settings label.chk { flex-direction: row; align-items: center; }
+    .settings label.chk input { margin-right: 6px; }
     .settings input,
     .settings select { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; }
 
     .settings .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
     .settings .row label { flex: 0; }
     .settings .row label input[type="number"] { width: 80px; }
-    .settings .row label.chk { flex: 0; flex-direction: row; align-items: center; }
-    .settings .row label.chk input { margin-right: 6px; }
+    .settings .row label.chk { flex: 0; }
+
+    .settings .row--toggles { align-items: center; }
+    .settings .row--toggles label { flex: 1 1 150px; }
+    .settings .rect-table { display:flex; flex-direction:column; gap:10px; }
+    .settings .rect-row { display:grid; gap:10px; grid-template-columns: repeat(4, minmax(0, 1fr)); align-items:end; }
+    .settings .rect-row label { min-width: 0; }
+    .settings .rect-row label.chk { justify-content: flex-start; align-items: center; }
 
     .c1 { fill: #e07c7c; }
     .c2 { fill: #f0c667; }
@@ -75,39 +86,52 @@
         </div>
         <div class="card card--settings">
           <div class="settings">
-            <div class="row">
-              <label>Lengde
-                <input id="length" type="number" value="17" min="1">
-              </label>
-              <label>Startposisjon
-                <input id="lengthStart" type="number" value="3" min="0">
-              </label>
-              <label class="chk"><input id="showLengthHandle" type="checkbox" checked> Vis håndtak</label>
+            <div class="settings-section">
+              <p class="section-title">Globale innstillinger</p>
+              <div class="row row--global">
+                <label class="label--grow">Type
+                  <select id="layoutMode">
+                    <option value="quad">4 rektangler (2 × 2)</option>
+                    <option value="horizontal">2 ved siden av hverandre</option>
+                    <option value="vertical">2 over hverandre</option>
+                  </select>
+                </label>
+                <label class="chk"><input id="grid" type="checkbox"> Vis rutenett</label>
+              </div>
+              <div class="row row--toggles">
+                <label class="chk"><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
+                <label class="chk"><input id="showExpressions" type="checkbox" checked> Vis regnestykker</label>
+                <label class="chk"><input id="showTotalHandle" type="checkbox"> Totalareal-håndtak</label>
+              </div>
             </div>
-            <div class="row">
-              <label>Høyde
-                <input id="height" type="number" value="16" min="1">
-              </label>
-              <label>Startposisjon
-                <input id="heightStart" type="number" value="5" min="0">
-              </label>
-              <label class="chk"><input id="showHeightHandle" type="checkbox" checked> Vis håndtak</label>
-            </div>
-            <div class="row">
-              <label>Oppdeling
-                <select id="layoutMode">
-                  <option value="quad">4 rektangler (2 × 2)</option>
-                  <option value="horizontal">2 ved siden av hverandre</option>
-                  <option value="vertical">2 over hverandre</option>
-                </select>
-              </label>
-            </div>
-            <div class="row">
-              <label class="chk"><input id="grid" type="checkbox"> Vis rutenett</label>
-              <label class="chk"><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
-            </div>
-            <div class="row">
-              <label class="chk"><input id="showTotalHandle" type="checkbox"> Totalareal-håndtak</label>
+            <div class="settings-section">
+              <p class="section-title">Rektangler</p>
+              <div class="rect-table">
+                <div class="rect-row">
+                  <label>Lengde
+                    <input id="length" type="number" value="17" min="1">
+                  </label>
+                  <label id="lengthStartWrap">Startposisjon
+                    <input id="lengthStart" type="number" value="3" min="0">
+                  </label>
+                  <label id="lengthMaxWrap" hidden>Maks lengde
+                    <input id="lengthMax" type="number" value="30" min="1">
+                  </label>
+                  <label class="chk"><input id="showLengthHandle" type="checkbox" checked> Håndtak</label>
+                </div>
+                <div class="rect-row">
+                  <label>Høyde
+                    <input id="height" type="number" value="16" min="1">
+                  </label>
+                  <label id="heightStartWrap">Startposisjon
+                    <input id="heightStart" type="number" value="5" min="0">
+                  </label>
+                  <label id="heightMaxWrap" hidden>Maks høyde
+                    <input id="heightMax" type="number" value="30" min="1">
+                  </label>
+                  <label class="chk"><input id="showHeightHandle" type="checkbox" checked> Håndtak</label>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -96,6 +96,7 @@ const DEFAULT_ADV_CFG = JSON.parse(JSON.stringify(CFG.ADV));
 let cleanupCurrentDraw = null;
 const layoutStateStore = Object.create(null);
 let currentLayoutMode = null;
+let lastVisibleCellMode = "factors";
 function ensureCfgDefaults() {
   const fill = (target, defaults) => {
     if (!defaults || typeof defaults !== 'object') return;
@@ -118,6 +119,9 @@ function ensureCfgDefaults() {
   if (!CFG.ADV || typeof CFG.ADV !== 'object') CFG.ADV = {};
   fill(CFG.SIMPLE, DEFAULT_SIMPLE_CFG);
   fill(CFG.ADV, DEFAULT_ADV_CFG);
+  if (CFG.ADV.labels && typeof CFG.ADV.labels === "object" && CFG.ADV.labels.cellMode && CFG.ADV.labels.cellMode !== "none") {
+    lastVisibleCellMode = CFG.ADV.labels.cellMode;
+  }
 }
 function normalizeLayout(value) {
   if (typeof value !== "string") return "quad";
@@ -357,6 +361,21 @@ function readConfigFromHtml() {
   }
   CFG.ADV.grid = (_document$getElementB9 = (_document$getElementB0 = document.getElementById("grid")) === null || _document$getElementB0 === void 0 ? void 0 : _document$getElementB0.checked) !== null && _document$getElementB9 !== void 0 ? _document$getElementB9 : CFG.ADV.grid;
   CFG.ADV.splitLines = (_document$getElementB1 = (_document$getElementB10 = document.getElementById("splitLines")) === null || _document$getElementB10 === void 0 ? void 0 : _document$getElementB10.checked) !== null && _document$getElementB1 !== void 0 ? _document$getElementB1 : CFG.ADV.splitLines;
+  const showExpressionsInput = document.getElementById("showExpressions");
+  if (!CFG.ADV.labels || typeof CFG.ADV.labels !== "object") CFG.ADV.labels = {};
+  if (showExpressionsInput) {
+    const currentMode = CFG.ADV.labels.cellMode;
+    if (showExpressionsInput.checked) {
+      if (!currentMode || currentMode === "none") {
+        CFG.ADV.labels.cellMode = lastVisibleCellMode || "factors";
+      }
+    } else {
+      if (currentMode && currentMode !== "none") {
+        lastVisibleCellMode = currentMode;
+      }
+      CFG.ADV.labels.cellMode = "none";
+    }
+  }
   CFG.SIMPLE.layout = currentLayoutMode;
   updateLayoutUi();
   saveLayoutState(currentLayoutMode);
@@ -1925,7 +1944,12 @@ function applyConfigToInputs() {
   setVal('heightMax', simple.totalHandle !== null && simple.totalHandle !== void 0 ? simple.totalHandle.maxRows : undefined);
   setChk('showTotalHandle', !!(simple.totalHandle && simple.totalHandle.show));
   setChk('grid', !!adv.grid);
+  const advLabels = adv.labels || {};
+  if (advLabels.cellMode && advLabels.cellMode !== "none") {
+    lastVisibleCellMode = advLabels.cellMode;
+  }
   setChk('splitLines', adv.splitLines !== false);
+  setChk('showExpressions', ((advLabels.cellMode) || 'factors') !== 'none');
   setSelect('layoutMode', normalizedLayout);
   updateLayoutUi();
 }


### PR DESCRIPTION
## Summary
- restructure the Arealmodell Beta settings panel into separate "Globale innstillinger" and "Rektangler" groups with updated layout styling
- add a "Vis regnestykker" toggle that controls the visibility of cell expressions while remembering the last visible mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfba3000748324b1c193cefd366e2f