### PR TITLE
Remove hidden field label badge

### DIFF
--- a/base.css
+++ b/base.css
@@ -240,18 +240,7 @@ select:disabled {
 }
 
 .card--examples .example-description.example-description--collapsed label::after {
-  content: 'Skjult felt';
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  color: #4338ca;
-  background: #e0e7ff;
-  border-radius: 999px;
-  padding: 2px 8px;
-  text-transform: uppercase;
+  display: none;
 }
 
 .card--examples .example-description.example-description--collapsed textarea {

--- a/split.css
+++ b/split.css
@@ -143,18 +143,7 @@
 }
 
 .card--examples .example-description.example-description--collapsed label::after {
-  content: 'Skjult felt';
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  color: #4338ca;
-  background: #e0e7ff;
-  border-radius: 999px;
-  padding: 2px 8px;
-  text-transform: uppercase;
+  display: none;
 }
 
 .card--examples .example-description.example-description--collapsed textarea {


### PR DESCRIPTION
## Summary
- hide the "Skjult felt" pseudo-element so only the base label is shown when the description is collapsed
- keep the collapsed styling unchanged aside from removing the badge text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfbd5cb5808324806d773023d92bff