### PR TITLE
Ensure the arealmodell example loads immediately

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -1064,9 +1064,17 @@
         window.__EXAMPLES_FORCE_PROVIDED__ = false;
       }
     };
-    if (document.readyState === 'complete') setTimeout(ensure, 0);else window.addEventListener('load', ensure, {
-      once: true
-    });
+    const runEnsure = () => {
+      window.removeEventListener('DOMContentLoaded', runEnsure);
+      window.removeEventListener('load', runEnsure);
+      setTimeout(ensure, 0);
+    };
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+      setTimeout(ensure, 0);
+    } else {
+      window.addEventListener('DOMContentLoaded', runEnsure);
+      window.addEventListener('load', runEnsure);
+    }
   }
   ensureDefaultExample();
 })();


### PR DESCRIPTION
## Summary
- trigger the automatic example loading as soon as the DOM is ready
- remove the dependency on the delayed window load event so the first tab appears without manual interaction

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d03621734083249e44f389dadd83dd