### PR TITLE
Simplify CI test step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,5 @@ jobs:
       - name: Install Playwright browsers (Chromium, Firefox, WebKit)
         run: npx playwright install --with-deps
 
-      - name: Check shared CSS variables and base styles
-        run: node tests/check-shared-styles.js
-
-      - name: Run Playwright end-to-end suite
-        run: npx playwright test
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- replace the separate shared-style and Playwright steps with a single npm test command so the workflow only reports one test run

## Testing
- npm test (fails locally: Playwright browsers not installed)

------
https://chatgpt.com/codex/tasks/task_e_68debb999e948324bd28fd657f5300fe