### PR TITLE
Improve sign chart annotations

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -73,29 +73,35 @@
       align-items: center;
       justify-content: center;
       min-width: 0;
-      padding: 4px;
+      padding: 6px 8px;
       border-radius: 10px;
       border: 1px solid rgba(203, 213, 245, 0.7);
       background: rgba(255, 255, 255, 0.95);
       box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
       pointer-events: auto;
       cursor: ew-resize;
-      gap: 4px;
+      gap: 6px;
+      font-size: 15px;
+      font-weight: 600;
+      color: #111827;
     }
     .chart-overlay__value input[type="number"] {
-      width: 4.8ch;
+      width: 6.5ch;
       min-width: 0;
     }
     .chart-overlay__value-input {
-      padding: 2px 4px;
+      padding: 3px 6px;
       border-radius: 6px;
       border: 1px solid #d1d5db;
       background: rgba(255, 255, 255, 0.95);
-      font-size: 14px;
+      font-size: 16px;
       font-weight: 600;
-      color: #1f2937;
+      color: #111827;
       text-align: center;
       box-shadow: none;
+      box-sizing: border-box;
+      line-height: 1.4;
+      font-variant-numeric: tabular-nums;
     }
     .chart-overlay__value-input:focus {
       outline: 2px solid rgba(59, 130, 246, 0.35);

--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -795,17 +795,19 @@
         cursor: 'ew-resize'
       });
       svg.append(vertical);
-      const labelY = point.type === 'pole' ? arrowY + 6 : baseRowY + 6;
+      const isPole = point.type === 'pole';
       const label = createSvgElement('text', {
         x: px,
-        y: labelY,
+        y: baseRowY,
         'text-anchor': 'middle',
-        'font-size': 16,
-        'font-weight': 600,
-        fill: point.type === 'pole' ? '#b91c1c' : '#111827',
+        'dominant-baseline': 'middle',
+        'alignment-baseline': 'middle',
+        'font-size': isPole ? 22 : 20,
+        'font-weight': 700,
+        fill: isPole ? '#b91c1c' : '#111827',
         'pointer-events': 'none'
       });
-      label.textContent = point.type === 'pole' ? '><' : '0';
+      label.textContent = isPole ? '><' : '0';
       svg.append(label);
       const dragHandle = createSvgElement('circle', {
         cx: px,
@@ -823,6 +825,7 @@
         valueBadge.className = 'chart-overlay__value';
         valueBadge.style.left = `${px}px`;
         valueBadge.style.top = `${arrowY}px`;
+        valueBadge.title = formatPointValue(point.value);
         valueBadge.dataset.pointId = point.id;
         const valueInput = document.createElement('input');
         valueInput.type = 'number';


### PR DESCRIPTION
## Summary
- enlarge the 0 and >< markers on the sign chart and align poles with the fortegn line
- increase the size and contrast of the point value badges so the numeric values are easy to read and add a tooltip with the value

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cff3f781cc832494fdaf7c59c564dc