### PR TITLE
Adjust single layout to use bottom-left rectangle

### DIFF
--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -336,15 +336,15 @@ function computeLayoutState(layout, width, height, cols, rows, sx, sy, unit) {
       mode,
       leftWidth: width,
       rightWidth: 0,
-      bottomHeight: 0,
-      topHeight: height,
+      bottomHeight: height,
+      topHeight: 0,
       leftCols: cols,
       rightCols: 0,
-      bottomRows: 0,
-      topRows: rows,
-      showTopLeft: true,
+      bottomRows: rows,
+      topRows: 0,
+      showTopLeft: false,
       showTopRight: false,
-      showBottomLeft: false,
+      showBottomLeft: true,
       showBottomRight: false
     };
   }
@@ -393,6 +393,16 @@ function enforceSingleLayoutRestrictions(layout) {
   CFG.SIMPLE.length.showHandle = false;
   CFG.SIMPLE.height.showHandle = false;
   CFG.SIMPLE.totalHandle.show = true;
+  const lengthCellsRaw = CFG.SIMPLE.length ? CFG.SIMPLE.length.cells : null;
+  const lengthCells = Number.isFinite(Number(lengthCellsRaw)) ? Math.max(0, Math.round(Number(lengthCellsRaw))) : null;
+  if (lengthCells != null) {
+    CFG.SIMPLE.length.handle = lengthCells;
+  }
+  const heightCellsRaw = CFG.SIMPLE.height ? CFG.SIMPLE.height.cells : null;
+  const heightCells = Number.isFinite(Number(heightCellsRaw)) ? Math.max(0, Math.round(Number(heightCellsRaw))) : null;
+  if (heightCells != null) {
+    CFG.SIMPLE.height.handle = heightCells;
+  }
 }
 
 function enforceQuadLayoutFill(layout) {


### PR DESCRIPTION
## Summary
- update the single-layout rendering to display the bottom-left rectangle
- align single-layout handles with the total length and height values so the start position covers the full area

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0fad14bc4832499f6bf34d5794c10