### PR TITLE
Normalize canonical example storage key encoding

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -277,7 +277,19 @@
     if (path.length > 1 && path.endsWith('/')) {
       path = path.slice(0, -1);
     }
-    return path || '/';
+    if (!path) return '/';
+    let decoded = path;
+    try {
+      decoded = decodeURI(path);
+    } catch (_) {}
+    let encoded = decoded;
+    try {
+      encoded = encodeURI(decoded);
+    } catch (_) {
+      encoded = path;
+    }
+    if (!encoded) return '/';
+    return encoded.replace(/%[0-9a-f]{2}/gi, match => match.toUpperCase());
   }
   function computeLegacyStorageKeys(rawPath, canonicalPath) {
     const prefix = 'examples_';


### PR DESCRIPTION
## Summary
- ensure the canonical example storage path is always returned percent-encoded
- re-encode decoded paths and normalize percent-escape casing to avoid missing migrations

## Testing
- npx playwright test tests/examples-legacy-keys.spec.js *(fails: missing Playwright system dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df9aa7e4d48324a9dd58c41312ebfb