### PR TITLE
Fix mobile layout issues for brøkfigurer

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -63,6 +63,11 @@
     .figure-controls{display:flex;gap:var(--gap);align-items:center;}
     .figure-controls--cols{grid-column:2;grid-row:1;flex-direction:column;justify-self:center;}
     .figure-controls--rows{grid-column:1;grid-row:2;justify-self:center;}
+    @supports not (gap: 1rem) {
+      .figure-controls{gap:0;}
+      .figure-controls .addFigureBtn + .addFigureBtn{margin-left:var(--gap);}
+      .figure-controls--cols .addFigureBtn + .addFigureBtn{margin-left:0;margin-top:var(--gap);}
+    }
     .figurePanel{display:flex;flex-direction:column;align-items:center;gap:12px;min-width:0;height:100%;width:100%;justify-content:center;padding-block:12px;}
     .figurePanel__actions{display:flex;gap:10px;justify-content:center;flex-wrap:wrap;}
     .addFigureBtn{
@@ -84,11 +89,12 @@
       flex-direction:column;gap:10px;
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    .figure{width:100%;flex:1 1 auto;border-radius:10px;background:#fff;overflow:visible;border:none;display:flex;justify-content:center;align-items:center;min-height:0;}
+    .figure{width:100%;flex:1 1 auto;border-radius:10px;background:#fff;overflow:visible;border:none;display:flex;justify-content:center;align-items:center;min-height:var(--figure-size, 240px);}
     .figure .box{
       width:100%;
       max-width:var(--figure-size, 360px);
       max-height:100%;
+      min-height:var(--figure-size, 240px);
       aspect-ratio:1;
       margin:0 auto;
       position:relative;
@@ -128,6 +134,14 @@
     .colors input{flex:0 0 40px;width:40px;height:40px;}
     .input--digit{width:60px;padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;box-sizing:border-box;text-align:center;}
     .box svg *:focus{outline:none;}
+    @media(max-width:720px){
+      .figure-board{grid-template-columns:1fr;grid-template-rows:auto auto auto;}
+      .figure-controls--cols{grid-column:1;grid-row:2;flex-direction:row;}
+      .figure-controls--rows{grid-column:1;grid-row:3;justify-self:center;}
+      @supports not (gap: 1rem) {
+        .figure-controls--cols .addFigureBtn + .addFigureBtn{margin-top:0;margin-left:var(--gap);}
+      }
+    }
   </style>
   <link rel="stylesheet" href="split.css" />
 </head>


### PR DESCRIPTION
## Summary
- ensure the fraction figure panels maintain a visible size on small displays
- add responsive layout rules and gap fallbacks so the add/remove controls no longer overlap on Safari

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dce24e462083249db6a32904a4ab77