### PR TITLE
Fix fallback layout when examples omit rows/cols

### DIFF
--- a/brøkfigurer.js
+++ b/brøkfigurer.js
@@ -305,8 +305,8 @@
     }
   }
   function renderAll() {
-    const desiredRows = clampInt(STATE.rows != null ? STATE.rows : rows, MIN_DIMENSION, MAX_ROWS);
-    const desiredCols = clampInt(STATE.cols != null ? STATE.cols : cols, MIN_DIMENSION, MAX_COLS);
+    const desiredRows = clampInt(STATE.rows != null ? STATE.rows : MIN_DIMENSION, MIN_DIMENSION, MAX_ROWS);
+    const desiredCols = clampInt(STATE.cols != null ? STATE.cols : MIN_DIMENSION, MIN_DIMENSION, MAX_COLS);
     let layoutChanged = false;
     if (desiredRows !== rows) {
       rows = desiredRows;


### PR DESCRIPTION
## Summary
- reset the fallback grid layout to the default when an example omits row/column settings

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d042a54d8c8324b5de851819d0e2b2