### PR TITLE
Adjust mobile nav spacing for compact layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,51 +161,72 @@
 
     @media (max-width: 768px) {
       nav {
-        gap: 8px;
-        padding: 12px 16px;
+        gap: 6px;
+        padding: 10px 14px;
       }
       .nav-header {
         flex-wrap: wrap;
+        row-gap: 6px;
       }
       .nav-title {
         flex: 1 1 auto;
+        font-size: 0.95rem;
       }
       .nav-toggle {
         display: inline-flex;
+        padding: 6px 10px;
+        border-radius: 8px;
+        font-size: 0.95rem;
+      }
+      .nav-toggle svg {
+        width: 1.15rem;
+        height: 1.15rem;
       }
       ul {
         display: none;
         width: 100%;
         flex-wrap: wrap;
-        gap: 8px;
+        gap: 6px;
         overflow: visible;
       }
       nav.is-open ul {
         display: flex;
       }
       li {
-        flex: 1 1 calc(33.333% - 8px);
-        min-width: 3rem;
+        flex: 1 1 calc(25% - 6px);
+        min-width: 2.75rem;
       }
       nav a {
         width: 100%;
-        height: 3.25rem;
+        height: 2.7rem;
+        border-radius: 0.9rem;
+      }
+      nav svg {
+        width: 1.25rem;
+        height: 1.25rem;
+        stroke-width: 1.6;
       }
     }
 
     @media (max-width: 480px) {
       nav {
-        padding: 10px 12px;
+        padding: 8px 12px;
+      }
+      .nav-title {
+        font-size: 0.9rem;
+      }
+      .nav-toggle {
+        padding: 5px 9px;
       }
       li {
-        flex: 1 1 calc(50% - 8px);
+        flex: 1 1 calc(33.333% - 6px);
       }
       nav a {
-        height: 2.9rem;
+        height: 2.6rem;
       }
       nav svg {
-        width: 1.4rem;
-        height: 1.4rem;
+        width: 1.2rem;
+        height: 1.2rem;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- reduce padding and gaps in the mobile navigation to make the menu more compact
- scale down button, icon, and grid sizing so more items fit on small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dce1a9ae088324a23fb7d89be279c5