### PR TITLE
Add CI workflow to run tests automatically

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on pushes to main and all pull requests
- install dependencies and Playwright browsers before running the existing npm test suite

## Testing
- npm test (fails: Playwright browsers not installed yet)

------
https://chatgpt.com/codex/tasks/task_e_68deafdda2ec83249779072419f6a6b2