### PR TITLE
Update handle label in diagram settings

### DIFF
--- a/diagram/index.html
+++ b/diagram/index.html
@@ -56,7 +56,7 @@
               <label>Etiketter (kommaseparert)
                 <input id="cfgLabels" type="text" value="Klatring,Fotball,Håndball,Basket,Tennis,Bowling">
               </label>
-              <label>Fjern håndtak (0/1, kommaseparert)
+              <label>Vis håndtak (0/1, kommaseparert). Hvis det ikke står noe her vises ingen håndtak.
                 <input id="cfgLocked" type="text" value="">
               </label>
             </div>


### PR DESCRIPTION
## Summary
- replace the diagram settings label text to "Vis håndtak"
- clarify that leaving the field empty hides handles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d071c3f4048324916b1794e9662c70