### PR TITLE
Add visual marker for collapsed oppgavetekst field

### DIFF
--- a/base.css
+++ b/base.css
@@ -217,10 +217,41 @@ select:disabled {
   gap: 6px;
   font-size: 13px;
   color: var(--label-color);
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.card--examples .example-description label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.card--examples .example-description label::after {
+  content: '';
+  display: none;
 }
 
 .card--examples .example-description.example-description--collapsed {
   gap: 0;
+  padding: 10px;
+  border: 1px dashed #c7d2fe;
+  border-radius: var(--control-radius);
+  background: #f8fafc;
+}
+
+.card--examples .example-description.example-description--collapsed label::after {
+  content: 'Skjult felt';
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: #4338ca;
+  background: #e0e7ff;
+  border-radius: 999px;
+  padding: 2px 8px;
+  text-transform: uppercase;
 }
 
 .card--examples .example-description.example-description--collapsed textarea {

--- a/split.css
+++ b/split.css
@@ -108,6 +108,18 @@
   gap: 6px;
   font-size: 13px;
   color: #4b5563;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.card--examples .example-description label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.card--examples .example-description label::after {
+  content: '';
+  display: none;
 }
 
 .card--examples .example-description textarea {
@@ -124,6 +136,25 @@
 
 .card--examples .example-description.example-description--collapsed {
   gap: 0;
+  padding: 10px;
+  border: 1px dashed #c7d2fe;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.card--examples .example-description.example-description--collapsed label::after {
+  content: 'Skjult felt';
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: #4338ca;
+  background: #e0e7ff;
+  border-radius: 999px;
+  padding: 2px 8px;
+  text-transform: uppercase;
 }
 
 .card--examples .example-description.example-description--collapsed textarea {


### PR DESCRIPTION
## Summary
- add a dashed highlight and badge to the collapsed Oppgavetekst field so its hidden state is visible
- ensure styling is applied consistently in both the standard and split stylesheets

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dfb47ae3288324b080c3c542c43250