### PR TITLE
Avoid clearing default examples when backend has no entry

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -481,11 +481,6 @@
     }
     if (res.status === 404) {
       backendAvailable = true;
-      applyBackendData({
-        examples: [],
-        deletedProvided: []
-      });
-      renderOptions();
       return {
         path: storagePath,
         examples: [],


### PR DESCRIPTION
## Summary
- prevent the examples backend 404 response from clearing locally provided default examples
- leave the existing defaults intact so the tabs no longer show "Ingen eksempler" after loading

## Testing
- npm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de2d7753608324b2fa08897700614d