### PR TITLE
Fix Kvikkbilder example numbering

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -790,13 +790,22 @@
         empty.textContent = 'Ingen eksempler';
         tabsContainer.appendChild(empty);
       } else {
+        const numericLabelPattern = /^[0-9]+$/;
         examples.forEach((ex, idx) => {
           const btn = document.createElement('button');
           btn.type = 'button';
           btn.className = 'example-tab';
-          let label = String(idx + 1);
-          if (ex && typeof ex.exampleNumber === 'string' && ex.exampleNumber.trim()) {
-            label = ex.exampleNumber.trim();
+          const defaultLabel = String(idx + 1);
+          let label = defaultLabel;
+          if (ex && typeof ex.exampleNumber === 'string') {
+            const trimmed = ex.exampleNumber.trim();
+            if (trimmed) {
+              if (!numericLabelPattern.test(trimmed)) {
+                label = trimmed;
+              } else if (Number(trimmed) === idx + 1) {
+                label = trimmed;
+              }
+            }
           }
           btn.textContent = label;
           btn.dataset.exampleIndex = String(idx);


### PR DESCRIPTION
## Summary
- ensure example tabs in examples.js fall back to sequential numbering when provided labels are numeric but out of order

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d036c2eba08324a882d27c36b51f91