### PR TITLE
Add alternative text management to Kuler

### DIFF
--- a/kuler.html
+++ b/kuler.html
@@ -113,7 +113,7 @@
         <div class="card card--settings">
           <div id="controls" class="controlsWrap"></div>
         </div>
-        <div class="card">
+        <div class="card" id="exportCard">
           <h2>Eksporter</h2>
           <div id="exportToolbar1" class="toolbar">
             <button id="downloadSVG1" class="btn" type="button">Last ned SVG</button>
@@ -135,6 +135,7 @@
       </div>
     </div>
   </div>
+  <script src="alt-text-ui.js"></script>
   <script src="kuler.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>


### PR DESCRIPTION
## Summary
- add alternative text state and generation for the Kuler visualization and exported figures
- expose the alt-text UI within the export card so authors can review and edit descriptions

## Testing
- npm test *(fails: styling-consistency and export-related suites in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de9bd10d688324b111e439f06f9f14