### PR TITLE
Add alt text support for Brøkvegg and Fortegnsskjema

### DIFF
--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -265,7 +265,7 @@
           </fieldset>
         </div>
 
-        <div class="card card--export">
+        <div class="card card--export" id="exportCard">
           <h2>Eksporter</h2>
           <div class="toolbar">
             <button id="btnDownloadSvg" class="btn" type="button">Last ned SVG</button>
@@ -276,6 +276,7 @@
     </div>
   </div>
 
+  <script src="alt-text-ui.js"></script>
   <script src="brøkvegg.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>

--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -448,7 +448,7 @@
           </div>
         </div>
 
-        <div class="card">
+        <div class="card" id="exportCard">
           <h2>Eksporter</h2>
           <div class="toolbar">
             <button type="button" class="btn" id="btnDownloadSvg">Last ned SVG</button>
@@ -460,6 +460,7 @@
   </div>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/mathlive/dist/mathlive.min.js"></script>
+  <script src="alt-text-ui.js"></script>
   <script src="fortegnsskjema.js"></script>
   <script src="split.js"></script>
   <script src="examples.js"></script>


### PR DESCRIPTION
## Summary
- integrate the shared alternative text UI into the Brøkvegg and Fortegnsskjema pages
- add automatic alt-text generation and persistence for the Brøkvegg fraction wall
- add automatic alt-text generation and persistence for the Fortegnsskjema sign chart, including reacting to expression updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dea6b01c648324a2787a72ad934c7c