### PR TITLE
Handle proportional line template for ax expressions

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -236,8 +236,15 @@ function extractLineRhs(expr) {
 function interpretLineTemplate(rhs) {
   const base = { kind: null, anchorC: 0, slopeM: 1 };
   if (typeof rhs !== 'string') return base;
-  const normalized = rhs.replace(/\s+/g, '').toLowerCase();
+  const normalized = rhs.replace(/\s+/g, '').replace(/·/g, '*').replace(/,/g, '.').replace(/−/g, '-').toLowerCase();
   if (!normalized) return base;
+  if (/^a\*?x$/.test(normalized)) {
+    return {
+      kind: 'anchorY',
+      anchorC: 0,
+      slopeM: 1
+    };
+  }
   if (/^a\*?x([+-])(\d+(?:\.\d+)?)$/.test(normalized)) {
     const sign = RegExp.$1 === '-' ? -1 : 1;
     const value = Number.parseFloat(RegExp.$2);


### PR DESCRIPTION
## Summary
- extend the line template parser to normalize additional characters
- detect ax templates so proportional graphs anchor at the origin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfbe181fa8832482e156e5ba857720