### PR TITLE
Add alt text UI to figurtall and tenkeblokker

### DIFF
--- a/figurtall.html
+++ b/figurtall.html
@@ -209,7 +209,7 @@
             <button id="resetBtn" class="btn" type="button">Nullstill</button>
           </div>
         </div>
-        <div class="card">
+        <div class="card" id="exportCard">
           <h2>Eksporter</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
@@ -219,6 +219,7 @@
       </div>
     </div>
   </div>
+  <script src="alt-text-ui.js"></script>
   <script src="figurtall.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -194,7 +194,7 @@
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
-        <div class="card">
+        <div class="card" id="exportCard">
           <h2>Eksport</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
@@ -207,6 +207,7 @@
       </div>
     </div>
   </div>
+  <script src="alt-text-ui.js"></script>
   <script src="tenkeblokker.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>


### PR DESCRIPTION
## Summary
- add shared alt-tekstpanel to figurtall and tenkeblokker sider
- generer og synkroniser beskrivende alternativ tekst basert på gjeldende konfigurasjon
- inkludér alternativ tekst i eksporterte SVG-filer for begge verktøy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de9835eec48324bc00a5abbf01b51e