### PR TITLE
Hide fortegnsskjema expression header

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -102,18 +102,6 @@
       --chart-label-width: 120px;
     }
     .chart-expression {
-      position: absolute;
-      top: 14px;
-      left: calc(var(--chart-label-width, 0px) + 18px);
-      pointer-events: none;
-      font-size: 22px;
-      font-weight: 600;
-      color: #111827;
-      min-height: 28px;
-      display: flex;
-      align-items: center;
-    }
-    .chart-expression--empty {
       display: none;
     }
     .chart-expression .katex {


### PR DESCRIPTION
## Summary
- hide the expression header above the fortegnsskjema chart so only row labels remain visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1086075dc8324af914ab9f15325f9