### PR TITLE
Add clamp option to number line

### DIFF
--- a/tallinje.html
+++ b/tallinje.html
@@ -73,6 +73,8 @@
       font-size: 12px;
       color: #6b7280;
     }
+    .checkbox-field { flex-direction: row; align-items: center; gap: 8px; font-weight: 500; }
+    .checkbox-field input[type="checkbox"] { width: auto; height: auto; margin: 0; }
     .number-line-base { stroke: #0f172a; stroke-width: 4; stroke-linecap: round; }
     .major-tick { stroke: #0f172a; stroke-width: 3; stroke-linecap: round; }
     .minor-tick { stroke: #4b5563; stroke-width: 2; stroke-linecap: round; opacity: 0.75; }
@@ -167,7 +169,11 @@
               <input id="cfg-labelFontSize" type="number" min="8" max="72" />
             </label>
           </div>
-          <p class="hint">Tallinjen viser 10&nbsp;% margin utenfor første og siste hovedmarkering.</p>
+          <label class="checkbox-field">
+            <input id="cfg-clampLine" type="checkbox" />
+            Stopp tallinjen ved start- og sluttpunktet
+          </label>
+          <p class="hint">Når avmerkingen er slått av, viser tallinjen 10&nbsp;% margin med ekstra markeringer utenfor start og stopp.</p>
         </div>
 
         <div class="card" id="exportCard">


### PR DESCRIPTION
## Summary
- add a checkbox in Tallinje settings to clamp the number line to the configured start and stop
- update rendering, tick generation, and alt text to respect the clamp option and extend marks when disabled
- persist the new setting in defaults and example presets

## Testing
- npm test --silent *(fails: Playwright browsers and system dependencies are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df7cbe87cc83249e63c5b7d74189fc