### PR TITLE
Add alt text support to Trefigurer exports

### DIFF
--- a/trefigurer.html
+++ b/trefigurer.html
@@ -297,6 +297,7 @@
     onload="this.dataset.loaded='true'"
     onerror="this.dataset.loaded='false'"
   ></script>
+  <script src="alt-text-ui.js"></script>
   <script src="trefigurer.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>


### PR DESCRIPTION
## Summary
- add the shared alt-text UI to Trefigurer so the export card shows an accessible description editor
- generate automatic descriptions for the current 3D figures and refresh them when figures or settings change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dda454990083248f2fd0353c3b11d0