### PR TITLE
Remove deprecated Observasjon line from fortegnsskjema

### DIFF
--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -711,7 +711,19 @@
     target.domain = sanitizeDomain(target.domain);
     target.autoDomain = sanitizeAutoDomain(target.autoDomain);
     target.criticalPoints = sanitizePointsArray(target.criticalPoints);
-    target.signRows = sanitizeRowsArray(target.signRows);
+    target.signRows = sanitizeRowsArray(target.signRows).filter(row => {
+      if (!row || typeof row.label !== 'string') {
+        return true;
+      }
+      const normalizedLabel = row.label.trim().toLowerCase();
+      if (normalizedLabel !== 'observasjon') {
+        return true;
+      }
+      if (row.role === 'result' || row.role === 'factor') {
+        return true;
+      }
+      return false;
+    });
     target.solution = sanitizeSolution(target.solution);
     if (typeof target.altText !== 'string') {
       target.altText = '';


### PR DESCRIPTION
## Summary
- filter sanitized sign rows so that legacy "Observasjon" helper rows are dropped while keeping actual result and factor rows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e136aae3108324aec3289520dd80ab