### PR TITLE
Vis bare prikk for prikk til prikk-punkter

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -282,30 +282,26 @@
     .line-answer { stroke: #0f766e; stroke-width: 4; stroke-dasharray: 10 8; pointer-events: none; opacity: .9; }
     .point { cursor: pointer; }
     .point-decoration {
-      fill: #fff;
-      stroke: #111827;
-      stroke-width: 2.4;
-      transition: stroke .2s, fill .2s;
-      stroke-linejoin: round;
+      fill: transparent;
+      stroke: none;
+      pointer-events: all;
     }
     .point-dot {
       fill: #111827;
       stroke: none;
+      pointer-events: none;
+      transition: transform .2s ease, filter .2s ease, fill .2s ease;
+      transform-origin: center;
     }
-    .point.is-selected .point-decoration {
-      stroke: #2563eb;
-      stroke-width: 3.2;
-    }
-    .point--false .point-decoration {
-      fill: #fef2f2;
-      stroke: #b91c1c;
-      stroke-dasharray: 6 4;
+    .point.is-selected .point-dot {
+      transform: scale(1.3);
+      filter: drop-shadow(0 0 4px rgba(37, 99, 235, 0.45));
     }
     .point--false .point-dot {
       fill: #b91c1c;
     }
-    .point--false.point.is-selected .point-decoration {
-      stroke: #991b1b;
+    .point--false.point.is-selected .point-dot {
+      filter: drop-shadow(0 0 4px rgba(185, 28, 28, 0.45));
     }
     .point-label {
       font-size: 14px;

--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -4,7 +4,8 @@
   const BOARD_HEIGHT = 700;
   const LABEL_OFFSET_X = 24;
   const LABEL_OFFSET_Y = -20;
-  const POINT_RADIUS = 11;
+  const POINT_RADIUS = 18;
+  const DOT_RADIUS = 6;
   const DEFAULT_LABEL_FONT_SIZE = 14;
   const MIN_LABEL_FONT_SIZE = 10;
   const MAX_LABEL_FONT_SIZE = 48;
@@ -1384,6 +1385,7 @@
     visual.decoration.setAttribute('r', POINT_RADIUS);
     visual.dot.setAttribute('cx', x);
     visual.dot.setAttribute('cy', y);
+    visual.dot.setAttribute('r', DOT_RADIUS);
   }
 
   function createPointVisual(point, pos) {
@@ -1397,7 +1399,7 @@
 
     const dot = document.createElementNS(SVG_NS, 'circle');
     dot.classList.add('point-dot');
-    dot.setAttribute('r', 4.5);
+    dot.setAttribute('r', DOT_RADIUS);
     group.appendChild(dot);
 
     attachPointInteraction(group, point.id);


### PR DESCRIPTION
## Summary
- make point decorations invisible so only the dot is rendered while preserving an ample hit target
- enlarge the dot radius handling and selection effects to keep interaction clear without an outer circle

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d033f3de1c83248bb39aac070570ea