### PR TITLE
Add hide block option with whole marker display

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -79,6 +79,7 @@
     .tb-panel .tb-header:not(:empty){margin-bottom:var(--tb-stepper-spacing,6px);}
     .tb-panel .tb-stepper{align-self:center;}
     .tb-svg{display:block;width:100%;height:var(--tb-svg-height,260px);background:#fff;overflow:visible;}
+    .tb-svg.tb-svg--hidden-block{background:transparent;}
     .tb-board .addFigureBtn{align-self:center;justify-self:center;}
     .tb-controls{display:flex;gap:var(--gap);align-items:center;}
     .tb-controls--cols{grid-column:2;grid-row:1;flex-direction:column;align-self:center;justify-self:center;}


### PR DESCRIPTION
## Summary
- add a "Skjul blokk" toggle that hides block graphics and forces the whole marker to remain visible
- adjust layout, overlays, and export logic to respect hidden blocks and updated active-block counting
- add styling tweaks for hidden blocks so the SVG background disappears when a block is hidden

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d170c928c08324abc09732b4cf4753