### PR TITLE
Add configurable value labels for diagrams

### DIFF
--- a/diagram.css
+++ b/diagram.css
@@ -80,7 +80,7 @@ body {
 .pie-slice{stroke:#fff;stroke-width:2;cursor:pointer}
 .pie-divider{stroke:#fff;stroke-width:2;stroke-dasharray:6 6;opacity:.6}
 .pie-label{fill:#333;font-size:16px;font-weight:600;pointer-events:none}
-.pie-label__percent{font-size:14px;font-weight:400;pointer-events:none}
+.pie-label__value{font-size:14px;font-weight:400;pointer-events:none}
 .pie-slice-0{fill:#4f2c8c}
 .pie-slice-1{fill:#6c3db5}
 .pie-slice-2{fill:#8a4de0}

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -55,6 +55,14 @@
                 <option value="pie">Sektordiagram</option>
               </select>
             </label>
+            <label id="cfgValueDisplayWrapper">Vis verdier
+              <select id="cfgValueDisplay">
+                <option value="none" selected>Ingen</option>
+                <option value="number">Tall</option>
+                <option value="fraction">Brøk</option>
+                <option value="percent">Prosent</option>
+              </select>
+            </label>
             <label>Overskrift
               <input id="cfgTitle" type="text" value="Favorittidretter i 5B">
             </label>


### PR DESCRIPTION
## Summary
- add a "Vis verdier" selector so authors can choose how to show data labels
- render formatted values for bar, grouped bar, line, and pie charts using number, fraction, or percent formats
- update pie label styling to support the new configurable value display

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfabaf58c8832492ad92956439ee1c