### PR TITLE
Fjern sortere punkter-knappen

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -414,9 +414,6 @@
           <h2>Punkter</h2>
           <fieldset class="settings-section">
             <legend>Punkter</legend>
-            <div class="toolbar">
-              <button id="btnSortPoints" class="btn" type="button">Sorter punkter</button>
-            </div>
             <div id="pointList" class="point-list"></div>
             <div class="toolbar toolbar--footer">
               <button id="btnAddPoint" class="btn" type="button">Legg til</button>

--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -205,7 +205,6 @@
   const statusBox = document.getElementById('statusMessage');
   const addPointBtn = document.getElementById('btnAddPoint');
   const addPointFalseBtn = document.getElementById('btnAddPointFalse');
-  const sortPointsBtn = document.getElementById('btnSortPoints');
   const pointListEl = document.getElementById('pointList');
   const falsePointListEl = document.getElementById('falsePointList');
   const labelFontSizeSelect = document.getElementById('cfg-labelFontSize');
@@ -2402,13 +2401,6 @@
   if (addPointFalseBtn) {
     addPointFalseBtn.addEventListener('click', () => {
       addPoint(true);
-    });
-  }
-
-  if (sortPointsBtn) {
-    sortPointsBtn.addEventListener('click', () => {
-      sortPoints();
-      clearStatus();
     });
   }
 


### PR DESCRIPTION
## Summary
- fjernet "Sorter punkter"-knappen fra punkter-innstillingene i prikk til prikk
- oppdatert JavaScript-initiering slik at den ikke forventer knappen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d069dca0d88324a30e2cab4023affd