### PR TITLE
Show diagram value ratios and render fractions with KaTeX

### DIFF
--- a/diagram.css
+++ b/diagram.css
@@ -94,6 +94,9 @@ body {
 
 /* Verdi‐tekst over søyle (ikke-interaktiv) */
 .value{fill:#111;font-size:16px;text-anchor:middle;paint-order:stroke fill;stroke:#fff;stroke-width:6;pointer-events:none}
+.value-fo{overflow:visible;pointer-events:none}
+.value.value--html{color:#111;font-size:16px;justify-content:center;text-align:center;text-shadow:0 0 6px #fff,0 0 2px #fff;font-weight:500;}
+.value.value--html .katex{pointer-events:none}
 
 /* Låsing */
 .bar.locked{cursor:not-allowed}

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="../base.css" />
   <link rel="stylesheet" href="../diagram.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-ywTprUI1Q+mEFz1Ok5AR52lCstOEPCTpQJZMa2+pzSQPwXTwns32xERiqnnn6T5+" crossorigin="anonymous" />
 
   <style>
     svg { touch-action: none; }
@@ -145,9 +146,10 @@
     </div>
   </div>
 
-  <script src="../diagram.js"></script>
-  <script src="../examples.js"></script>
-  <script src="../split.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" integrity="sha384-95pQhY9qsK0kGugHgdGXNqBJ38qRAjPR9U1FVLtZL1NVr7DiJ9N6byj1LxX+BPvk" crossorigin="anonymous"></script>
+  <script defer src="../diagram.js"></script>
+  <script defer src="../examples.js"></script>
+  <script defer src="../split.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- compute percent and fraction value displays from each series total across bar, line, and grouped charts
- render fraction value labels with KaTeX via SVG foreignObject overlays and supporting helpers
- load KaTeX assets and add styling for the new HTML-based value labels

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfb2b7ee4c83249dbdc9499a350c82