### PR TITLE
Enlarge overlay input width

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -86,8 +86,8 @@
       color: #111827;
     }
     .chart-overlay__value input[type="number"] {
-      width: 6.5ch;
-      min-width: 0;
+      width: 10ch;
+      min-width: 8ch;
     }
     .chart-overlay__value-input {
       padding: 3px 6px;


### PR DESCRIPTION
## Summary
- increase the width of the draggable overlay's number inputs so they can display at least three digits

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff6f75b788324a04b147e553b2bfe