### PR TITLE
Render number line fractions with KaTeX

### DIFF
--- a/tallinje.html
+++ b/tallinje.html
@@ -126,6 +126,12 @@
       pointer-events: none;
     }
     .major-label .katex { pointer-events: none; }
+    .major-label__katex {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+    }
     .badge {
       display: inline-flex;
       align-items: center;

--- a/tallinje.js
+++ b/tallinje.js
@@ -263,18 +263,17 @@
     const info = getLabelRenderInfo(value);
     container.textContent = '';
 
-    if (info.type === 'katex' && window.katex) {
+    if (info.type === 'katex' && window.katex && typeof window.katex.render === 'function') {
       try {
-        if (typeof window.katex.renderToString === 'function') {
-          container.innerHTML = window.katex.renderToString(info.katex, { throwOnError: false });
+        const span = document.createElement('span');
+        span.className = 'major-label__katex';
+        container.appendChild(span);
+        window.katex.render(info.katex, span, { throwOnError: false });
+        const hasKatexContent = span.querySelector('.katex');
+        if (hasKatexContent) {
           return;
         }
-        if (typeof window.katex.render === 'function') {
-          const span = document.createElement('span');
-          container.appendChild(span);
-          window.katex.render(info.katex, span, { throwOnError: false });
-          return;
-        }
+        container.innerHTML = '';
       } catch (err) {
         container.innerHTML = '';
       }


### PR DESCRIPTION
## Summary
- render fraction tick labels on the number line using KaTeX when available
- add styling for the KaTeX container so fractions remain centered in their labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e12972e3d08324a33e1a7c4ad14dff