### PR TITLE
Use KaTeX renderToString for fraction labels

### DIFF
--- a/tallinje.js
+++ b/tallinje.js
@@ -263,14 +263,20 @@
     const info = getLabelRenderInfo(value);
     container.textContent = '';
 
-    if (info.type === 'katex' && window.katex && typeof window.katex.render === 'function') {
-      const span = document.createElement('span');
-      container.appendChild(span);
+    if (info.type === 'katex' && window.katex) {
       try {
-        window.katex.render(info.katex, span, { throwOnError: false });
-        return;
+        if (typeof window.katex.renderToString === 'function') {
+          container.innerHTML = window.katex.renderToString(info.katex, { throwOnError: false });
+          return;
+        }
+        if (typeof window.katex.render === 'function') {
+          const span = document.createElement('span');
+          container.appendChild(span);
+          window.katex.render(info.katex, span, { throwOnError: false });
+          return;
+        }
       } catch (err) {
-        container.removeChild(span);
+        container.innerHTML = '';
       }
     }
 


### PR DESCRIPTION
## Summary
- render fraction labels on the number line with KaTeX markup when available
- fall back to KaTeX's DOM renderer or plain text if rendering fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc7c3318c8324ba97eb2841b22e17