### PR TITLE
Prevent settings sync from reloading graftegner

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -4026,7 +4026,20 @@ function setupSettingsForm() {
       }
     };
     handleFontInput('cfgFontSize', 'fontSize', currentFontSize, { keepWhenEqual: keepFontParam });
-    location.search = p.toString();
+    const newSearch = p.toString();
+    const currentSearch = typeof window !== 'undefined' && window.location ? window.location.search : '';
+    const normalizedCurrentSearch = currentSearch.startsWith('?') ? currentSearch.slice(1) : currentSearch;
+    if (newSearch !== normalizedCurrentSearch) {
+      const hash = typeof window !== 'undefined' && window.location ? window.location.hash || '' : '';
+      const basePath = typeof window !== 'undefined' && window.location ? window.location.pathname || '' : '';
+      const nextSearch = newSearch ? `?${newSearch}` : '';
+      const nextUrl = `${basePath}${nextSearch}${hash}`;
+      if (typeof window !== 'undefined' && window.history && typeof window.history.replaceState === 'function') {
+        window.history.replaceState(null, '', nextUrl);
+      } else if (typeof window !== 'undefined' && window.location) {
+        window.location.search = newSearch;
+      }
+    }
   };
   root.addEventListener('change', apply);
   root.addEventListener('keydown', e => {


### PR DESCRIPTION
## Summary
- avoid reloading graftegner when settings UI fires synthetic change events by replacing `location.search` assignment with history updates
- skip URL updates when no query-string changes and preserve existing hash fragments

## Testing
- PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1 CI=1 npx playwright test tests/styling-consistency.spec.js --project=chromium --grep "graftegner" *(fails: missing system libraries for Chromium in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df95b733e88324b7b9923e8f392801