### PR TITLE
Adjust edge label spacing

### DIFF
--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -600,8 +600,8 @@ function draw() {
 
   // spacing for kant-tekst utenfor
   const EDGE_GAP = {
-    x: 14,
-    y: 32
+    x: 8,
+    y: 20
   };
 
   // pilstørrelse + auto-margin


### PR DESCRIPTION
## Summary
- move the exterior length and width labels closer to the figure by reducing the configured edge gap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d105c6e74c8324bd140ce897d409f5