### PR TITLE
Restore red base color in Arealmodell beta

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -26,7 +26,7 @@
     }
     .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
     svg { width: 100%; height: auto; background: #fff; display: block; }
-    #area .c1 { fill: #2563eb !important; }
+    #area .c1 { fill: #e07c7c !important; }
     .settings { display: flex; flex-direction: column; gap: 10px; }
     .settings .section-title { margin: 4px 2px 0; font-size: 12px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: #6b7280; }
     .toolbar { display:flex; gap:10px; justify-content:flex-start; align-items:center; flex-wrap:wrap; }


### PR DESCRIPTION
## Summary
- switch the area model's primary cell fill color back to the original red hue

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfe64000ec83248ebe1053c09b45a2