### PR TITLE
Remove beta banner from fortegnsskjema

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -21,43 +21,6 @@
       flex-direction: column;
       gap: var(--gap);
     }
-    .development-banner {
-      display: flex;
-      align-items: center;
-      padding: 14px 18px;
-      border-radius: 12px;
-      border: 1px solid rgba(217, 119, 6, 0.4);
-      background: linear-gradient(120deg, rgba(255, 237, 213, 0.95), rgba(255, 247, 237, 0.95));
-      color: #92400e;
-      font-size: 14px;
-      line-height: 1.5;
-    }
-    .development-banner__icon {
-      position: relative;
-      display: inline-flex;
-    }
-    .development-banner svg {
-      width: 22px;
-      height: 22px;
-      flex-shrink: 0;
-    }
-    .development-banner__badge {
-      position: absolute;
-      top: -8px;
-      right: -12px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 2px 6px;
-      border-radius: 999px;
-      background: #f97316;
-      color: #fff;
-      font-size: 10px;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      font-weight: 600;
-      line-height: 1;
-    }
     .grid {
       display: grid;
       gap: var(--gap);
@@ -308,15 +271,6 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="development-banner" role="note" aria-label="Fortegnsskjema (beta)">
-      <span class="development-banner__icon" aria-hidden="true">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01" />
-          <path stroke-linecap="round" stroke-linejoin="round" d="M10.29 3.86 1.82 18a1.8 1.8 0 0 0 1.55 2.7h17.26a1.8 1.8 0 0 0 1.55-2.7L13.11 3.86a1.8 1.8 0 0 0-2.82 0Z" />
-        </svg>
-        <span class="development-banner__badge">Beta</span>
-      </span>
-    </div>
     <div class="grid">
       <div class="card">
         <div class="figure">


### PR DESCRIPTION
## Summary
- remove the beta development banner above the fortegnsskjema figure
- keep the rest of the layout unchanged

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cfe04f6130832485801a55254dd797