### PR TITLE
Fix brick layout spacing in Kvikkbilder

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -43,11 +43,15 @@
       gap:10px;
       transform:translateY(-12px);
       align-content:start;
-      grid-auto-rows:auto;
+      align-items:center;
+      justify-items:center;
+      grid-auto-rows:minmax(0,1fr);
     }
     #brickContainer > svg{
-      width:100%;
-      height:auto;
+      width:auto;
+      height:100%;
+      max-width:100%;
+      max-height:100%;
       display:block;
     }
     #patternContainer,

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -339,8 +339,8 @@
     const height = Math.max(1, Math.trunc(hoyde));
     const depth = Math.max(1, Math.trunc(dybde));
     brickContainer.innerHTML = '';
-    brickContainer.style.gridTemplateColumns = cols > 0 ? `repeat(${cols}, 1fr)` : '';
-    brickContainer.style.gridTemplateRows = rows > 0 ? `repeat(${rows}, auto)` : '';
+    brickContainer.style.gridTemplateColumns = cols > 0 ? `repeat(${cols}, minmax(0, 1fr))` : '';
+    brickContainer.style.gridTemplateRows = rows > 0 ? `repeat(${rows}, minmax(0, 1fr))` : '';
     const defaultLayerGap = Number.isFinite(DEFAULT_CFG.klosser.layerGap) ? DEFAULT_CFG.klosser.layerGap : 0;
     const layerGap = Number.isFinite(CFG.klosser.layerGap) ? Math.max(0, CFG.klosser.layerGap) : defaultLayerGap;
     CFG.klosser.layerGap = layerGap;


### PR DESCRIPTION
## Summary
- prevent tall brick figures from overlapping by using fractional grid tracks in the brick container
- center and constrain rendered brick SVGs so each figure stays within its grid cell

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfe3c3e01c8324a59679beddc5a557