### PR TITLE
Add line chart example with negative y-axis support

### DIFF
--- a/diagram/index.html
+++ b/diagram/index.html
@@ -66,6 +66,9 @@
               </label>
             </div>
             <div class="settings-row">
+              <label>Min y (valgfritt)
+                <input id="cfgYMin" type="text" value="0">
+              </label>
               <label>Maks y (valgfritt)
                 <input id="cfgYMax" type="text" value="8">
               </label>


### PR DESCRIPTION
## Summary
- add a default line chart example that plots temperature data with negative values
- extend the diagram configuration to support configurable minimum y-values and dynamic scaling for negative ranges
- update the UI with a Min y field and adjust rendering logic so bars, lines, and axes respect negative baselines

## Testing
- npm test *(fails: Playwright cannot launch browsers because required system libraries are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68df918c34b88324bb355b9416cb0a88