### PR TITLE
Add automatic alt text generation to Graftegner

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -288,7 +288,7 @@
           </div>
         </div>
 
-        <div class="card">
+        <div class="card" id="exportCard">
           <h2>Eksporter</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn">Last ned SVG</button>
@@ -301,6 +301,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
+  <script src="alt-text-ui.js"></script>
   <script defer src="graftegner.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>


### PR DESCRIPTION
## Summary
- attach the shared alt-text UI to Graftegner's export card
- generate descriptive alt text from the current graph configuration and apply it to the board
- refresh the automatic suggestions when the form or rendered content changes

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de7e7077708324abed984ea03e3c67