### PR TITLE
Add GitHub Pages redirect to Vercel

### DIFF
--- a/docs/hosting-comparison.md
+++ b/docs/hosting-comparison.md
@@ -1,0 +1,20 @@
+# GitHub Pages vs. Vercel for math_visuals
+
+## Distribusjonsmodell
+- **GitHub Pages** bygger statiske filer direkte fra en gren (f.eks. `main` eller `gh-pages`).
+- **Vercel** bygger et prosjekt via sin egen pipeline og kan håndtere både statiske og server-side genererte sider.
+
+## Bygg og deploy
+- GitHub Pages trigges vanligvis ved push til valgt gren eller `docs/`-mappen og krever at statiske artefakter allerede er sjekket inn eller genereres via GitHub Actions.
+- Vercel kjører `npm install`, `npm run build` osv. automatisk på hver push og lagrer bygde artefakter i sin edge-infrastruktur.
+
+## URL og ruting
+- GitHub Pages serverer innhold fra et domenenavn under `github.io` (f.eks. `brukernavn.github.io/math_visuals/`).
+- Vercel gir et eget domenenavn per prosjekt (f.eks. `math-visuals.vercel.app`) og støtter egendefinerte domener.
+
+## Ytelse og funksjoner
+- GitHub Pages er optimalisert for enkel hosting av statiske filer uten serverlogikk.
+- Vercel tilbyr funksjoner som edge caching, serverløse funksjoner og forhåndsvisningsdeploy per pull request.
+
+## Lenking mellom plattformer
+- Du kan lenke fra et GitHub Pages-nettsted til en Vercel-distribusjon ved å bruke en vanlig `<a href="https://...">`-lenke. Hvis du vil beholde eksisterende URL-er, kan GitHub Pages fungere som en portal som peker brukerne videre til den nye adressen på Vercel.

--- a/examples.js
+++ b/examples.js
@@ -1,3 +1,31 @@
+(function ensureVercelRedirect() {
+  if (typeof window === 'undefined') return;
+  if (window.__MATH_VISUALS_REDIRECT_INITIALIZED__) return;
+  const { hostname, pathname, search, hash } = window.location;
+  if (!hostname || !hostname.endsWith('github.io')) return;
+  window.__MATH_VISUALS_REDIRECT_INITIALIZED__ = true;
+  const targetOrigin = 'https://math-visuals.vercel.app';
+  const repoBasePath = '/math_visuals';
+  let path = typeof pathname === 'string' && pathname ? pathname : '/';
+  if (!path.startsWith('/')) {
+    path = `/${path}`;
+  }
+  const normalizedRepoPath = repoBasePath.toLowerCase();
+  if (normalizedRepoPath && path.toLowerCase().startsWith(normalizedRepoPath)) {
+    path = path.slice(repoBasePath.length) || '/';
+  }
+  if (!path.startsWith('/')) {
+    path = `/${path}`;
+  }
+  const destination = new URL(`${path}${search || ''}${hash || ''}`, targetOrigin).toString();
+  if (destination === window.location.href) return;
+  try {
+    window.location.replace(destination);
+  } catch (_) {
+    window.location.href = destination;
+  }
+})();
+
 (function () {
   const globalScope = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
   function createFallbackStorage() {

--- a/router.js
+++ b/router.js
@@ -1,3 +1,31 @@
+(function ensureVercelRedirect() {
+  if (typeof window === 'undefined') return;
+  if (window.__MATH_VISUALS_REDIRECT_INITIALIZED__) return;
+  const { hostname, pathname, search, hash } = window.location;
+  if (!hostname || !hostname.endsWith('github.io')) return;
+  window.__MATH_VISUALS_REDIRECT_INITIALIZED__ = true;
+  const targetOrigin = 'https://math-visuals.vercel.app';
+  const repoBasePath = '/math_visuals';
+  let path = typeof pathname === 'string' && pathname ? pathname : '/';
+  if (!path.startsWith('/')) {
+    path = `/${path}`;
+  }
+  const normalizedRepoPath = repoBasePath.toLowerCase();
+  if (normalizedRepoPath && path.toLowerCase().startsWith(normalizedRepoPath)) {
+    path = path.slice(repoBasePath.length) || '/';
+  }
+  if (!path.startsWith('/')) {
+    path = `/${path}`;
+  }
+  const destination = new URL(`${path}${search || ''}${hash || ''}`, targetOrigin).toString();
+  if (destination === window.location.href) return;
+  try {
+    window.location.replace(destination);
+  } catch (_) {
+    window.location.href = destination;
+  }
+})();
+
 const globalScope = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
 function createFallbackStorage() {
   const data = new Map();


### PR DESCRIPTION
## Summary
- add a client-side redirect that forwards GitHub Pages traffic to the Vercel deployment while preserving paths
- initialize the redirect logic from both the main router and example pages so all entry points redirect consistently

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db86e858188324af2c4f8c12443a2f