### PR TITLE
Adjust graftegner draw controls layout

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -91,6 +91,28 @@
       gap:6px;
       width:100%;
     }
+    .func-row--main,
+    .func-row--secondary{
+      display:grid;
+      gap:12px;
+      grid-template-columns:repeat(2,minmax(0,1fr));
+      align-items:start;
+    }
+    .func-main{
+      display:flex;
+      gap:12px;
+      align-items:flex-end;
+    }
+    .func-main .func-input{
+      flex:1 1 auto;
+      min-width:0;
+    }
+    .btn--inline-draw{
+      flex:0 0 auto;
+      white-space:nowrap;
+      min-height:42px;
+      padding-inline:16px;
+    }
     .func-input .func-editor{
       display:flex;
       flex-direction:column;
@@ -146,7 +168,7 @@
     .func-row--gliders{
       display:grid;
       gap:12px;
-      grid-template-columns:repeat(auto-fit,minmax(160px,1fr));
+      grid-template-columns:repeat(3,minmax(120px,1fr));
       align-items:end;
     }
     .func-row--gliders .linepoints-row{
@@ -154,11 +176,15 @@
     }
     .func-row--gliders label.points,
     .func-row--gliders label.linepoint{
-      max-width:180px;
+      max-width:100%;
     }
     .func-row--gliders label.linepoint input,
     .func-row--gliders label.points select{
       max-width:100%;
+    }
+    .func-row--gliders label.points select,
+    .func-row--gliders label.linepoint input{
+      width:100%;
     }
     .func-row--gliders .startx-label{
       grid-column:1 / -1;
@@ -167,7 +193,11 @@
     @media (max-width:680px){
       .function-controls{ align-items:stretch; }
       .func-group .func-fields{ grid-template-columns:1fr; }
-      .func-fields--first .func-row{ grid-template-columns:1fr; }
+      .func-fields--first .func-row,
+      .func-row--secondary{ grid-template-columns:1fr; }
+      .func-main{ flex-direction:column; align-items:stretch; }
+      .btn--inline-draw{ width:100%; }
+      .func-row--gliders{ grid-template-columns:1fr; }
     }
     .addFigureBtn{ width:clamp(36px,8vw,56px); aspect-ratio:1; border:2px dashed #cfcfcf; border-radius:10px; background:#fff; display:flex; align-items:center; justify-content:center; font-size:20px; color:#6b7280; cursor:pointer; transition:box-shadow .2s, transform .02s; }
     .addFigureBtn:hover{ box-shadow:0 2px 8px rgba(0,0,0,.06); }
@@ -231,7 +261,6 @@
             <div class="function-controls">
               <div id="funcRows" class="func-groups"></div>
               <div class="func-actions">
-                <button id="btnDraw" class="btn" type="button">Tegn graf(er)</button>
                 <button id="addFunc" class="addFigureBtn" type="button" aria-label="Legg til funksjon">+</button>
               </div>
             </div>

--- a/graftegner.js
+++ b/graftegner.js
@@ -3091,7 +3091,7 @@ function setupSettingsForm() {
   const showBracketsInput = g('cfgShowBrackets');
   const forceTicksInput = g('cfgForceTicks');
   const snapCheckbox = g('cfgSnap');
-  const drawBtn = g('btnDraw');
+  const drawButtonSelector = '[data-action="draw"]';
   let gliderSection = null;
   let gliderCountInput = null;
   let gliderStartInput = null;
@@ -3828,12 +3828,15 @@ function setupSettingsForm() {
         <legend>Funksjon ${index}</legend>
         <div class="func-fields func-fields--first">
           <div class="func-row func-row--main">
-            <label class="func-input">
-              <span>${titleLabel}</span>
-              <div class="func-editor">
-                <math-field data-fun class="func-math-field" ${mathFieldKeyboardAttr} smart-mode="false" aria-label="${titleLabel}"></math-field>
-              </div>
-            </label>
+            <div class="func-main">
+              <label class="func-input">
+                <span>${titleLabel}</span>
+                <div class="func-editor">
+                  <math-field data-fun class="func-math-field" ${mathFieldKeyboardAttr} smart-mode="false" aria-label="${titleLabel}"></math-field>
+                </div>
+              </label>
+              <button type="button" class="btn btn--inline-draw" data-action="draw" data-draw-index="${index}" aria-label="Tegn graf for funksjon ${index}">Tegn graf</button>
+            </div>
             <label class="domain">
               <span>Avgrensning</span>
               <input type="text" data-dom placeholder="[start, stopp]">
@@ -3869,16 +3872,21 @@ function setupSettingsForm() {
       row.innerHTML = `
         <legend>Funksjon ${index}</legend>
         <div class="func-fields">
-          <label class="func-input">
-            <span>${titleLabel}</span>
-            <div class="func-editor">
-              <math-field data-fun class="func-math-field" ${mathFieldKeyboardAttr} smart-mode="false" aria-label="${titleLabel}"></math-field>
+          <div class="func-row func-row--secondary">
+            <div class="func-main">
+              <label class="func-input">
+                <span>${titleLabel}</span>
+                <div class="func-editor">
+                  <math-field data-fun class="func-math-field" ${mathFieldKeyboardAttr} smart-mode="false" aria-label="${titleLabel}"></math-field>
+                </div>
+              </label>
+              <button type="button" class="btn btn--inline-draw" data-action="draw" data-draw-index="${index}" aria-label="Tegn graf for funksjon ${index}">Tegn graf</button>
             </div>
-          </label>
-          <label class="domain">
-            <span>Avgrensning</span>
-            <input type="text" data-dom placeholder="[start, stopp]">
-          </label>
+            <label class="domain">
+              <span>Avgrensning</span>
+              <input type="text" data-dom placeholder="[start, stopp]">
+            </label>
+          </div>
         </div>
       `;
     }
@@ -4245,9 +4253,10 @@ function setupSettingsForm() {
   root.addEventListener('keydown', e => {
     if (e.key === 'Enter') apply();
   });
-  if (drawBtn) {
-    drawBtn.addEventListener('click', () => {
-      apply();
-    });
-  }
+  root.addEventListener('click', event => {
+    const trigger = event.target.closest(drawButtonSelector);
+    if (!trigger) return;
+    event.preventDefault();
+    apply();
+  });
 }


### PR DESCRIPTION
## Summary
- move the draw buttons into each function block so the trigger sits next to "Funksjon 1" and "Funksjon 2"
- tighten the layout of the graph point controls so the fields align on a single row

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10e39985883249abea7cfcf537b70