### PR TITLE
Align graph draw button beside function fieldset

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -78,7 +78,9 @@
       .func-actions .addFigureBtn{ align-self:center; }
     }
     .func-groups{ display:flex; flex-direction:column; gap:12px; width:100%; }
-    .func-group{ gap:14px; }
+    .func-group{ display:flex; align-items:flex-start; gap:12px; }
+    .func-group fieldset{ flex:1 1 auto; margin:0; }
+    .func-group .func-draw{ align-self:flex-start; }
     .func-group .func-fields{
       display:grid;
       gap:12px;
@@ -101,7 +103,7 @@
     .func-main{
       display:flex;
       gap:12px;
-      align-items:flex-end;
+      align-items:stretch;
     }
     .func-main .func-input{
       flex:1 1 auto;
@@ -192,6 +194,8 @@
     }
     @media (max-width:680px){
       .function-controls{ align-items:stretch; }
+      .func-group{ flex-direction:column; }
+      .func-group .func-draw{ width:100%; }
       .func-group .func-fields{ grid-template-columns:1fr; }
       .func-fields--first .func-row,
       .func-row--secondary{ grid-template-columns:1fr; }

--- a/graftegner.js
+++ b/graftegner.js
@@ -3819,75 +3819,82 @@ function setupSettingsForm() {
     updateLinePointControls({ silent: true });
   };
   const createRow = (index, funVal = '', domVal = '') => {
-    const row = document.createElement('fieldset');
+    const row = document.createElement('div');
     row.className = 'func-group';
     row.dataset.index = String(index);
     const titleLabel = index === 1 ? 'Funksjon eller punkter' : 'Funksjon ' + index;
+    const drawButtonHtml = `
+      <button type="button" class="btn btn--inline-draw func-draw" data-action="draw" data-draw-index="${index}" aria-label="Tegn graf for funksjon ${index}">Tegn graf</button>
+    `;
     if (index === 1) {
       row.innerHTML = `
-        <legend>Funksjon ${index}</legend>
-        <div class="func-fields func-fields--first">
-          <div class="func-row func-row--main">
-            <div class="func-main">
-              <label class="func-input">
-                <span>${titleLabel}</span>
-                <div class="func-editor">
-                  <math-field data-fun class="func-math-field" ${mathFieldKeyboardAttr} smart-mode="false" aria-label="${titleLabel}"></math-field>
-                </div>
-              </label>
-              <button type="button" class="btn btn--inline-draw" data-action="draw" data-draw-index="${index}" aria-label="Tegn graf for funksjon ${index}">Tegn graf</button>
-            </div>
-            <label class="domain">
-              <span>Avgrensning</span>
-              <input type="text" data-dom placeholder="[start, stopp]">
-            </label>
-          </div>
-          <div class="func-row func-row--gliders glider-row">
-            <label class="points">
-              <span>Antall punkter på grafen</span>
-              <select data-points>
-                <option value="0">0</option>
-                <option value="1">1</option>
-                <option value="2">2</option>
-              </select>
-            </label>
-            <div class="linepoints-row">
-              <label class="linepoint" data-linepoint-label="0">
-                <span>Punkt 1 (x, y)</span>
-                <input type="text" data-linepoint="0" placeholder="(0, 0)">
-              </label>
-              <label class="linepoint" data-linepoint-label="1">
-                <span>Punkt 2 (x, y)</span>
-                <input type="text" data-linepoint="1" placeholder="(1, 1)">
+        <fieldset>
+          <legend>Funksjon ${index}</legend>
+          <div class="func-fields func-fields--first">
+            <div class="func-row func-row--main">
+              <div class="func-main">
+                <label class="func-input">
+                  <span>${titleLabel}</span>
+                  <div class="func-editor">
+                    <math-field data-fun class="func-math-field" ${mathFieldKeyboardAttr} smart-mode="false" aria-label="${titleLabel}"></math-field>
+                  </div>
+                </label>
+              </div>
+              <label class="domain">
+                <span>Avgrensning</span>
+                <input type="text" data-dom placeholder="[start, stopp]">
               </label>
             </div>
-            <label class="startx-label">
-              <span>Startposisjon, x</span>
-              <input type="text" data-startx value="1" placeholder="1">
-            </label>
+            <div class="func-row func-row--gliders glider-row">
+              <label class="points">
+                <span>Antall punkter på grafen</span>
+                <select data-points>
+                  <option value="0">0</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                </select>
+              </label>
+              <div class="linepoints-row">
+                <label class="linepoint" data-linepoint-label="0">
+                  <span>Punkt 1 (x, y)</span>
+                  <input type="text" data-linepoint="0" placeholder="(0, 0)">
+                </label>
+                <label class="linepoint" data-linepoint-label="1">
+                  <span>Punkt 2 (x, y)</span>
+                  <input type="text" data-linepoint="1" placeholder="(1, 1)">
+                </label>
+              </div>
+              <label class="startx-label">
+                <span>Startposisjon, x</span>
+                <input type="text" data-startx value="1" placeholder="1">
+              </label>
+            </div>
           </div>
-        </div>
+        </fieldset>
+        ${drawButtonHtml}
       `;
     } else {
       row.innerHTML = `
-        <legend>Funksjon ${index}</legend>
-        <div class="func-fields">
-          <div class="func-row func-row--secondary">
-            <div class="func-main">
-              <label class="func-input">
-                <span>${titleLabel}</span>
-                <div class="func-editor">
-                  <math-field data-fun class="func-math-field" ${mathFieldKeyboardAttr} smart-mode="false" aria-label="${titleLabel}"></math-field>
-                </div>
+        <fieldset>
+          <legend>Funksjon ${index}</legend>
+          <div class="func-fields">
+            <div class="func-row func-row--secondary">
+              <div class="func-main">
+                <label class="func-input">
+                  <span>${titleLabel}</span>
+                  <div class="func-editor">
+                    <math-field data-fun class="func-math-field" ${mathFieldKeyboardAttr} smart-mode="false" aria-label="${titleLabel}"></math-field>
+                  </div>
+                </label>
+              </div>
+              <label class="domain">
+                <span>Avgrensning</span>
+                <input type="text" data-dom placeholder="[start, stopp]">
               </label>
-              <button type="button" class="btn btn--inline-draw" data-action="draw" data-draw-index="${index}" aria-label="Tegn graf for funksjon ${index}">Tegn graf</button>
             </div>
-            <label class="domain">
-              <span>Avgrensning</span>
-              <input type="text" data-dom placeholder="[start, stopp]">
-            </label>
           </div>
-        </div>
+        </fieldset>
+        ${drawButtonHtml}
       `;
     }
     if (funcRows) {


### PR DESCRIPTION
## Summary
- wrap each generated Graftegner function fieldset in a flex container and render the draw button outside of the fieldset
- adjust Graftegner styles to align the draw button to the right of the card and keep the compact point input layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e130f96bdc8324b54e068a8d356164