### PR TITLE
Add beta badge to tallinje navigation entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,17 +371,6 @@
         </a>
       </li>
       <li>
-        <a href="tallinje.html" target="content" title="Tallinje" aria-label="Tallinje">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <line x1="3" y1="12" x2="21" y2="12" stroke-linecap="round" />
-            <line x1="7" y1="8" x2="7" y2="16" stroke-linecap="round" />
-            <line x1="12" y1="9" x2="12" y2="15" stroke-linecap="round" />
-            <line x1="17" y1="9.5" x2="17" y2="14.5" stroke-linecap="round" />
-          </svg>
-          <span class="sr-only">Tallinje</span>
-        </a>
-      </li>
-      <li>
         <a href="kuler.html" target="content" title="Kuler" aria-label="Kuler">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 11q9 9 18 0" />
@@ -449,6 +438,18 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 18h16" />
           </svg>
           <span class="sr-only">Fortegnsskjema</span>
+          <span class="nav-badge" aria-hidden="true">Beta</span>
+        </a>
+      </li>
+      <li>
+        <a href="tallinje.html" target="content" title="Tallinje (beta)" aria-label="Tallinje (beta)">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <line x1="3" y1="12" x2="21" y2="12" stroke-linecap="round" />
+            <line x1="7" y1="8" x2="7" y2="16" stroke-linecap="round" />
+            <line x1="12" y1="9" x2="12" y2="15" stroke-linecap="round" />
+            <line x1="17" y1="9.5" x2="17" y2="14.5" stroke-linecap="round" />
+          </svg>
+          <span class="sr-only">Tallinje</span>
           <span class="nav-badge" aria-hidden="true">Beta</span>
         </a>
       </li>


### PR DESCRIPTION
## Summary
- mark the Tallinje navigation link as beta with a badge on the icon
- move the Tallinje link to the end of the navigation menu for consistency with other beta tools

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df98674d388324aeaddce3cbe0824a