### PR TITLE
Adjust layout of length and height controls

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -37,13 +37,13 @@
     .settings select { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; }
     .settings .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
     .settings .row.row--global { align-items: center; justify-content: space-between; }
-    .settings .row.row--handles,
     .settings .row.row--checkboxes { align-items: center; }
     .settings .row label { flex: 0; }
     .settings .row label.label--grow { flex: 1 1 220px; min-width: 200px; }
     .settings .row label.label--grow select { width: 100%; }
-    .settings .row label input[type="number"] { width: 80px; }
+    .settings .row label input[type="number"] { width: 70px; }
     .settings .row label.chk { flex: 0; flex-direction: row; align-items: center; }
+    .settings .row label.chk.inline { align-self: center; }
     .settings .row label.chk input { margin-right: 6px; }
     .page-header { display: flex; flex-direction: column; gap: 6px; padding: 0 4px; }
     .page-header h1 { margin: 0; font-size: 1.65rem; font-weight: 650; color: #1f2937; display: flex; align-items: center; gap: 10px; }
@@ -91,6 +91,7 @@
               <label id="lengthMaxWrap" hidden>Maks lengde
                 <input id="lengthMax" type="number" value="30" min="1">
               </label>
+              <label class="chk inline"><input id="showLengthHandle" type="checkbox" checked> Lengde-håndtak</label>
             </div>
             <div class="row">
               <label>Høyde
@@ -102,10 +103,7 @@
               <label id="heightMaxWrap" hidden>Maks høyde
                 <input id="heightMax" type="number" value="30" min="1">
               </label>
-            </div>
-            <div class="row row--handles">
-              <label class="chk"><input id="showLengthHandle" type="checkbox" checked> Lengde-håndtak</label>
-              <label class="chk"><input id="showHeightHandle" type="checkbox" checked> Høyde-håndtak</label>
+              <label class="chk inline"><input id="showHeightHandle" type="checkbox" checked> Høyde-håndtak</label>
             </div>
             <div class="row row--checkboxes">
               <label class="chk"><input id="splitLines" type="checkbox" checked> Delingslinjer</label>


### PR DESCRIPTION
## Summary
- shrink the numerical input fields for length and height settings in the Arealmodell beta page
- place the length and height handle checkboxes alongside their respective settings rows for a tidier layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfcde9d5908324ab9b506ebb067afc