### PR TITLE
Add SPA fallback for deep link routes

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="no">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="stylesheet" href="base.css" />
+  <title>Math Visuals</title>
+  <style>
+    :root {
+      color-scheme: light;
+    }
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #f7f8fb;
+      color: #0f172a;
+      display: grid;
+      place-items: center;
+      min-height: 100vh;
+      padding: 32px;
+      text-align: center;
+    }
+    main {
+      max-width: 480px;
+      background: #ffffff;
+      border-radius: 16px;
+      box-shadow: 0 18px 45px rgba(15, 109, 143, 0.12);
+      padding: 32px 28px;
+      border: 1px solid rgba(15, 109, 143, 0.16);
+    }
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(1.5rem, 4vw, 2rem);
+    }
+    p {
+      margin: 0;
+      font-size: 1rem;
+      line-height: 1.5;
+      color: #1f2937;
+    }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <div class="grid" id="status">
+      <h1>Fant ikke siden</h1>
+      <p>Prøver å åpne Math Visuals-appen …</p>
+    </div>
+  </main>
+  <script>
+    (function() {
+      if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return;
+      }
+
+      const statusElement = document.getElementById('status');
+      const path = typeof window.location.pathname === 'string' ? window.location.pathname : '';
+      if (!path || path === '/' || path === '/index.html') {
+        return;
+      }
+      if (path.startsWith('/api/')) {
+        return;
+      }
+      if (/\.[^/]+$/.test(path)) {
+        return;
+      }
+
+      const isGithubHost = /github\.io$/i.test(window.location.hostname);
+      const repoBaseMatch = isGithubHost ? window.location.pathname.match(/^(.*?\/math_visuals\/)/i) : null;
+      const baseHref = isGithubHost && repoBaseMatch ? repoBaseMatch[1] : (isGithubHost ? '/math_visuals/' : '/');
+
+      const rewriteHtml = html => {
+        if (typeof html !== 'string' || !html) {
+          return null;
+        }
+        const baseTag = `<base href="${baseHref}">`;
+        if (html.includes('<base ')) {
+          return html;
+        }
+        return html.replace('<head>', `<head>${baseTag}`);
+      };
+
+      fetch('/index.html', { credentials: 'same-origin' })
+        .then(response => {
+          if (!response || !response.ok) {
+            throw new Error('Failed to load index.html');
+          }
+          return response.text();
+        })
+        .then(html => {
+          const transformed = rewriteHtml(html);
+          if (!transformed) {
+            throw new Error('Received empty index.html');
+          }
+          document.open();
+          document.write(transformed);
+          document.close();
+        })
+        .catch(error => {
+          if (statusElement) {
+            statusElement.innerHTML = '';
+            const heading = document.createElement('h1');
+            heading.textContent = 'Fant ikke siden';
+            const paragraph = document.createElement('p');
+            paragraph.textContent = 'Vi klarte ikke å laste inn Math Visuals. Gå tilbake og prøv igjen.';
+            statusElement.appendChild(heading);
+            statusElement.appendChild(paragraph);
+          }
+          console.error('Math Visuals 404 fallback failed:', error);
+        });
+    })();
+  </script>
+</body>
+</html>

--- a/tests/router-deep-links.spec.js
+++ b/tests/router-deep-links.spec.js
@@ -1,0 +1,18 @@
+const { test, expect } = require('@playwright/test');
+
+const FORTEGN_NAV_SELECTOR = 'nav a[href="fortegnsskjema.html"]';
+const IFRAME_SELECTOR = 'iframe[name="content"]';
+
+test.describe('deep links', () => {
+  test('direct visit to fortegnsskjema route loads the app', async ({ page }) => {
+    await page.goto('/fortegnsskjema-under-utvikling');
+    await expect(page.locator(IFRAME_SELECTOR)).toHaveAttribute('src', /fortegnsskjema\.html/);
+    await expect(page.locator(FORTEGN_NAV_SELECTOR)).toHaveAttribute('aria-current', 'page');
+  });
+
+  test('deep link with example segment keeps the example selection', async ({ page }) => {
+    await page.goto('/fortegnsskjema-under-utvikling/eksempel2');
+    await expect(page.locator(IFRAME_SELECTOR)).toHaveAttribute('src', /fortegnsskjema\.html\?example=2/);
+    await expect(page.locator(FORTEGN_NAV_SELECTOR)).toHaveAttribute('aria-current', 'page');
+  });
+});


### PR DESCRIPTION
## Summary
- add a custom `404.html` fallback that loads `index.html` and preserves deep links for the single page app
- ensure the fallback injects a base tag so assets resolve correctly on Vercel and GitHub Pages
- add a Playwright regression test that covers fortegnsskjema deep links

## Testing
- npm test *(fails in this environment because the Playwright browsers require system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e108d724e48324b98d8129155ec067