### PR TITLE
Adjust Graftegner point labels and field widths

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -188,13 +188,13 @@
     .func-row--gliders label.linepoint{
       max-width:100%;
     }
-    .func-row--gliders label.linepoint input,
     .func-row--gliders label.points select{
-      max-width:100%;
+      width:100%;
+      max-width:72px;
     }
-    .func-row--gliders label.points select,
     .func-row--gliders label.linepoint input{
       width:100%;
+      max-width:140px;
     }
     .func-row--gliders .startx-label{
       grid-column:1 / -1;

--- a/graftegner.js
+++ b/graftegner.js
@@ -3847,7 +3847,7 @@ function setupSettingsForm() {
             </div>
             <div class="func-row func-row--gliders glider-row">
               <label class="points">
-                <span>Antall punkter på grafen</span>
+                <span>Punkter på grafen</span>
                 <select data-points>
                   <option value="0">0</option>
                   <option value="1">1</option>
@@ -3856,11 +3856,11 @@ function setupSettingsForm() {
               </label>
               <div class="linepoints-row">
                 <label class="linepoint" data-linepoint-label="0">
-                  <span>Punkt 1 (x, y)</span>
+                  <span>Punkt 1</span>
                   <input type="text" data-linepoint="0" placeholder="(0, 0)">
                 </label>
                 <label class="linepoint" data-linepoint-label="1">
-                  <span>Punkt 2 (x, y)</span>
+                  <span>Punkt 2</span>
                   <input type="text" data-linepoint="1" placeholder="(1, 1)">
                 </label>
               </div>


### PR DESCRIPTION
## Summary
- rename the Graftegner point controls to shorter Norwegian labels
- shrink the select and input controls for graph points to better match their content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e23b9a8af08324b7368331fd5d263b