### PR TITLE
Add shared style consistency check to test suite

### DIFF
--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -14,6 +14,11 @@ Dette dokumentet skisserer flere nivåer av automatisert testing som kan hjelpe 
    - Innhold: Sikrer konsistent formattering og gjør git-diff enklere å lese.
    - Integrasjon: Kjør `npm run format:check` i CI; tilby en `format`-kommando lokalt.
 
+3. **Felles stylingkonvensjoner**
+   - Verktøy: Node-skriptet `tests/check-shared-styles.js`.
+   - Innhold: Verifiserer at visualiseringenes HTML-filer inkluderer viewport-metaen, lenken til `base.css` og de forventede `.wrap`/`.grid`-layoutbeholderne.
+   - Integrasjon: Kjøres automatisk via `npm test` både lokalt og i CI.
+
 ## 2. Enhetstester
 
 1. **Funksjonelle moduler**

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "arealmodell0.js",
   "scripts": {
-    "test": "playwright test",
+    "test": "node tests/check-shared-styles.js && playwright test",
     "start": "npx http-server -c-1"
   },
   "keywords": [],

--- a/tests/check-shared-styles.js
+++ b/tests/check-shared-styles.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const skipDirectories = new Set(['node_modules', '.git', 'docs', 'tests', 'vendor']);
+const skipFiles = new Set(['index.html']);
+
+function collectHtmlFiles(startDir) {
+  const entries = fs.readdirSync(startDir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const absolutePath = path.join(startDir, entry.name);
+    if (entry.isDirectory()) {
+      if (skipDirectories.has(entry.name)) {
+        continue;
+      }
+      files.push(...collectHtmlFiles(absolutePath));
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      const relative = path.relative(repoRoot, absolutePath);
+      if (!skipFiles.has(relative)) {
+        files.push({ absolute: absolutePath, relative });
+      }
+    }
+  }
+
+  return files;
+}
+
+const htmlFiles = collectHtmlFiles(repoRoot);
+
+const checks = [
+  {
+    name: 'viewport meta tag',
+    pattern: /<meta\s+name=["']viewport["']\s+content=["']width=device-width,initial-scale=1["']\s*\/?\s*>/i,
+  },
+  {
+    name: 'base.css stylesheet',
+    pattern: /<link[^>]+href=["'](?:(?:\.\.?\/)+|\/)?base\.css["'][^>]*>/i,
+  },
+  {
+    name: '.wrap layout container',
+    pattern: /class=["'][^"']*\bwrap\b[^"']*["']/i,
+  },
+  {
+    name: '.grid layout container',
+    pattern: /class=["'][^"']*\bgrid\b[^"']*["']/i,
+  },
+];
+
+const failures = [];
+
+for (const file of htmlFiles) {
+  const content = fs.readFileSync(file.absolute, 'utf8');
+  for (const check of checks) {
+    if (!check.pattern.test(content)) {
+      failures.push(`${file.relative}: missing ${check.name}`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Shared styling check failed:');
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exitCode = 1;
+} else {
+  console.log(`Shared styling check passed for ${htmlFiles.length} files.`);
+}


### PR DESCRIPTION
## Summary
- add a Node-based shared styling guard that validates viewport meta, base.css usage, and layout containers across visualization HTML files
- run the shared styling guard as part of `npm test` before the existing Playwright suite
- document the new check in the automated test plan

## Testing
- npm test *(fails: Playwright browsers need to be installed with `npx playwright install` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de9d898bb88324844c336e731fd066