### PR TITLE
Use KaTeX for Tallinje fractions

### DIFF
--- a/tallinje.html
+++ b/tallinje.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Tallinje</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" />
   <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }
@@ -40,9 +41,11 @@
       background: #fafbfc;
       overflow: hidden;
       border: 1px solid #eef0f3;
+      position: relative;
     }
     .figure svg { width: 100%; height: 320px; display: block; }
     .toolbar { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+    .toolbar--menu { width: 100%; }
     .btn {
       appearance: none;
       border: 1px solid #d1d5db;
@@ -76,7 +79,36 @@
     .number-line-base { stroke: #0f172a; stroke-width: 4; stroke-linecap: round; }
     .major-tick { stroke: #0f172a; stroke-width: 3; stroke-linecap: round; }
     .minor-tick { stroke: #4b5563; stroke-width: 2; stroke-linecap: round; opacity: 0.75; }
-    .major-label { font-size: 18px; fill: #111827; font-weight: 500; }
+    .major-label-fo { pointer-events: none; }
+    .major-label {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 18px;
+      font-weight: 500;
+      color: #111827;
+      line-height: 1.1;
+      white-space: nowrap;
+      pointer-events: none;
+    }
+    .major-label .katex { font-size: 1.05em; }
+    .badge-beta {
+      margin-left: auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 30px;
+      height: 30px;
+      border-radius: 50%;
+      background: #0f6d8f;
+      color: #fff;
+      font-size: 16px;
+      font-weight: 600;
+      line-height: 1;
+      box-shadow: 0 2px 6px rgba(15, 109, 143, 0.25);
+    }
   </style>
   <link rel="stylesheet" href="split.css" />
 </head>
@@ -95,9 +127,10 @@
             <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
-          <div class="toolbar">
+          <div class="toolbar toolbar--menu">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <span class="badge-beta" role="text" aria-label="Beta" title="Beta">β</span>
           </div>
         </div>
 
@@ -145,6 +178,7 @@
     </div>
   </div>
 
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" onload="window.dispatchEvent(new Event('katexloaded'))"></script>
   <script src="alt-text-ui.js"></script>
   <script src="tallinje.js"></script>
   <script src="examples.js"></script>


### PR DESCRIPTION
## Summary
- render fraction labels on the Tallinje number line with KaTeX and HTML-based SVG labels
- extend the axis stroke to the full SVG width and ensure labels align via foreignObject containers
- add a beta badge in the Tallinje example toolbar and load the KaTeX CDN resources

## Testing
- npm test *(fails: Playwright browser download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68defce1de688324b4760a3e8c730c52