### PR TITLE
Increase margins for area model display

### DIFF
--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -33,10 +33,10 @@ const CFG = {
     svgId: "area",
     unit: 40,
     margins: {
-      l: 110,
-      r: 40,
-      t: 40,
-      b: 120
+      l: 140,
+      r: 60,
+      t: 60,
+      b: 140
     },
     grid: false,
     splitLines: true,


### PR DESCRIPTION
## Summary
- increase the default margins for the area model view so outer labels have more room

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d05c87099c8324ada1824f4e2ff7ea