### PR TITLE
Add automated coverage for nKant circle command

### DIFF
--- a/nkant.html
+++ b/nkant.html
@@ -104,7 +104,7 @@ Rettvinklet trekant</textarea>
         <div class="small"><code>a=5, b=5, c=5, d=5, B=90</code> – firkant med fire like sider og rett vinkel i B</div>
         <div class="small"><code>Rettvinklet trekant</code> – tolkes av AI</div>
         <div class="small">Fritekst tolkes av AI; kun a–d og A–D gjenkjennes. Ukjent tekst faller tilbake til «a=3».</div>
-        <div class="small"><code>sirkel radius: r</code> eller <code>mangekant sider: 6 side: a</code> – samme format som i appen 3D-figurer.</div>
+        <div class="small"><code>sirkel radius: r</code> tegner en sirkel med radius merket r. <code>mangekant sider: 6 side: a</code> gir en regulær mangekant – samme format som i appen 3D-figurer.</div>
         <div class="sep"></div>
 
         <!-- Figur 1 -->

--- a/tests/nkant-circle.spec.js
+++ b/tests/nkant-circle.spec.js
@@ -1,0 +1,20 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('nKant sirkel-kommando', () => {
+  test('tegner en sirkel når spesifikasjonen inneholder «sirkel»', async ({ page }) => {
+    await page.goto('/nkant.html', { waitUntil: 'load' });
+
+    const specs = page.locator('#inpSpecs');
+    await specs.fill('sirkel radius: r');
+    await page.click('#btnDraw');
+
+    const circles = page.locator('#paper circle');
+    await expect.poll(async () => await circles.count()).toBeGreaterThanOrEqual(3);
+
+    const radii = await circles.evaluateAll(elements => elements.map(el => Number(el.getAttribute('r')) || 0));
+    expect(Math.max(...radii)).toBeGreaterThan(100);
+
+    const radiusLabel = page.locator('#paper text', { hasText: 'r' });
+    await expect(radiusLabel.first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- clarify the inline help text in nkant.html to spell out what the sirkel command draws
- add a Playwright test that enters "sirkel radius: r" and verifies that a circle with a visible radius label is rendered

## Testing
- npm test *(fails: Playwright requires missing system libraries in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfddd192488324bfdaa8ecd6e2cf9d