### PR TITLE
Move Arealmodell menu entry after Tenkeblokker

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,6 +204,20 @@
         </a>
       </li>
       <li>
+        <a href="arealmodell.html" target="content" title="Arealmodell" aria-label="Arealmodell">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <rect x="4" y="5" width="16" height="14" rx="1.8" stroke="currentColor" stroke-width="1.4" />
+            <rect x="4.5" y="5.5" width="7" height="6" fill="currentColor" fill-opacity=".15" stroke="none" />
+            <rect x="12.5" y="5.5" width="7" height="6" fill="currentColor" fill-opacity=".28" stroke="none" />
+            <rect x="4.5" y="12.5" width="7" height="6" fill="currentColor" fill-opacity=".4" stroke="none" />
+            <rect x="12.5" y="12.5" width="7" height="6" fill="currentColor" fill-opacity=".55" stroke="none" />
+            <line x1="12" y1="5" x2="12" y2="19" stroke-linecap="round" stroke-width="1.2" />
+            <line x1="4" y1="12" x2="20" y2="12" stroke-linecap="round" stroke-width="1.2" />
+          </svg>
+          <span class="sr-only">Arealmodell</span>
+        </a>
+      </li>
+      <li>
         <a href="perlesnor.html" target="content" title="Perlesnor" aria-label="Perlesnor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M2 12h20" />
@@ -282,20 +296,6 @@
           </svg>
           <span class="sr-only">Fortegnsskjema</span>
           <span class="nav-badge" aria-hidden="true">Beta</span>
-        </a>
-      </li>
-      <li>
-        <a href="arealmodell.html" target="content" title="Arealmodell" aria-label="Arealmodell">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <rect x="4" y="5" width="16" height="14" rx="1.8" stroke="currentColor" stroke-width="1.4" />
-            <rect x="4.5" y="5.5" width="7" height="6" fill="currentColor" fill-opacity=".15" stroke="none" />
-            <rect x="12.5" y="5.5" width="7" height="6" fill="currentColor" fill-opacity=".28" stroke="none" />
-            <rect x="4.5" y="12.5" width="7" height="6" fill="currentColor" fill-opacity=".4" stroke="none" />
-            <rect x="12.5" y="12.5" width="7" height="6" fill="currentColor" fill-opacity=".55" stroke="none" />
-            <line x1="12" y1="5" x2="12" y2="19" stroke-linecap="round" stroke-width="1.2" />
-            <line x1="4" y1="12" x2="20" y2="12" stroke-linecap="round" stroke-width="1.2" />
-          </svg>
-          <span class="sr-only">Arealmodell</span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
## Summary
- move the Arealmodell navigation link to immediately follow Tenkeblokker so it appears earlier in the menu

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cffd3f89148324887274ebde9fa7c3