### PR TITLE
Minimize empty task descriptions

### DIFF
--- a/base.css
+++ b/base.css
@@ -219,6 +219,21 @@ select:disabled {
   color: var(--label-color);
 }
 
+.card--examples .example-description.example-description--collapsed {
+  gap: 0;
+}
+
+.card--examples .example-description.example-description--collapsed textarea {
+  min-height: 0;
+  height: 1px;
+  padding: 0;
+  margin: 0;
+  border-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  resize: none;
+}
+
 .form-row {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/examples.js
+++ b/examples.js
@@ -508,9 +508,33 @@
   let tabsContainer = null;
   let tabButtons = [];
   let descriptionInput = null;
+  const descriptionInputsWithListeners = new WeakSet();
+
+  function updateDescriptionCollapsedState(target) {
+    const input = target && target.nodeType === 1 ? target : getDescriptionInput();
+    if (!input || typeof input.value !== 'string') return;
+    const container = input.closest('.example-description');
+    if (!container) return;
+    const isFocused = document.activeElement === input;
+    const shouldCollapse = !isFocused && input.value.trim() === '';
+    container.classList.toggle('example-description--collapsed', shouldCollapse);
+  }
+
+  function ensureDescriptionListeners(input) {
+    if (!input || descriptionInputsWithListeners.has(input)) return;
+    descriptionInputsWithListeners.add(input);
+    const update = () => updateDescriptionCollapsedState(input);
+    input.addEventListener('input', update);
+    input.addEventListener('change', update);
+    input.addEventListener('focus', update);
+    input.addEventListener('blur', update);
+    setTimeout(update, 0);
+  }
+
   function getDescriptionInput() {
     if (descriptionInput && descriptionInput.isConnected) return descriptionInput;
     descriptionInput = document.getElementById('exampleDescription');
+    if (descriptionInput) ensureDescriptionListeners(descriptionInput);
     return descriptionInput || null;
   }
   function getDescriptionValue() {
@@ -527,6 +551,7 @@
     } else {
       input.value = '';
     }
+    updateDescriptionCollapsedState(input);
   }
   let defaultEnsureScheduled = false;
   let tabsHostCard = null;

--- a/split.css
+++ b/split.css
@@ -122,6 +122,21 @@
   min-height: 72px;
 }
 
+.card--examples .example-description.example-description--collapsed {
+  gap: 0;
+}
+
+.card--examples .example-description.example-description--collapsed textarea {
+  min-height: 0;
+  height: 1px;
+  padding: 0;
+  margin: 0;
+  border-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  resize: none;
+}
+
 .card--settings input[type="checkbox"],
 .card--settings input[type="radio"],
 .card[data-card="settings"] input[type="checkbox"],


### PR DESCRIPTION
## Summary
- collapse the optional task description textarea when it is empty
- share collapsed styling in both base and split layouts so the label remains compact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deb534cb648324ac400012f83f4139