### PR TITLE
Redesign figurtall settings controls and expand shape options

### DIFF
--- a/figurtall.html
+++ b/figurtall.html
@@ -94,14 +94,24 @@
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
     .btn:active{transform:translateY(1px);}
-    .card--settings fieldset .fieldLabel{flex-direction:column;align-items:center;gap:6px;text-align:center;}
-    .card--settings fieldset .fieldLabel span{display:block;}
-    .card--settings fieldset .fieldLabel .stepper{margin:0;}
-    .card--settings fieldset .toggleLabel input{margin:0;}
+    .card--settings fieldset{display:flex;flex-direction:column;gap:12px;margin:0;padding:0;border:none;}
+    .card--settings fieldset + fieldset{margin-top:12px;}
+    .card--settings legend{font-weight:600;font-size:14px;margin-bottom:4px;color:#374151;}
+    .settingsRow{display:flex;flex-wrap:wrap;gap:16px;align-items:center;}
+    .settingsRow--grid{justify-content:flex-start;}
+    .inlineLabel{display:flex;align-items:center;gap:8px;font-size:14px;color:#4b5563;}
+    .inlineLabel span{white-space:nowrap;}
+    .segmentedControl{display:flex;flex-wrap:wrap;gap:8px;align-items:center;}
+    .segmentedOption{position:relative;display:inline-flex;align-items:center;justify-content:center;}
+    .segmentedOption input{position:absolute;opacity:0;pointer-events:none;}
+    .segmentedOption span{display:inline-flex;align-items:center;justify-content:center;padding:6px 12px;border:1px solid #d1d5db;border-radius:999px;background:#fff;color:#374151;font-size:14px;cursor:pointer;min-width:0;transition:background .2s,border-color .2s,color .2s,box-shadow .2s;}
+    .segmentedOption input:checked + span{background:#111827;color:#fff;border-color:#111827;box-shadow:0 2px 6px rgba(17,24,39,.18);}
+    .segmentedOption input:focus-visible + span{outline:2px solid #6366f1;outline-offset:2px;}
+    .segmentedOption input:disabled + span{opacity:.5;cursor:not-allowed;}
     .card input[type="color"]{width:40px;height:40px;padding:0;border:none;}
     .colors{display:flex;flex-wrap:wrap;gap:6px;}
     .colors input{flex:0 0 40px;width:40px;height:40px;}
-    .input--digit{width:60px;padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;box-sizing:border-box;text-align:center;}
+    .input--digit{width:72px;padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;box-sizing:border-box;text-align:center;}
     .figure{
       border-radius:10px;
       background:#fff;
@@ -124,32 +134,23 @@
       display:grid;
       grid-template-columns:repeat(var(--cols),1fr);
     }
-    .cell{
-      border:1px solid #d1d5db;
-      background:#fff;
-      cursor:pointer;
-    }
-    .box.hide-grid .cell{
-      border:none;
-    }
-    .row.offset{
-      transform:translateX(calc(var(--cellSize)/2));
-    }
-    .cell.circle{
-      border-radius:50%;
-      border:none;
-    }
-    .stepper{
-      display:flex;align-items:center;gap:12px;
-      padding:6px 10px;border:1px solid #cfcfcf;border-radius:12px;
-      box-shadow:0 2px 10px rgba(0,0,0,.06);background:#fff;
-      margin:0 auto;
-    }
-    .stepper button{
-      width:40px;height:36px;border:1px solid #cfcfcf;border-radius:8px;
-      background:#fff;font-size:20px;cursor:pointer;
-    }
-    .stepper span{min-width:32px;text-align:center;font-variant-numeric:tabular-nums;font-size:16px;}
+    .cell{position:relative;border:1px solid #d1d5db;background:#fff;cursor:pointer;transition:background .2s,box-shadow .2s;}
+    .cell::after{content:"";position:absolute;inset:12%;border-radius:999px;background:var(--cell-fill,transparent);opacity:0;transition:opacity .15s,transform .2s;}
+    .box.hide-grid .cell{border:none;}
+    .row.offset{transform:translateX(calc(var(--cellSize)/2));}
+    .cell--square::after{display:none;}
+    .cell--circle{border:none;border-radius:50%;overflow:hidden;}
+    .cell--circle::after{display:none;}
+    .cell--line{background:#fff;}
+    .cell--line::before,.cell--line::after{content:"";position:absolute;inset:18%;border-radius:999px;background:transparent;pointer-events:none;}
+    .cell--line::before{background:linear-gradient(45deg,transparent calc(50% - 2px),var(--cell-fill,transparent) calc(50% - 2px),var(--cell-fill,transparent) calc(50% + 2px),transparent calc(50% + 2px));opacity:0;}
+    .cell--line::after{background:linear-gradient(-45deg,transparent calc(50% - 2px),var(--cell-fill,transparent) calc(50% - 2px),var(--cell-fill,transparent) calc(50% + 2px),transparent calc(50% + 2px));opacity:0;}
+    .cell--star{background:#fff;}
+    .cell--star::after{clip-path:polygon(50% 5%,61% 35%,95% 35%,67% 57%,78% 90%,50% 70%,22% 90%,33% 57%,5% 35%,39% 35%);opacity:0;background:var(--cell-fill,transparent);} 
+    .cell--filled.cell--line::before,.cell--filled.cell--line::after{opacity:1;}
+    .cell--filled.cell--star::after{opacity:1;}
+    .cell--filled.cell--square{background:var(--cell-fill,#fff);}
+    .cell--filled.cell--circle{background:var(--cell-fill,#fff);}
     .nameInput{width:100%;border:1px solid #d1d5db;border-radius:8px;padding:6px 8px;font-size:14px;box-sizing:border-box;}
     .nameDisplay{width:100%;border:1px solid #d1d5db;border-radius:8px;padding:6px 8px;font-size:14px;box-sizing:border-box;background:#f3f4f6;color:#374151;}
     .removeFigureBtn{
@@ -196,33 +197,80 @@
         <div class="card card--settings">
           <fieldset>
             <legend>Ruter</legend>
-            <label class="fieldLabel">
-              <span>Rader</span>
-              <div class="stepper" aria-label="Antall ruter i høyden">
-                <button id="rowsMinus" type="button" aria-label="Færre rader">&minus;</button>
-                <span id="rowsVal">3</span>
-                <button id="rowsPlus" type="button" aria-label="Flere rader">+</button>
-              </div>
-            </label>
-            <label class="fieldLabel">
-              <span>Kolonner</span>
-              <div class="stepper" aria-label="Antall ruter i bredden">
-                <button id="colsMinus" type="button" aria-label="Færre kolonner">&minus;</button>
-                <span id="colsVal">3</span>
-                <button id="colsPlus" type="button" aria-label="Flere kolonner">+</button>
-              </div>
-            </label>
-            <label class="toggleLabel"><input id="showGrid" type="checkbox" /> Vis rutenett</label>
-            <label class="toggleLabel"><input id="offsetRows" type="checkbox" /> Forskyv annenhver rad</label>
-            <label class="toggleLabel"><input id="circleMode" type="checkbox" checked /> Bruk sirkler</label>
-            <label class="fieldLabel">
-              <span>Figurtekst</span>
-              <select id="labelMode">
-                <option value="hidden">Skjult</option>
-                <option value="count">Antall</option>
-                <option value="custom">Egendefinert</option>
-              </select>
-            </label>
+            <div class="settingsRow settingsRow--grid">
+              <label class="inlineLabel" for="rowsInput">
+                <span>Rader:</span>
+                <input id="rowsInput" class="input--digit" type="number" min="1" max="20" value="3" />
+              </label>
+              <label class="inlineLabel" for="colsInput">
+                <span>Kolonner:</span>
+                <input id="colsInput" class="input--digit" type="number" min="1" max="20" value="3" />
+              </label>
+            </div>
+          </fieldset>
+          <fieldset>
+            <legend>Type</legend>
+            <div class="segmentedControl" role="group" aria-label="Type markering">
+              <label class="segmentedOption">
+                <input type="radio" name="figureType" value="square" checked />
+                <span>Fylte kvadrater</span>
+              </label>
+              <label class="segmentedOption">
+                <input type="radio" name="figureType" value="circle" />
+                <span>Sirkler</span>
+              </label>
+              <label class="segmentedOption">
+                <input type="radio" name="figureType" value="line" />
+                <span>Linjer</span>
+              </label>
+              <label class="segmentedOption">
+                <input type="radio" name="figureType" value="star" />
+                <span>Stjerner</span>
+              </label>
+            </div>
+          </fieldset>
+          <fieldset>
+            <legend>Vis rutenett</legend>
+            <div class="segmentedControl" role="group" aria-label="Vis rutenett">
+              <label class="segmentedOption">
+                <input id="showGridNo" type="radio" name="showGrid" value="false" />
+                <span>Nei</span>
+              </label>
+              <label class="segmentedOption">
+                <input id="showGridYes" type="radio" name="showGrid" value="true" checked />
+                <span>Ja</span>
+              </label>
+            </div>
+          </fieldset>
+          <fieldset>
+            <legend>Forskyv annenhver rad</legend>
+            <div class="segmentedControl" role="group" aria-label="Forskyv annenhver rad">
+              <label class="segmentedOption">
+                <input id="offsetRowsNo" type="radio" name="offsetRows" value="false" />
+                <span>Nei</span>
+              </label>
+              <label class="segmentedOption">
+                <input id="offsetRowsYes" type="radio" name="offsetRows" value="true" checked />
+                <span>Ja</span>
+              </label>
+            </div>
+          </fieldset>
+          <fieldset>
+            <legend>Figurtekst</legend>
+            <div class="segmentedControl" role="group" aria-label="Figurtekst">
+              <label class="segmentedOption">
+                <input type="radio" name="labelMode" value="hidden" />
+                <span>Skjult</span>
+              </label>
+              <label class="segmentedOption">
+                <input type="radio" name="labelMode" value="count" />
+                <span>Tall</span>
+              </label>
+              <label class="segmentedOption">
+                <input type="radio" name="labelMode" value="custom" checked />
+                <span>Egendefinert</span>
+              </label>
+            </div>
           </fieldset>
           <fieldset>
             <legend>Farger</legend>

--- a/figurtall.js
+++ b/figurtall.js
@@ -7,6 +7,7 @@
   const MAX_DIM = 20;
   const MAX_COLORS = 6;
   const LABEL_MODES = ['hidden', 'count', 'custom'];
+  const FIGURE_TYPES = ['square', 'circle', 'line', 'star'];
   let rows = 3;
   let cols = 3;
   const colorCountInp = document.getElementById('colorCount');
@@ -39,6 +40,36 @@
     const normalized = value.toLowerCase();
     if (normalized === 'numbered') return 'count';
     return LABEL_MODES.includes(normalized) ? normalized : 'custom';
+  }
+  function normalizeFigureType(value) {
+    if (typeof value !== 'string') return null;
+    const normalized = value.toLowerCase();
+    const alias = {
+      square: 'square',
+      squares: 'square',
+      kvadrat: 'square',
+      kvadrater: 'square',
+      'filled-squares': 'square',
+      'filled square': 'square',
+      'filled squares': 'square',
+      fylte: 'square',
+      'fylte kvadrater': 'square',
+      circle: 'circle',
+      circles: 'circle',
+      sirkel: 'circle',
+      sirkler: 'circle',
+      line: 'line',
+      lines: 'line',
+      linje: 'line',
+      linjer: 'line',
+      star: 'star',
+      stars: 'star',
+      stjerne: 'star',
+      stjerner: 'star'
+    };
+    if (FIGURE_TYPES.includes(normalized)) return normalized;
+    if (alias[normalized]) return alias[normalized];
+    return null;
   }
   function clampInt(value, min, max) {
     const num = parseInt(value, 10);
@@ -118,7 +149,18 @@
     cols = clampInt((_STATE$cols = STATE.cols) !== null && _STATE$cols !== void 0 ? _STATE$cols : cols, 1, MAX_DIM);
     STATE.rows = rows;
     STATE.cols = cols;
-    STATE.circleMode = STATE.circleMode !== false;
+    let figureType = normalizeFigureType(STATE.figureType);
+    if (!figureType) {
+      if (STATE.circleMode === true) {
+        figureType = 'circle';
+      } else if (STATE.circleMode === false) {
+        figureType = 'square';
+      } else {
+        figureType = 'square';
+      }
+    }
+    STATE.figureType = figureType;
+    STATE.circleMode = figureType === 'circle';
     STATE.offset = STATE.offset !== false;
     STATE.showGrid = STATE.showGrid !== false;
     const inferredMode = typeof STATE.labelMode === 'string' ? STATE.labelMode : STATE.showFigureText === false ? 'hidden' : 'custom';
@@ -169,16 +211,36 @@
     }, 0);
   }
   function applyCellAppearance(cell, idx, colors) {
+    const shape = normalizeFigureType(STATE.figureType) || 'square';
+    const color = idx > 0 ? colors[idx - 1] || '#6C1BA2' : '';
+    const hasFill = !!color;
     cell.dataset.color = String(idx);
-    if (idx === 0) {
+    cell.style.setProperty('--cell-fill', color || 'transparent');
+    cell.classList.remove('circle', 'cell--square', 'cell--circle', 'cell--line', 'cell--star', 'cell--filled');
+    if (shape === 'circle') {
+      cell.classList.add('cell--circle');
+      if (hasFill) {
+        cell.classList.add('cell--filled');
+        cell.style.backgroundColor = color;
+      } else {
+        cell.style.backgroundColor = '#fff';
+      }
+    } else if (shape === 'line') {
+      cell.classList.add('cell--line');
       cell.style.backgroundColor = '#fff';
+      if (hasFill) cell.classList.add('cell--filled');
+    } else if (shape === 'star') {
+      cell.classList.add('cell--star');
+      cell.style.backgroundColor = '#fff';
+      if (hasFill) cell.classList.add('cell--filled');
     } else {
-      cell.style.backgroundColor = colors[idx - 1] || '#fff';
-    }
-    if (STATE.circleMode && idx !== 0) {
-      cell.classList.add('circle');
-    } else {
-      cell.classList.remove('circle');
+      cell.classList.add('cell--square');
+      if (hasFill) {
+        cell.classList.add('cell--filled');
+        cell.style.backgroundColor = color;
+      } else {
+        cell.style.backgroundColor = '#fff';
+      }
     }
   }
   function updateCellColors() {
@@ -355,23 +417,26 @@
     updateFigureLabelDisplay();
     scheduleAltTextRefresh('cells');
   }
-  const rowsMinus = document.getElementById('rowsMinus');
-  const rowsPlus = document.getElementById('rowsPlus');
-  const rowsVal = document.getElementById('rowsVal');
-  const colsMinus = document.getElementById('colsMinus');
-  const colsPlus = document.getElementById('colsPlus');
-  const colsVal = document.getElementById('colsVal');
+  const rowsInput = document.getElementById('rowsInput');
+  const colsInput = document.getElementById('colsInput');
+  const figureTypeInputs = Array.from(document.querySelectorAll('input[name="figureType"]'));
+  const showGridInputs = Array.from(document.querySelectorAll('input[name="showGrid"]'));
+  const offsetInputs = Array.from(document.querySelectorAll('input[name="offsetRows"]'));
+  const labelModeInputs = Array.from(document.querySelectorAll('input[name="labelMode"]'));
+  function setRadioGroup(inputs, value) {
+    if (!Array.isArray(inputs)) return;
+    inputs.forEach(inp => {
+      if (!inp) return;
+      inp.checked = inp.value === value;
+    });
+  }
   function applyStateToControls() {
-    if (rowsVal) rowsVal.textContent = rows;
-    if (colsVal) colsVal.textContent = cols;
-    const circleInp = document.getElementById('circleMode');
-    const offsetInp = document.getElementById('offsetRows');
-    const gridInp = document.getElementById('showGrid');
-    const labelModeSel = document.getElementById('labelMode');
-    if (circleInp) circleInp.checked = !!STATE.circleMode;
-    if (offsetInp) offsetInp.checked = !!STATE.offset;
-    if (gridInp) gridInp.checked = !!STATE.showGrid;
-    if (labelModeSel) labelModeSel.value = STATE.labelMode;
+    if (rowsInput) rowsInput.value = String(rows);
+    if (colsInput) colsInput.value = String(cols);
+    setRadioGroup(figureTypeInputs, normalizeFigureType(STATE.figureType) || 'square');
+    setRadioGroup(showGridInputs, STATE.showGrid ? 'true' : 'false');
+    setRadioGroup(offsetInputs, STATE.offset ? 'true' : 'false');
+    setRadioGroup(labelModeInputs, STATE.labelMode);
     if (colorCountInp) colorCountInp.value = String(STATE.colorCount);
     updateColorVisibility();
   }
@@ -399,41 +464,67 @@
     STATE.cols = clamped;
     render();
   }
-  rowsMinus === null || rowsMinus === void 0 || rowsMinus.addEventListener('click', () => {
-    if (rows > 1) setRows(rows - 1);
+  if (rowsInput) {
+    rowsInput.addEventListener('input', () => {
+      if (rowsInput.value === '') return;
+      setRows(rowsInput.value);
+    });
+    rowsInput.addEventListener('change', () => {
+      setRows(rowsInput.value);
+    });
+    rowsInput.addEventListener('blur', () => {
+      setRows(rowsInput.value);
+    });
+  }
+  if (colsInput) {
+    colsInput.addEventListener('input', () => {
+      if (colsInput.value === '') return;
+      setCols(colsInput.value);
+    });
+    colsInput.addEventListener('change', () => {
+      setCols(colsInput.value);
+    });
+    colsInput.addEventListener('blur', () => {
+      setCols(colsInput.value);
+    });
+  }
+  figureTypeInputs.forEach(inp => {
+    if (!inp) return;
+    inp.addEventListener('change', () => {
+      if (!inp.checked) return;
+      const nextType = normalizeFigureType(inp.value) || 'square';
+      STATE.figureType = nextType;
+      STATE.circleMode = nextType === 'circle';
+      updateCellColors();
+      scheduleAltTextRefresh('shape');
+    });
   });
-  rowsPlus === null || rowsPlus === void 0 || rowsPlus.addEventListener('click', () => {
-    if (rows < MAX_DIM) setRows(rows + 1);
+  offsetInputs.forEach(inp => {
+    if (!inp) return;
+    inp.addEventListener('change', () => {
+      if (!inp.checked) return;
+      STATE.offset = inp.value === 'true';
+      render();
+    });
   });
-  colsMinus === null || colsMinus === void 0 || colsMinus.addEventListener('click', () => {
-    if (cols > 1) setCols(cols - 1);
+  showGridInputs.forEach(inp => {
+    if (!inp) return;
+    inp.addEventListener('change', () => {
+      if (!inp.checked) return;
+      STATE.showGrid = inp.value === 'true';
+      updateGridVisibility();
+      scheduleAltTextRefresh('grid');
+    });
   });
-  colsPlus === null || colsPlus === void 0 || colsPlus.addEventListener('click', () => {
-    if (cols < MAX_DIM) setCols(cols + 1);
-  });
-  const circleInp = document.getElementById('circleMode');
-  circleInp === null || circleInp === void 0 || circleInp.addEventListener('change', () => {
-    STATE.circleMode = circleInp.checked;
-    updateCellColors();
-    scheduleAltTextRefresh('circle-mode');
-  });
-  const offsetInp = document.getElementById('offsetRows');
-  offsetInp === null || offsetInp === void 0 || offsetInp.addEventListener('change', () => {
-    STATE.offset = offsetInp.checked;
-    render();
-  });
-  const gridInp = document.getElementById('showGrid');
-  gridInp === null || gridInp === void 0 || gridInp.addEventListener('change', () => {
-    STATE.showGrid = gridInp.checked;
-    updateGridVisibility();
-    scheduleAltTextRefresh('grid');
-  });
-  const labelModeSel = document.getElementById('labelMode');
-  labelModeSel === null || labelModeSel === void 0 || labelModeSel.addEventListener('change', () => {
-    STATE.labelMode = normalizeLabelMode(labelModeSel.value);
-    STATE.showFigureText = STATE.labelMode !== 'hidden';
-    updateFigureLabelDisplay();
-    scheduleAltTextRefresh('label-mode');
+  labelModeInputs.forEach(inp => {
+    if (!inp) return;
+    inp.addEventListener('change', () => {
+      if (!inp.checked) return;
+      STATE.labelMode = normalizeLabelMode(inp.value);
+      STATE.showFigureText = STATE.labelMode !== 'hidden';
+      updateFigureLabelDisplay();
+      scheduleAltTextRefresh('label-mode');
+    });
   });
   colorCountInp === null || colorCountInp === void 0 || colorCountInp.addEventListener('input', () => {
     STATE.colorCount = clampInt(colorCountInp.value, 1, colorInputs.length || MAX_COLORS);
@@ -556,11 +647,13 @@
         });
       });
     }
+    const figureType = normalizeFigureType(STATE.figureType) || (STATE.circleMode ? 'circle' : 'square');
     return {
       figureCount,
       rows,
       cols,
-      circleMode: !!STATE.circleMode,
+      circleMode: figureType === 'circle',
+      figureType,
       offset: !!STATE.offset,
       showGrid: !!STATE.showGrid,
       figures
@@ -574,7 +667,14 @@
     sentences.push(`Visualiseringen viser ${countText} i et rutenett med ${formatCount(data.rows, 'rad', 'rader')} og ${formatCount(data.cols, 'kolonne', 'kolonner')}.`);
     const detailParts = [];
     detailParts.push(data.showGrid ? 'Rutenettet er synlig' : 'Rutenettet er skjult');
-    detailParts.push(data.circleMode ? 'Fylte posisjoner vises som sirkler' : 'Fylte posisjoner vises som kvadrater');
+    const shapeMap = {
+      square: 'Fylte posisjoner vises som kvadrater',
+      circle: 'Fylte posisjoner vises som sirkler',
+      line: 'Fylte posisjoner vises som linjer',
+      star: 'Fylte posisjoner vises som stjerner'
+    };
+    const shapeKey = normalizeFigureType(data.figureType) || (data.circleMode ? 'circle' : 'square');
+    detailParts.push(shapeMap[shapeKey] || shapeMap.square);
     if (data.offset && data.rows > 1) detailParts.push('Annenhver rad er forskjøvet');
     if (detailParts.length) {
       sentences.push(`${detailParts.join(', ')}.`);
@@ -698,6 +798,20 @@
     const figCount = boxes.length;
     const totalW = figCount > 0 ? figCount * figW + gap * (figCount - 1) : figW;
     const totalH = figH + nameH;
+    const shapeMode = normalizeFigureType(STATE.figureType) || 'square';
+    const buildStarPoints = (cx, cy, outerR) => {
+      const innerR = outerR * 0.45;
+      const points = [];
+      const startAngle = -Math.PI / 2;
+      for (let i = 0; i < 10; i++) {
+        const angle = startAngle + i * Math.PI / 5;
+        const radius = i % 2 === 0 ? outerR : innerR;
+        const x = cx + Math.cos(angle) * radius;
+        const y = cy + Math.sin(angle) * radius;
+        points.push(`${x},${y}`);
+      }
+      return points.join(' ');
+    };
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     svg.setAttribute('viewBox', `0 0 ${totalW} ${totalH}`);
     svg.setAttribute('width', totalW);
@@ -736,20 +850,50 @@
           }
           g.appendChild(base);
           if (colorIdx > 0) {
-            if (STATE.circleMode) {
+            const fillColor = colors[colorIdx - 1];
+            if (shapeMode === 'circle') {
+              const radius = cellSize / 2 - (STATE.showGrid ? 1 : 0);
               const circ = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
               circ.setAttribute('cx', x + cellSize / 2);
               circ.setAttribute('cy', yPos + cellSize / 2);
-              circ.setAttribute('r', cellSize / 2);
-              circ.setAttribute('fill', colors[colorIdx - 1]);
+              circ.setAttribute('r', Math.max(0, radius));
+              circ.setAttribute('fill', fillColor);
               g.appendChild(circ);
+            } else if (shapeMode === 'line') {
+              const inset = cellSize * 0.2;
+              const line1 = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+              line1.setAttribute('x1', x + inset);
+              line1.setAttribute('y1', yPos + inset);
+              line1.setAttribute('x2', x + cellSize - inset);
+              line1.setAttribute('y2', yPos + cellSize - inset);
+              line1.setAttribute('stroke', fillColor);
+              line1.setAttribute('stroke-width', '4');
+              line1.setAttribute('stroke-linecap', 'round');
+              const line2 = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+              line2.setAttribute('x1', x + inset);
+              line2.setAttribute('y1', yPos + cellSize - inset);
+              line2.setAttribute('x2', x + cellSize - inset);
+              line2.setAttribute('y2', yPos + inset);
+              line2.setAttribute('stroke', fillColor);
+              line2.setAttribute('stroke-width', '4');
+              line2.setAttribute('stroke-linecap', 'round');
+              g.appendChild(line1);
+              g.appendChild(line2);
+            } else if (shapeMode === 'star') {
+              const star = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
+              const outerR = cellSize / 2 - 2;
+              const cx = x + cellSize / 2;
+              const cy = yPos + cellSize / 2;
+              star.setAttribute('points', buildStarPoints(cx, cy, Math.max(outerR, 4)));
+              star.setAttribute('fill', fillColor);
+              g.appendChild(star);
             } else {
               const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
               rect.setAttribute('x', x);
               rect.setAttribute('y', yPos);
               rect.setAttribute('width', cellSize);
               rect.setAttribute('height', cellSize);
-              rect.setAttribute('fill', colors[colorIdx - 1]);
+              rect.setAttribute('fill', fillColor);
               if (STATE.showGrid) {
                 rect.setAttribute('stroke', '#d1d5db');
                 rect.setAttribute('stroke-width', '1');
@@ -785,7 +929,8 @@
   function resetState() {
     STATE.rows = 3;
     STATE.cols = 3;
-    STATE.circleMode = true;
+    STATE.figureType = 'square';
+    STATE.circleMode = false;
     STATE.offset = true;
     STATE.showGrid = true;
     STATE.labelMode = 'custom';


### PR DESCRIPTION
## Summary
- restyled the figurtall settings card with inline row/column inputs and segmented controls for type, grid, offset, and labels
- added shape mode handling for squares, circles, lines, and stars including updates to cell rendering, alt text, and SVG export

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe2cdca0483249cc8862950e9af48