### PR TITLE
Fix iOS compatibility for mobile navigation toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,8 +404,13 @@
 
         navToggle.addEventListener('click', () => {
           const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
-          navToggle.setAttribute('aria-expanded', String(!isExpanded));
-          nav.classList.toggle('is-open', !isExpanded);
+          const nextState = !isExpanded;
+          navToggle.setAttribute('aria-expanded', String(nextState));
+          if (nextState) {
+            nav.classList.add('is-open');
+          } else {
+            nav.classList.remove('is-open');
+          }
         });
 
         if (navLinks) {


### PR DESCRIPTION
## Summary
- replace the use of the second argument to `classList.toggle` when opening the mobile menu
- ensure the menu button works consistently on browsers without support for the forced toggle parameter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd47e1124832493a5bc1ea3009669