### PR TITLE
Normalize example storage keys across HTML variants

### DIFF
--- a/examples-viewer.js
+++ b/examples-viewer.js
@@ -239,6 +239,10 @@ function normalizePath(value) {
   path = path.replace(/[\\]+/g, '/');
   path = path.replace(/\/+/g, '/');
   path = path.replace(/\/index\.html?$/i, '/');
+  if (/\.html?$/i.test(path)) {
+    path = path.replace(/\.html?$/i, '');
+    if (!path) path = '/';
+  }
   if (path.length > 1 && path.endsWith('/')) {
     path = path.slice(0, -1);
   }

--- a/examples.js
+++ b/examples.js
@@ -274,6 +274,11 @@
     path = path.replace(/\/+/g, '/');
     // Remove trailing index.html or index.htm
     path = path.replace(/\/index\.html?$/i, '/');
+    // Treat page.html and page.htm as the same canonical location as /page
+    if (/\.html?$/i.test(path)) {
+      path = path.replace(/\.html?$/i, '');
+      if (!path) path = '/';
+    }
     if (path.length > 1 && path.endsWith('/')) {
       path = path.slice(0, -1);
     }
@@ -340,6 +345,10 @@
     addPath(canonicalPath);
     if (canonicalPath && canonicalPath !== '/' && !canonicalPath.endsWith('/')) {
       addPath(canonicalPath + '/');
+    }
+    if (canonicalPath && canonicalPath !== '/' && !/\.html?$/i.test(canonicalPath)) {
+      addPath(`${canonicalPath}.html`);
+      addPath(`${canonicalPath}.htm`);
     }
     const canonicalBase = canonicalPath.endsWith('/') ? canonicalPath : `${canonicalPath}/`;
     addPath(canonicalBase + 'index.html');


### PR DESCRIPTION
## Summary
- normalize example storage paths by stripping trailing .html/.htm so graftegner and other pages share the same key across browsers
- extend legacy migration to pull forward data saved under former .html/.htm keys
- align the examples viewer path normalization with the new canonicalization

## Testing
- npm test *(fails: missing Playwright browser dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df964a35708324abe85fc0a3dac022