### PR TITLE
Add alt text management to Kvikkbilder

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -277,7 +277,7 @@
             <label for="cfg-show-expression">Vis regnestykke</label>
           </div>
         </div>
-        <div class="card">
+        <div class="card" id="exportCard">
           <h2>Eksporter</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
@@ -287,6 +287,7 @@
       </div>
     </div>
   </div>
+  <script src="alt-text-ui.js"></script>
   <script src="kvikkbilder.js"></script>
   <script src="split.js"></script>
   <script src="examples.js"></script>


### PR DESCRIPTION
## Summary
- add alt text helper utilities and MathVisAltText manager integration to kvikkbilder.js
- update rendering logic for blocks, number visuals, and rectangles to refresh auto alt text and honor manual overrides
- expose the export card and load the shared alt-text UI script in kvikkbilder.html

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfca6ab7108324bcde17958e77a37b