### PR TITLE
Add expression toggle and align exports for Arealmodell

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -120,6 +120,7 @@
             </div>
             <div class="row row--checkboxes">
               <label class="chk"><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
+              <label class="chk"><input id="showExpressions" type="checkbox" checked> Vis regnestykker</label>
               <label class="chk"><input id="showTotalHandle" type="checkbox"> Totalareal-håndtak</label>
             </div>
             <div class="row" id="challengeSettings" hidden>
@@ -133,9 +134,9 @@
         <div class="card">
           <h2>Eksporter</h2>
           <div class="toolbar">
-            <button id="btnSvgStatic" class="btn" type="button">Last ned SVG</button>
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSvg" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnSvgInteractive" class="btn" type="button">Last ned interaktiv SVG</button>
             <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
           </div>
         </div>

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -138,9 +138,9 @@
         <div class="card">
           <h2>Eksporter</h2>
           <div class="toolbar">
-            <button id="btnSvgStatic" class="btn" type="button">Last ned SVG</button>
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
-            <button id="btnSvg" class="btn" type="button">Last ned interaktiv SVG</button>
+            <button id="btnSvgInteractive" class="btn" type="button">Last ned interaktiv SVG</button>
             <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
           </div>
         </div>

--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -1710,8 +1710,9 @@ function draw() {
       showTotalHandle: !!(CFG.SIMPLE.totalHandle && CFG.SIMPLE.totalHandle.show)
     };
   }
-  const btnSvgStatic = document.getElementById("btnSvgStatic");
-  if (btnSvgStatic) btnSvgStatic.onclick = () => {
+  const legacySvgStaticBtn = document.getElementById("btnSvgStatic");
+  const btnSvgDownload = legacySvgStaticBtn || document.getElementById("btnSvg");
+  if (btnSvgDownload) btnSvgDownload.onclick = () => {
     var _ADV$export3;
     const svgStr = buildBaseSvgMarkup(buildExportOptions({
       includeHandles: false,
@@ -1730,8 +1731,8 @@ function draw() {
     }), true);
     downloadPNGFromString(svgStr, ((_ADV$export4 = ADV.export) === null || _ADV$export4 === void 0 ? void 0 : _ADV$export4.filenamePng) || "arealmodell.png");
   };
-  const btnSvg = document.getElementById("btnSvg");
-  if (btnSvg) btnSvg.onclick = () => {
+  const btnSvgInteractive = document.getElementById("btnSvgInteractive") || (legacySvgStaticBtn ? document.getElementById("btnSvg") : null);
+  if (btnSvgInteractive) btnSvgInteractive.onclick = () => {
     var _ADV$export5;
     const svgStr = buildInteractiveSvgString(buildExportOptions());
     downloadText(((_ADV$export5 = ADV.export) === null || _ADV$export5 === void 0 ? void 0 : _ADV$export5.filename) || "arealmodell_interaktiv.svg", svgStr, "image/svg+xml");


### PR DESCRIPTION
## Summary
- add a "Vis regnestykker" checkbox to the Arealmodell settings
- align the static export buttons with the shared layout and update the JS handlers accordingly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cffd1a41c48324a8757f985a05284a