### PR TITLE
Update Arealmodell navigation entry

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Arealmodell (beta)</title>
+  <title>Arealmodell</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <style>
     :root { --gap: 18px; }

--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@
         </a>
       </li>
       <li>
-        <a href="arealmodell.html" target="content" title="Arealmodell (beta)" aria-label="Arealmodell (beta)">
+        <a href="arealmodell.html" target="content" title="Arealmodell" aria-label="Arealmodell">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <rect x="4" y="5" width="16" height="14" rx="1.8" stroke="currentColor" stroke-width="1.4" />
             <rect x="4.5" y="5.5" width="7" height="6" fill="currentColor" fill-opacity=".15" stroke="none" />
@@ -295,29 +295,7 @@
             <line x1="12" y1="5" x2="12" y2="19" stroke-linecap="round" stroke-width="1.2" />
             <line x1="4" y1="12" x2="20" y2="12" stroke-linecap="round" stroke-width="1.2" />
           </svg>
-          <span class="sr-only">Arealmodell (beta)</span>
-          <span class="nav-badge" aria-hidden="true">Beta</span>
-        </a>
-      </li>
-      <li>
-        <a href="arealmodell0.html" target="content" title="Arealmodell A" aria-label="Arealmodell A">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <rect x="3" y="6" width="18" height="12" />
-            <path stroke-linecap="round" d="M9 6v12M15 6v12M3 12h18" />
-            <circle cx="21" cy="5" r="1.5" />
-          </svg>
-          <span class="sr-only">Arealmodell A</span>
-        </a>
-      </li>
-      <li>
-        <a href="arealmodellen1.html" target="content" title="Arealmodell B" aria-label="Arealmodell B">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <rect x="3" y="4" width="18" height="15" />
-            <path d="M4.5 4v15M6 4v15M7.5 4v15M9 4v15M10.5 4v15M12 4v15M13.5 4v15M15 4v15M16.5 4v15M18 4v15M19.5 4v15" />
-            <path d="M3 5h18M3 6h18M3 7h18M3 8h18M3 9h18M3 10h18M3 11h18M3 12h18M3 13h18M3 14h18M3 15h18M3 16h18M3 17h18M3 18h18" />
-            <path stroke-linecap="round" stroke-linejoin="round" d="M21 11.5l2 1.5-2 1.5" />
-          </svg>
-          <span class="sr-only">Arealmodell B</span>
+          <span class="sr-only">Arealmodell</span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
## Summary
- remove the Arealmodell A and B entries from the top navigation
- keep the single Arealmodell entry and drop the beta labelling on it and its page title

## Testing
- not run (static changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cffacfce3c8324a33b928e9188ce88