### PR TITLE
Halve tick lengths on number line visualization

### DIFF
--- a/tallinje.js
+++ b/tallinje.js
@@ -368,8 +368,8 @@
     const paddingRight = 80;
     const width = 1000;
     const baselineY = 140;
-    const majorTickHeight = 32;
-    const minorTickHeight = 18;
+    const majorTickHeight = 16;
+    const minorTickHeight = 9;
     const labelOffset = 52 + (STATE.labelFontSize - BASE_LABEL_FONT_SIZE) * 1.2;
 
     const domainMin = clampToRange ? from : from - margin;


### PR DESCRIPTION
## Summary
- halve the size of the major and minor tick marks on the number line to shorten their horizontal segments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df9b0b3c208324ad9a93fb52a29de9