### PR TITLE
Rename spillmodus to oppgavemodus

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -351,7 +351,7 @@
     <div class="grid">
       <div class="card card--board">
         <div class="toolbar toolbar--mode">
-          <button id="btnToggleMode" class="btn btn--primary" type="button">Gå til spillmodus</button>
+          <button id="btnToggleMode" class="btn btn--primary" type="button">Gå til oppgavemodus</button>
           <span id="modeLabel" class="mode-label">Redigeringsmodus</span>
         </div>
         <div class="figure">

--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -1318,9 +1318,9 @@
 
   function updateModeUI() {
     if (modeToggleBtn) {
-      modeToggleBtn.textContent = isEditMode ? 'Gå til spillmodus' : 'Gå til redigeringsmodus';
+      modeToggleBtn.textContent = isEditMode ? 'Gå til oppgavemodus' : 'Gå til redigeringsmodus';
     }
-    if (modeLabel) modeLabel.textContent = isEditMode ? 'Redigeringsmodus' : 'Spillmodus';
+    if (modeLabel) modeLabel.textContent = isEditMode ? 'Redigeringsmodus' : 'Oppgavemodus';
     if (checkBtn) checkBtn.disabled = isEditMode;
     if (clearBtn) clearBtn.disabled = isEditMode;
     document.body.classList.toggle('is-edit-mode', isEditMode);


### PR DESCRIPTION
## Summary
- rename the toggle button text from "Gå til spillmodus" to "Gå til oppgavemodus"
- update the runtime mode label to show "Oppgavemodus" when not editing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfce361d7c83248d53cf1d135db5a6