### PR TITLE
Fix styling consistency button checks

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -324,7 +324,7 @@
       padding: 8px 14px;
       cursor: pointer;
       font-size: 14px;
-      color: #1f2937;
+      color: inherit;
       transition: background 0.2s ease;
     }
     .btn:hover {

--- a/tests/styling-consistency.spec.js
+++ b/tests/styling-consistency.spec.js
@@ -21,9 +21,8 @@ test.describe('Styling consistency across visualizations', () => {
         probeButton.className = 'btn';
         document.body.appendChild(probeButton);
         const buttonStyle = getComputedStyle(probeButton);
-        probeButton.remove();
 
-        return {
+        const stylesSnapshot = {
           root: {
             surfaceBg: rootStyle.getPropertyValue('--surface-bg').trim(),
             textColor: rootStyle.getPropertyValue('--text-color').trim(),
@@ -42,6 +41,10 @@ test.describe('Styling consistency across visualizations', () => {
             fontFamily: buttonStyle.fontFamily
           }
         };
+
+        probeButton.remove();
+
+        return stylesSnapshot;
       });
 
       expect.soft(styles.root.surfaceBg).toBe('#f7f8fb');


### PR DESCRIPTION
## Summary
- snapshot button styles before removal in the styling consistency test so computed values persist
- make Fortegnsskjema buttons inherit the shared text color to match the base styling expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df8ff5dcb88324b291f1c82dcab3b1