### PR TITLE
Adjust spacing when showing combined whole marker

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -44,7 +44,7 @@
       gap:0;
       row-gap:0;
       column-gap:0;
-      padding:20px 18px 18px 28px;
+      padding:var(--tb-grid-padding-top,20px) 18px 18px 28px;
       width:100%;
       align-items:flex-start;
       overflow:visible;

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -178,6 +178,8 @@ const BASE_INNER_RATIO = BOTTOM_RATIO - TOP_RATIO;
 const ROW_GAP = 18;
 const ROW_LABEL_GAP = 18;
 const DEFAULT_FRAME_INSET = 3;
+const DEFAULT_GRID_PADDING_TOP = 20;
+const COMBINED_WHOLE_TOP_MARGIN = 12;
 const BLOCKS = [];
 let multipleBlocksActive = false;
 const board = document.getElementById('tbBoard');
@@ -1453,14 +1455,16 @@ function drawCombinedWholeOverlayHorizontal() {
   const canShow = CONFIG.activeBlocks > 1 && CONFIG.showCombinedWhole;
   if (!canShow) {
     overlay.svg.style.display = 'none';
+    if (grid) grid.style.removeProperty('--tb-grid-padding-top');
     return;
   }
-  const metrics = getCombinedFigureMetrics();
+  let metrics = getCombinedFigureMetrics();
   if (!metrics) {
     overlay.svg.style.display = 'none';
+    if (grid) grid.style.removeProperty('--tb-grid-padding-top');
     return;
   }
-  const { left, top, width, height, boardLeft, boardTop } = metrics;
+  let { left, top, width, height, boardLeft, boardTop } = metrics;
   const labelOffsetY = Math.max(height * LABEL_OFFSET_RATIO, 12);
   const gapToBlocks = Math.max(Math.min(height * 0.03, 24), 12);
   const textPadding = Math.max(Math.min(labelOffsetY * 0.45, 10), 5);
@@ -1468,6 +1472,23 @@ function drawCombinedWholeOverlayHorizontal() {
   const braceStartY = labelOffsetY + textPadding + textSafeMargin;
   const braceTick = gapToBlocks;
   const overlayTopOffset = braceStartY + braceTick;
+  if (grid) {
+    const desiredPaddingTop = Math.max(DEFAULT_GRID_PADDING_TOP, overlayTopOffset + COMBINED_WHOLE_TOP_MARGIN);
+    const currentPaddingRaw = grid.style.getPropertyValue('--tb-grid-padding-top');
+    const currentPadding = Number.parseFloat(currentPaddingRaw);
+    if (!Number.isFinite(currentPadding) || Math.abs(currentPadding - desiredPaddingTop) > 0.5) {
+      grid.style.setProperty('--tb-grid-padding-top', `${desiredPaddingTop}px`);
+      const updatedMetrics = getCombinedFigureMetrics();
+      if (updatedMetrics) {
+        left = updatedMetrics.left;
+        top = updatedMetrics.top;
+        width = updatedMetrics.width;
+        height = updatedMetrics.height;
+        boardLeft = updatedMetrics.boardLeft;
+        boardTop = updatedMetrics.boardTop;
+      }
+    }
+  }
   const overlayHeight = height + overlayTopOffset;
   overlay.svg.style.display = '';
   overlay.svg.style.left = `${left - boardLeft}px`;


### PR DESCRIPTION
## Summary
- expose the tenkeblokker grid top padding as a CSS custom property
- dynamically increase the top padding when the combined whole overlay is shown so it stays inside the card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0714cb59c83248d1c5115fadd82b4