### PR TITLE
Remove Arealmodell beta header

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -54,10 +54,6 @@
 </head>
 <body>
   <div class="wrap">
-    <header class="page-header">
-      <h1>Arealmodell <span class="tag">beta</span></h1>
-      <p>Velg hvor mange deler rektangelet skal ha, og tilpass lengde og høyde etter behov.</p>
-    </header>
     <div class="grid">
       <div class="card">
         <svg id="area" preserveAspectRatio="xMidYMid meet" aria-label="Arealmodell"></svg>


### PR DESCRIPTION
## Summary
- remove the Arealmodell beta header banner and intro text from the beta page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfc91791a88324bf3153d0933ede4c