### PR TITLE
Use data-label attributes for navigation tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
       transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
     }
     nav a::after {
-      content: attr(title);
+      content: attr(data-label);
       position: absolute;
       left: 50%;
       top: 100%;
@@ -303,7 +303,7 @@
     </div>
     <ul id="nav-list">
       <li>
-        <a href="graftegner.html" target="content" title="Graftegner" aria-label="Graftegner">
+        <a href="graftegner.html" target="content" data-label="Graftegner" aria-label="Graftegner">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M6.5 8.5Q12 21 17.5 8.5" />
@@ -312,7 +312,7 @@
         </a>
       </li>
       <li>
-        <a href="nkant.html" target="content" title="nKant" aria-label="nKant">
+        <a href="nkant.html" target="content" data-label="nKant" aria-label="nKant">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <polygon stroke-linejoin="round" points="12 4 20 20 4 20" />
           </svg>
@@ -320,7 +320,7 @@
         </a>
       </li>
       <li>
-        <a href="diagram/index.html" target="content" title="Diagram" aria-label="Diagram">
+        <a href="diagram/index.html" target="content" data-label="Diagram" aria-label="Diagram">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75Z" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625Z" />
@@ -330,7 +330,7 @@
         </a>
       </li>
       <li>
-        <a href="brøkpizza.html" target="content" title="Brøkpizza" aria-label="Brøkpizza">
+        <a href="brøkpizza.html" target="content" data-label="Brøkpizza" aria-label="Brøkpizza">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z" />
@@ -339,7 +339,7 @@
         </a>
       </li>
       <li>
-        <a href="brøkfigurer.html" target="content" title="Brøkfigurer" aria-label="Brøkfigurer">
+        <a href="brøkfigurer.html" target="content" data-label="Brøkfigurer" aria-label="Brøkfigurer">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <polygon points="4 20 12 20 12 4" fill="currentColor" />
             <polygon points="4 20 20 20 12 4" />
@@ -349,7 +349,7 @@
         </a>
       </li>
       <li>
-        <a href="figurtall.html" target="content" title="Figurtall" aria-label="Figurtall">
+        <a href="figurtall.html" target="content" data-label="Figurtall" aria-label="Figurtall">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <rect x="3" y="15" width="6" height="6" fill="currentColor" stroke="none" />
             <rect x="9" y="9" width="6" height="6" fill="currentColor" stroke="none" />
@@ -362,7 +362,7 @@
         </a>
       </li>
       <li>
-        <a href="tenkeblokker.html" target="content" title="Tenkeblokker" aria-label="Tenkeblokker">
+        <a href="tenkeblokker.html" target="content" data-label="Tenkeblokker" aria-label="Tenkeblokker">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 40" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <line x1="0" y1="5" x2="100" y2="5" stroke-linecap="round" />
             <rect x="0" y="10" width="100" height="25" fill="currentColor" stroke="none" />
@@ -371,7 +371,7 @@
         </a>
       </li>
       <li>
-        <a href="arealmodell.html" target="content" title="Arealmodell" aria-label="Arealmodell">
+        <a href="arealmodell.html" target="content" data-label="Arealmodell" aria-label="Arealmodell">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <rect x="4" y="5" width="16" height="14" rx="1.8" stroke="currentColor" stroke-width="1.4" />
             <rect x="4.5" y="5.5" width="7" height="6" fill="currentColor" fill-opacity=".15" stroke="none" />
@@ -385,7 +385,7 @@
         </a>
       </li>
       <li>
-        <a href="perlesnor.html" target="content" title="Perlesnor" aria-label="Perlesnor">
+        <a href="perlesnor.html" target="content" data-label="Perlesnor" aria-label="Perlesnor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M2 12h20" />
             <circle cx="6" cy="12" r="1.5" />
@@ -396,7 +396,7 @@
         </a>
       </li>
       <li>
-        <a href="kuler.html" target="content" title="Kuler" aria-label="Kuler">
+        <a href="kuler.html" target="content" data-label="Kuler" aria-label="Kuler">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 11q9 9 18 0" />
             <circle cx="9" cy="13" r="1.5" fill="currentColor" stroke="none" />
@@ -407,7 +407,7 @@
         </a>
       </li>
       <li>
-        <a href="kvikkbilder.html" target="content" title="Kvikkbilder" aria-label="Kvikkbilder">
+        <a href="kvikkbilder.html" target="content" data-label="Kvikkbilder" aria-label="Kvikkbilder">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <circle cx="6" cy="8" r="1.5" fill="currentColor" stroke="none" />
             <circle cx="12" cy="8" r="1.5" fill="currentColor" stroke="none" />
@@ -420,7 +420,7 @@
         </a>
       </li>
       <li>
-        <a href="trefigurer.html" target="content" title="Trefigurer" aria-label="Trefigurer">
+        <a href="trefigurer.html" target="content" data-label="Trefigurer" aria-label="Trefigurer">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M6 6v8c0 2.05 2.686 3.7 6 3.7s6-1.65 6-3.7V6c0 2.05-2.686 3.7-6 3.7S6 8.05 6 6Z" fill="currentColor" fill-opacity=".15" />
             <ellipse cx="12" cy="6" rx="6" ry="3.2" fill="currentColor" fill-opacity=".2" />
@@ -432,7 +432,7 @@
         </a>
       </li>
       <li>
-        <a href="brøkvegg.html" target="content" title="Brøkvegg" aria-label="Brøkvegg">
+        <a href="brøkvegg.html" target="content" data-label="Brøkvegg" aria-label="Brøkvegg">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <rect x="4" y="4" width="16" height="4" rx="1.5" fill="currentColor" stroke="none" />
             <rect x="4" y="10" width="16" height="4" rx="1.5" />
@@ -442,7 +442,7 @@
         </a>
       </li>
       <li>
-        <a href="prikktilprikk.html" target="content" title="Prikk til prikk (beta)" aria-label="Prikk til prikk (beta)">
+        <a href="prikktilprikk.html" target="content" data-label="Prikk til prikk (beta)" aria-label="Prikk til prikk (beta)">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <line x1="6" y1="18" x2="12" y2="6" stroke-linecap="round" stroke-linejoin="round" />
             <line x1="12" y1="6" x2="18" y2="18" stroke-linecap="round" stroke-linejoin="round" />
@@ -455,7 +455,7 @@
         </a>
       </li>
       <li>
-        <a href="fortegnsskjema.html" target="content" title="Fortegnsskjema – under utvikling" aria-label="Fortegnsskjema, under utvikling">
+        <a href="fortegnsskjema.html" target="content" data-label="Fortegnsskjema – under utvikling" aria-label="Fortegnsskjema, under utvikling">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.2" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 7h16" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M20 7l-3-3M20 7l-3 3" />
@@ -467,7 +467,7 @@
         </a>
       </li>
       <li>
-        <a href="tallinje.html" target="content" title="Tallinje (beta)" aria-label="Tallinje (beta)">
+        <a href="tallinje.html" target="content" data-label="Tallinje (beta)" aria-label="Tallinje (beta)">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <line x1="3" y1="12" x2="21" y2="12" stroke-linecap="round" />
             <line x1="7" y1="8" x2="7" y2="16" stroke-linecap="round" />


### PR DESCRIPTION
## Summary
- update the navigation tooltip styling to read from the new data-label attribute
- add matching data-label attributes on each navigation link so the tooltip text is always available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfc04272b48324815dfaf49ef9ce06