### PR TITLE
Fix row label width effect on block proportions

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -51,11 +51,15 @@
     }
     .tb-row{
       --tb-row-width-percent:100%;
+      --tb-row-effective-label-width:var(--tb-label-max-width,0px);
       display:flex;
-      width:calc(var(--tb-label-max-width,0px) + var(--tb-row-width-percent,100%));
-      margin-left:calc(-1 * var(--tb-label-max-width,0px));
+      width:calc(var(--tb-row-effective-label-width,0px) + var(--tb-row-width-percent,100%));
+      margin-left:calc(-1 * var(--tb-row-effective-label-width,0px));
       gap:0;
       align-items:stretch;
+    }
+    .tb-row[data-has-label="false"]{
+      --tb-row-effective-label-width:0px;
     }
     .tb-row-label{
       flex:0 0 var(--tb-label-max-width,0px);

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -770,6 +770,10 @@ function draw(skipNormalization = false) {
     label.textContent = trimmed;
     const hasText = trimmed.length > 0;
     label.dataset.empty = hasText ? 'false' : 'true';
+    const rowEl = label.parentElement;
+    if (rowEl && rowEl.classList && rowEl.classList.contains('tb-row')) {
+      rowEl.dataset.hasLabel = hasText ? 'true' : 'false';
+    }
     if (hasText) {
       label.style.display = 'flex';
       const measured = measureRowLabelWidth(trimmed);


### PR DESCRIPTION
## Summary
- adjust the row width calculation to only include the label width when a label is present
- keep the layout ratio intact by flagging rows that have a label in the rendering logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d035d99bec8324a8f0f853c451940f