### PR TITLE
Fix label offsets to use constant pixel spacing

### DIFF
--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -283,8 +283,8 @@
 
   function positionBoardLabel(element, pos) {
     if (!element || !pos) return;
-    const left = (pos.x + LABEL_OFFSET_X) * boardScaleX;
-    const top = (pos.y + LABEL_OFFSET_Y) * boardScaleY;
+    const left = pos.x * boardScaleX + LABEL_OFFSET_X;
+    const top = pos.y * boardScaleY + LABEL_OFFSET_Y;
     element.style.transform = `translate(${left}px, ${top}px)`;
   }
 


### PR DESCRIPTION
## Summary
- ensure board labels use a fixed pixel offset from their associated point regardless of the board scaling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfe44a86c48324bce292c873fe9d46