### PR TITLE
Move graftegner draw buttons outside function card

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -79,6 +79,23 @@
     }
     .func-groups{ display:flex; flex-direction:column; gap:12px; width:100%; }
     .func-group{ gap:14px; }
+    .func-group-wrapper{
+      display:flex;
+      align-items:flex-start;
+      gap:12px;
+    }
+    .func-group-wrapper .func-group{
+      flex:1 1 auto;
+      min-width:0;
+    }
+    .func-draw{
+      flex:0 0 auto;
+      display:flex;
+      align-items:flex-start;
+    }
+    .func-group-wrapper .btn--inline-draw{
+      align-self:flex-start;
+    }
     .func-group .func-fields{
       display:grid;
       gap:12px;
@@ -90,6 +107,18 @@
       flex-direction:column;
       gap:6px;
       width:100%;
+    }
+    .func-row--main,
+    .func-row--secondary{
+      display:grid;
+      gap:12px;
+      grid-template-columns:repeat(2,minmax(0,1fr));
+      align-items:start;
+    }
+    .btn--inline-draw{
+      white-space:nowrap;
+      min-height:42px;
+      padding-inline:16px;
     }
     .func-input .func-editor{
       display:flex;
@@ -146,7 +175,7 @@
     .func-row--gliders{
       display:grid;
       gap:12px;
-      grid-template-columns:repeat(auto-fit,minmax(160px,1fr));
+      grid-template-columns:repeat(3,minmax(120px,1fr));
       align-items:end;
     }
     .func-row--gliders .linepoints-row{
@@ -154,11 +183,15 @@
     }
     .func-row--gliders label.points,
     .func-row--gliders label.linepoint{
-      max-width:180px;
+      max-width:100%;
     }
     .func-row--gliders label.linepoint input,
     .func-row--gliders label.points select{
       max-width:100%;
+    }
+    .func-row--gliders label.points select,
+    .func-row--gliders label.linepoint input{
+      width:100%;
     }
     .func-row--gliders .startx-label{
       grid-column:1 / -1;
@@ -167,7 +200,12 @@
     @media (max-width:680px){
       .function-controls{ align-items:stretch; }
       .func-group .func-fields{ grid-template-columns:1fr; }
-      .func-fields--first .func-row{ grid-template-columns:1fr; }
+      .func-fields--first .func-row,
+      .func-row--secondary{ grid-template-columns:1fr; }
+      .func-group-wrapper{ flex-direction:column; align-items:stretch; }
+      .func-draw{ justify-content:flex-end; }
+      .btn--inline-draw{ width:100%; }
+      .func-row--gliders{ grid-template-columns:1fr; }
     }
     .addFigureBtn{ width:clamp(36px,8vw,56px); aspect-ratio:1; border:2px dashed #cfcfcf; border-radius:10px; background:#fff; display:flex; align-items:center; justify-content:center; font-size:20px; color:#6b7280; cursor:pointer; transition:box-shadow .2s, transform .02s; }
     .addFigureBtn:hover{ box-shadow:0 2px 8px rgba(0,0,0,.06); }
@@ -231,7 +269,6 @@
             <div class="function-controls">
               <div id="funcRows" class="func-groups"></div>
               <div class="func-actions">
-                <button id="btnDraw" class="btn" type="button">Tegn graf(er)</button>
                 <button id="addFunc" class="addFigureBtn" type="button" aria-label="Legg til funksjon">+</button>
               </div>
             </div>

--- a/graftegner.js
+++ b/graftegner.js
@@ -3091,7 +3091,7 @@ function setupSettingsForm() {
   const showBracketsInput = g('cfgShowBrackets');
   const forceTicksInput = g('cfgForceTicks');
   const snapCheckbox = g('cfgSnap');
-  const drawBtn = g('btnDraw');
+  const drawButtonSelector = '[data-action="draw"]';
   let gliderSection = null;
   let gliderCountInput = null;
   let gliderStartInput = null;
@@ -3819,6 +3819,8 @@ function setupSettingsForm() {
     updateLinePointControls({ silent: true });
   };
   const createRow = (index, funVal = '', domVal = '') => {
+    const rowWrapper = document.createElement('div');
+    rowWrapper.className = 'func-group-wrapper';
     const row = document.createElement('fieldset');
     row.className = 'func-group';
     row.dataset.index = String(index);
@@ -3869,21 +3871,35 @@ function setupSettingsForm() {
       row.innerHTML = `
         <legend>Funksjon ${index}</legend>
         <div class="func-fields">
-          <label class="func-input">
-            <span>${titleLabel}</span>
-            <div class="func-editor">
-              <math-field data-fun class="func-math-field" ${mathFieldKeyboardAttr} smart-mode="false" aria-label="${titleLabel}"></math-field>
-            </div>
-          </label>
-          <label class="domain">
-            <span>Avgrensning</span>
-            <input type="text" data-dom placeholder="[start, stopp]">
-          </label>
+          <div class="func-row func-row--secondary">
+            <label class="func-input">
+              <span>${titleLabel}</span>
+              <div class="func-editor">
+                <math-field data-fun class="func-math-field" ${mathFieldKeyboardAttr} smart-mode="false" aria-label="${titleLabel}"></math-field>
+              </div>
+            </label>
+            <label class="domain">
+              <span>Avgrensning</span>
+              <input type="text" data-dom placeholder="[start, stopp]">
+            </label>
+          </div>
         </div>
       `;
     }
+    const drawButton = document.createElement('button');
+    drawButton.type = 'button';
+    drawButton.className = 'btn btn--inline-draw';
+    drawButton.dataset.action = 'draw';
+    drawButton.dataset.drawIndex = String(index);
+    drawButton.setAttribute('aria-label', `Tegn graf for funksjon ${index}`);
+    drawButton.textContent = 'Tegn graf';
+    const drawHolder = document.createElement('div');
+    drawHolder.className = 'func-draw';
+    drawHolder.appendChild(drawButton);
+    rowWrapper.appendChild(row);
+    rowWrapper.appendChild(drawHolder);
     if (funcRows) {
-      funcRows.appendChild(row);
+      funcRows.appendChild(rowWrapper);
     }
     const funInput = row.querySelector('[data-fun]');
     const domInput = row.querySelector('input[data-dom]');
@@ -4245,9 +4261,10 @@ function setupSettingsForm() {
   root.addEventListener('keydown', e => {
     if (e.key === 'Enter') apply();
   });
-  if (drawBtn) {
-    drawBtn.addEventListener('click', () => {
-      apply();
-    });
-  }
+  root.addEventListener('click', event => {
+    const trigger = event.target.closest(drawButtonSelector);
+    if (!trigger) return;
+    event.preventDefault();
+    apply();
+  });
 }


### PR DESCRIPTION
## Summary
- wrap each funksjon-fieldset in a flex container so the «Tegn graf»-knapp sits to the right of the grey card
- adjust the generated markup to keep the draw buttons outside the fieldset while preserving the compact point inputs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10e39985883249abea7cfcf537b70