### PR TITLE
Set Kvikkbilder layer gap default to 6

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -177,8 +177,8 @@
               </label>
             </div>
             <div class="field-row field-row--two">
-              <label>Lag-avstand i hver figur
-                <input id="cfg-klosser-layerGap" type="number" min="0" value="0">
+              <label>Lagavstand i hver figur
+                <input id="cfg-klosser-layerGap" type="number" min="0" value="6">
               </label>
             </div>
           </div>

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -65,7 +65,7 @@
       dybde: 2,
       duration: 3,
       showBtn: false,
-      layerGap: 0
+      layerGap: 6
     },
     monster: {
       antallX: 2,
@@ -341,7 +341,8 @@
     brickContainer.innerHTML = '';
     brickContainer.style.gridTemplateColumns = cols > 0 ? `repeat(${cols}, 1fr)` : '';
     brickContainer.style.gridTemplateRows = rows > 0 ? `repeat(${rows}, auto)` : '';
-    const layerGap = Number.isFinite(CFG.klosser.layerGap) ? Math.max(0, CFG.klosser.layerGap) : 0;
+    const defaultLayerGap = Number.isFinite(DEFAULT_CFG.klosser.layerGap) ? DEFAULT_CFG.klosser.layerGap : 0;
+    const layerGap = Number.isFinite(CFG.klosser.layerGap) ? Math.max(0, CFG.klosser.layerGap) : defaultLayerGap;
     CFG.klosser.layerGap = layerGap;
     if (cfgKlosserLayerGap) {
       cfgKlosserLayerGap.value = String(layerGap);


### PR DESCRIPTION
## Summary
- set the default layer gap for Kvikkbilder bricks to 6 and make the renderer fall back to that default
- update the settings form so the Lagavstand field shows 6 by default and uses the preferred label text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfe0be64288324903b77a682c0678f