### PR TITLE
Refine shared layout styling

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -6,61 +6,11 @@
   <title>Arealmodell</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
-
 <style>
-    :root { --gap: 18px; }
-    html,body { height: 100%; }
-    body {
-      margin: 0;
-      font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      color: #111827;
-      background: #f7f8fb;
-      padding: 20px;
-    }
-    .wrap { max-width: 1200px; margin: 0 auto; display: flex; flex-direction: column; gap: var(--gap); }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 360px; align-items: start; }
-    .side { display:flex; flex-direction:column; gap:var(--gap); }
+    .grid { grid-template-columns: 1fr 360px; }
     @media (max-width:980px){ .grid { grid-template-columns: 1fr; } }
-    .card {
-      background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
-      box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 14px;
-      display: flex; flex-direction: column; gap: 10px;
-    }
     .card.card--canvas { position: relative; }
     .area-container { position: relative; }
-    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
     svg { width: 100%; height: auto; background: #fff; display: block; }
     #area .c1 { fill: #e07c7c !important; }
     .pairs-list { position:absolute; top:10px; right:10px; display:flex; gap:1.2em; text-align:right; pointer-events:none; font-size:16px; line-height:1.25; }
@@ -69,13 +19,6 @@
     .settings { display: flex; flex-direction: column; gap: 10px; }
     .settings [hidden] { display: none !important; }
     .settings .section-title { margin: 4px 2px 0; font-size: 12px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: #6b7280; }
-    .toolbar { display:flex; gap:10px; justify-content:flex-start; align-items:center; flex-wrap:wrap; }
-    .btn { appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px; padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s; }
-    .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform:translateY(1px); }
-    .settings label { font-size: 13px; color: #4b5563; display: flex; flex-direction: column; }
-    .settings input,
-    .settings select { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; }
     .settings .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
     .settings .row.row--global { align-items: center; justify-content: space-between; }
     .settings .row.row--checkboxes { align-items: center; }

--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -7,73 +7,14 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; }
-    html,body{height:100%;}
-    body{
-      margin:0;
-      font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      color:#111827;
-      background:#f7f8fb;
-      padding:20px;
-    }
-    .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
-    .side{display:flex;flex-direction:column;gap:var(--gap);}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
-    .card{
-      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
-      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
-      display:flex;flex-direction:column;gap:10px;
-    }
-    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    :root { --grid-side-width: 360px; }
     #box{width:clamp(280px,60vw,460px);aspect-ratio:1;margin:0 auto;position:relative;}
     .pairs-list{position:absolute;top:10px;right:10px;display:flex;gap:1.2em;text-align:right;pointer-events:none;font-size:16px;line-height:1.2;}
     .pairs-list .col{display:flex;flex-direction:column;gap:4px;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
-    .btn{
-      appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;
-      padding:8px 12px;font-size:14px;cursor:pointer;
-      transition:box-shadow .2s,transform .02s;
-    }
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
-    .btn:active{transform:translateY(1px);}
     .settings{display:flex;flex-direction:column;gap:10px;}
-    .settings label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
-    .settings input{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
     .settings .row{display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end;}
     .settings .row label{flex:0;}
     .settings .row label input[type="number"]{width:80px;}

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -6,73 +6,17 @@
   <title>Arealmodell B</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; }
-    html,body { height: 100%; }
-    body {
-      margin: 0;
-      font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      color: #111827;
-      background: #f7f8fb;
-      padding: 20px;
-    }
-    .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 360px; align-items: start; }
-    .side { display:flex; flex-direction:column; gap:var(--gap); }
-    @media (max-width:980px){ .grid { grid-template-columns: 1fr; } }
-    .card {
-      background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
-      box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 14px;
-      display: flex; flex-direction: column; gap: 10px;
-    }
-    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+    :root { --grid-side-width: 360px; }
     svg { width: 100%; height: auto; background: #fff; display: block; }
     .settings { display: flex; flex-direction: column; gap: 16px; }
     .settings-section { display:flex; flex-direction:column; gap:10px; }
     .settings .section-title { margin: 4px 2px 0; font-size: 12px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: #6b7280; }
-    .toolbar { display:flex; gap:10px; justify-content:flex-start; align-items:center; flex-wrap:wrap; }
-    .btn { appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px; padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s; }
-    .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform:translateY(1px); }
-    .settings label { font-size: 13px; color: #4b5563; display: flex; flex-direction: column; }
     .settings .label--grow { flex: 1; }
     .settings label.chk { flex-direction: row; align-items: center; }
     .settings label.chk input { margin-right: 6px; }
-    .settings input,
-    .settings select { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; }
 
     .settings .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
     .settings .row label { flex: 0; }

--- a/base.css
+++ b/base.css
@@ -8,6 +8,7 @@
   --card-border: #e5e7eb;
   --card-radius: 14px;
   --control-radius: 10px;
+  --grid-side-width: 360px;
 }
 
 html,
@@ -26,12 +27,22 @@ body {
 .wrap {
   max-width: 1200px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
 }
 
 .grid {
   display: grid;
   gap: var(--gap);
   align-items: start;
+  grid-template-columns: minmax(0, 1fr) minmax(0, var(--grid-side-width));
+}
+
+@media (max-width: 980px) {
+  .grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .side {
@@ -103,6 +114,9 @@ body {
 label {
   font-size: 13px;
   color: var(--label-color);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 textarea,

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -9,46 +9,11 @@
   <!-- JSXGraph -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css">
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap:18px; --purple:#5B2AA5; --rim:#333; --dash:#000; }
-    html,body{height:100%;}
-    body{
-      margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      color:#111827; background:#f7f8fb; display:flex; flex-direction:column;
-    }
+    :root { --purple:#5B2AA5; --rim:#333; --dash:#000; --grid-side-width: 420px; }
+    body{ display:flex; flex-direction:column; }
     .wrap{
       flex:1;
       width:min(1600px,100%);
@@ -61,9 +26,7 @@
     }
     .grid{
       flex:1;
-      display:grid;
-      gap:var(--gap);
-      grid-template-columns:minmax(0,1fr) minmax(320px,420px);
+      grid-template-columns:minmax(0,1fr) minmax(320px,var(--grid-side-width));
       grid-template-rows:minmax(0,1fr);
       align-items:stretch;
       min-height:0;
@@ -116,12 +79,7 @@
       color:#6b7280;
       cursor:pointer;
     }
-    .card{
-      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
-      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;display:flex;
-      flex-direction:column;gap:10px;
-    }
-    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    .card{gap:10px;}
     .figure{width:100%;flex:1 1 auto;border-radius:10px;background:#fff;overflow:visible;border:none;display:flex;justify-content:center;align-items:center;min-height:var(--figure-size, 240px);}
     .figure .box{
       width:100%;
@@ -157,10 +115,6 @@
       background:#fff;font-size:20px;cursor:pointer;
     }
     .stepper span{min-width:32px;text-align:center;font-variant-numeric:tabular-nums;font-size:16px;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
-    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
-    .btn:active{transform:translateY(1px)}
     .figureSettings{
       --figure-settings-cols:1;
       --figure-settings-rows:1;

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -7,68 +7,11 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
 
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
-
 <style>
-    :root { --purple:#5B2AA5; --rim:#333; --dash:#000; --gap:18px; }
-    html,body { height:100%; }
-    body {
-      margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      color:#111827; background:#f7f8fb; padding:20px;
-    }
-    .wrap { max-width:1200px; margin:0 auto; }
-    .grid { display:grid; gap:var(--gap); grid-template-columns:1fr 360px; align-items:start; }
-    .side { display:flex; flex-direction:column; gap:var(--gap); }
+    :root { --purple:#5B2AA5; --rim:#333; --dash:#000; }
+    .grid { grid-template-columns:1fr 360px; }
     @media (max-width:980px){ .grid { grid-template-columns:1fr; } }
-    .card {
-      background:#fff; border:1px solid #e5e7eb; border-radius:14px;
-      box-shadow:0 1px 2px rgba(0,0,0,.04); padding:14px;
-      display:flex; flex-direction:column; gap:10px;
-    }
-    .card h2 { margin:0 0 6px 2px; font-size:16px; font-weight:600; color:#374151; }
-    .toolbar { display:flex; gap:10px; justify-content:flex-start; align-items:center; flex-wrap:wrap; }
-    .btn {
-      appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px;
-      padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s;
-    }
-    .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform:translateY(1px); }
-    label { font-size:13px; color:#4b5563; }
-    input[type="number"], select {
-      border:1px solid #d1d5db; border-radius:10px; padding:8px 10px;
-      font-size:14px; background:#fff; width:100%; box-sizing:border-box;
-    }
+    input[type="number"], select { width:100%; box-sizing:border-box; }
     fieldset { border:1px solid #e5e7eb; border-radius:10px; padding:10px; margin:0; display:flex; flex-direction:column; gap:8px; }
     .settings { display:flex; gap:var(--gap); }
     .settings fieldset { flex:1; }

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -6,78 +6,11 @@
   <title>Brøkvegg</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; --purple:#5B2AA5; }
-    html, body { height: 100%; }
-    body {
-      margin: 0;
-      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
-      color: #111827;
-      background: #f7f8fb;
-      padding: 20px;
-    }
-    .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 360px; align-items: start; }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
-    .side { display: flex; flex-direction: column; gap: var(--gap); }
-    .card {
-      background: #fff;
-      border: 1px solid #e5e7eb;
-      border-radius: 14px;
-      box-shadow: 0 1px 2px rgba(0,0,0,.04);
-      padding: 14px;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
-    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+    :root { --purple:#5B2AA5; --grid-side-width: 360px; }
     .card p { margin: 0; font-size: 13px; color: #4b5563; line-height: 1.5; }
-    .toolbar { display: flex; gap: 10px; justify-content: flex-start; align-items: center; flex-wrap: wrap; }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: 10px;
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow .2s, transform .02s;
-    }
-    .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform: translateY(1px); }
     .btn:disabled { opacity: .6; cursor: not-allowed; }
     .btn.is-active {
       background: #0f6d8f;
@@ -85,13 +18,7 @@
       border-color: #0f6d8f;
       box-shadow: 0 2px 8px rgba(15, 109, 143, 0.2);
     }
-    label { font-size: 13px; color: #4b5563; display: flex; flex-direction: column; gap: 6px; }
     input[type="text"], input[type="number"] {
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      padding: 8px 10px;
-      font-size: 14px;
-      background: #fff;
       width: 100%;
       box-sizing: border-box;
     }

--- a/diagram.css
+++ b/diagram.css
@@ -1,29 +1,6 @@
-:root { --gap: 18px; }
-html,body { height: 100%; }
-body {
-  margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
-  color: #111827; background: #f7f8fb; padding: 20px;
-}
-.wrap { max-width: 1200px; margin: 0 auto; }
-.grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
-.side { display:flex; flex-direction:column; gap:var(--gap); }
-@media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
-.card {
-  background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 14px; display: flex;
-  flex-direction: column; gap: 10px;
-}
-.card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+:root { --grid-side-width: 480px; }
 .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
 .figure svg { width: 100%; height: auto; display: block; background: #fff; }
-.toolbar { display: flex; gap: 10px; justify-content: flex-start; align-items: center; flex-wrap: wrap; }
-.btn {
-  appearance: none; border: 1px solid #d1d5db; background: #fff; border-radius: 10px;
-  padding: 8px 12px; font-size: 14px; cursor: pointer;
-  transition: box-shadow .2s, transform .02s;
-}
-.btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
-.btn:active { transform: translateY(1px); }
 .status {
   position: absolute;
   width: 1px; height: 1px; margin: -1px;
@@ -31,8 +8,7 @@ body {
   white-space: nowrap; border: 0;
 }
 .settings { display: flex; flex-direction: column; gap: 8px; }
-.settings label { display: flex; flex-direction: column; font-size: 13px; color: #4b5563; }
-.settings input, .settings select { padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 10px; font-size: 14px; background: #fff; width: 100%; }
+.settings input, .settings select { width: 100%; }
 .settings fieldset { border: 1px solid #e5e7eb; border-radius: 10px; padding: 10px; margin: 0; display: flex; flex-direction: column; gap: 10px; }
 .settings legend { font-weight: 600; font-size: 13px; color: #374151; padding: 0 4px; }
 .settings-row { display: flex; gap: 8px; }

--- a/figurtall.html
+++ b/figurtall.html
@@ -6,50 +6,11 @@
   <title>Figurtall</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap:18px; --card-min:240px; }
-    html,body{height:100%;}
-    body{
-      margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      color:#111827; background:#f7f8fb; padding:20px;
-    }
-    .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:minmax(0,1fr) clamp(260px,32vw,360px);align-items:start;}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
-    .side{display:flex;flex-direction:column;gap:var(--gap);}
+    :root { --card-min:240px; --grid-side-width: clamp(260px,32vw,360px); }
+    .grid{grid-template-columns:minmax(0,1fr) var(--grid-side-width);}
     .grid2{
       --panel-min:clamp(200px,22vw,260px);
       display:grid;
@@ -84,16 +45,6 @@
     @media(max-width:720px){
       .grid2{gap:16px;}
     }
-    .card{
-      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
-      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;display:flex;
-      flex-direction:column;gap:10px;
-    }
-    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
-    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
-    .btn:active{transform:translateY(1px);}
     .card--settings fieldset{display:flex;flex-direction:column;gap:12px;margin:0;padding:0;border:none;}
     .card--settings fieldset + fieldset{margin-top:12px;}
     .card--settings legend{font-weight:600;font-size:14px;margin-bottom:4px;color:#374151;}

--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -7,80 +7,14 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mathlive/dist/mathlive-static.css" />
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; }
-    html, body { height: 100%; }
-    body {
-      margin: 0;
-      padding: 20px;
-      background: #f7f8fb;
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Inter, Arial, sans-serif;
-      color: #111827;
-    }
-    .wrap {
-      max-width: 1200px;
-      margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: var(--gap);
-    }
-    .grid {
-      display: grid;
-      gap: var(--gap);
-      grid-template-columns: 1fr 380px;
-      align-items: start;
-    }
-    .side {
-      display: flex;
-      flex-direction: column;
-      gap: var(--gap);
-    }
+    :root { --grid-side-width: 380px; }
     @media (max-width: 1000px) {
       .grid { grid-template-columns: 1fr; }
     }
-    .card {
-      background: #fff;
-      border: 1px solid #e5e7eb;
-      border-radius: 14px;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-      padding: 16px;
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-    }
+    .card { padding: 16px; gap: 16px; }
     .card h1 {
       margin: 0;
       font-size: 22px;

--- a/graftegner.html
+++ b/graftegner.html
@@ -10,61 +10,20 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mathlive/dist/mathlive-static.css" />
 
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; }
-    html,body { height: 100%; }
+    :root { --grid-side-width: 420px; }
     html { scroll-behavior: smooth; }
     @media (prefers-reduced-motion: reduce) {
       html { scroll-behavior: auto; }
     }
-    body{
-      margin:0; padding:20px; background:#f7f8fb;
-      font-family:system-ui,-apple-system,"Segoe UI",Roboto,Inter,Arial,sans-serif; color:#111827;
-    }
-    .wrap{ max-width:1200px; margin:0 auto; }
-    .grid{ display:grid; gap:var(--gap); grid-template-columns:1fr 420px; align-items:start; }
-    .side{ display:flex; flex-direction:column; gap:var(--gap); }
     @media (max-width:980px){ .grid{ grid-template-columns:1fr; } }
-    .card{ background:#fff; border:1px solid #e5e7eb; border-radius:14px; box-shadow:0 1px 2px rgba(0,0,0,.04); padding:14px; display:flex; flex-direction:column; gap:10px; }
-    .card h2{ margin:0 0 6px 2px; font-size:16px; font-weight:600; color:#374151; }
     .figure{ border-radius:10px; background:#fafbfc; overflow:hidden; border:1px solid #eef0f3; }
     #board{ width:100%; height:560px; background:#fff; }
-    .toolbar{ display:flex; gap:12px; flex-wrap:wrap; justify-content:flex-start; align-items:center; }
+    .toolbar{ gap:12px; justify-content:flex-start; }
     #toolbar{ justify-content:space-between; }
-    .btn{ appearance:none; cursor:pointer; padding:8px 14px; border-radius:10px; border:1px solid #d1d5db; background:#fff; }
+    .btn{ padding:8px 14px; }
     .mobile-nav{ display:none; gap:12px; margin-top:12px; flex-wrap:wrap; }
     .mobile-nav .btn{ flex:1 1 160px; text-align:center; text-decoration:none; display:flex; justify-content:center; align-items:center; }
     .mobile-nav .btn:link,
@@ -75,8 +34,8 @@
     .status--err{ color:#b91c1c; background:#fef2f2; border-color:#fecaca; }
     .status--info{ color:#1f2937; background:#f3f4f6; border-color:#e5e7eb; }
     .settings{ display:flex; flex-direction:column; gap:8px; }
-    .settings label{ display:flex; flex-direction:column; gap:6px; font-size:13px; color:#4b5563; white-space:normal; }
-    .settings input[type="text"], .settings input[type="number"], .settings select{ padding:8px 10px; border:1px solid #d1d5db; border-radius:10px; font-size:14px; background:#fff; width:100%; }
+    .settings label{ white-space:normal; }
+    .settings input[type="text"], .settings input[type="number"], .settings select{ width:100%; }
     .function-controls{ display:flex; flex-direction:column; gap:16px; align-items:stretch; }
     .func-actions{ display:flex; gap:12px; align-items:center; justify-content:space-between; }
     .func-actions .btn{ flex:1; min-height:42px; }

--- a/index.html
+++ b/index.html
@@ -5,38 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <link rel="stylesheet" href="base.css" />
   <title>Math Visuals</title>
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
     *, *::before, *::after {

--- a/kuler.html
+++ b/kuler.html
@@ -6,49 +6,12 @@
   <title>Kuler</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap:18px; }
-    html,body{height:100%;}
-    body{
-      margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      color:#111827; background:#f7f8fb; padding:20px;
-    }
-    .wrap{max-width:1400px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
-    .side{display:flex;flex-direction:column;gap:var(--gap);}
+    :root { --grid-side-width: 360px; }
+    .wrap{max-width:1400px;}
+    .grid{grid-template-columns:1fr var(--grid-side-width);}
     .figureGrid{
       --figure-columns:1;
       display:grid;
@@ -69,12 +32,7 @@
     .addFigureBtn{width:clamp(36px,8vw,56px);aspect-ratio:1;border:2px dashed #cfcfcf;border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;font-size:18px;color:#6b7280;cursor:pointer;justify-self:center;align-self:center;}
     @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     @media(max-width:720px){.figureGrid{--figure-columns:1;justify-items:center;}.figurePanel{max-width:100%;}.figure{max-width:100%;}.addFigureBtn{width:clamp(36px,14vw,60px);}}
-    .card{
-      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
-      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
-      display:flex;flex-direction:column;gap:10px;
-    }
-    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    .card{gap:10px;}
     .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;width:100%;max-width:680px;margin:0 auto;}
     .figure svg{width:100%;height:auto;display:block;touch-action:none;}
     .ctrlRow{display:flex;align-items:center;gap:6px;font-size:14px;}
@@ -87,10 +45,6 @@
     .bead{cursor:grab;}
     .bead:active{cursor:grabbing;}
     .beadShadow{filter:drop-shadow(0 1px 1px rgba(0,0,0,.25));}
-    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
-    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
-    .btn:active{transform:translateY(1px);}
     .toolbar select{border:1px solid #d1d5db;border-radius:10px;padding:6px 10px;font-size:14px;background:#fff;}
     .controlsWrap{display:grid;gap:var(--gap);grid-template-columns:minmax(0,1fr);}
     .controlsWrap.controlsWrap--split{grid-template-columns:repeat(2,minmax(0,1fr));}

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -5,59 +5,10 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Numbervisuals</title>
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; }
-    html,body{height:100%;}
-    body{
-      margin:0;
-      font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      color:#111827;
-      background:#f7f8fb;
-      padding:20px;
-    }
-    .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
-    .side{display:flex;flex-direction:column;gap:var(--gap);}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
-    .card{
-      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
-      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
-      display:flex;flex-direction:column;gap:10px;
-    }
-    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    :root { --grid-side-width: 360px; }
     .figure-area{
       position:relative;
       width:min(80vmin,100%);
@@ -90,8 +41,7 @@
     }
     #patternContainer svg{width:100%;height:100%;display:block;}
     #expression{text-align:center;font-size:24px;font-weight:600;}
-    label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
-    input[type="number"]{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
+    input[type="number"]{width:100%;}
     .field-row{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));}
     .field-grid{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));}
     #playBtn{
@@ -112,10 +62,6 @@
       cursor:pointer;
       box-shadow:0 2px 8px rgba(0,0,0,.15);
     }
-    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
-    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
-    .btn:active{transform:translateY(1px);}
   </style>
   <link rel="stylesheet" href="split.css" />
 </head>

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -5,59 +5,10 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Kvikkbilder</title>
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; }
-    html,body{height:100%;}
-    body{
-      margin:0;
-      font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      color:#111827;
-      background:#f7f8fb;
-      padding:20px;
-    }
-    .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
-    .side{display:flex;flex-direction:column;gap:var(--gap);}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
-    .card{
-      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
-      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
-      display:flex;flex-direction:column;gap:10px;
-    }
-    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    :root { --grid-side-width: 360px; }
     .figure-area{
       position:relative;
       width:min(80vmin,100%);
@@ -116,8 +67,7 @@
     #patternContainer svg,
     #rectangleContainer svg{width:100%;height:100%;display:block;}
     #expression{text-align:center;font-size:24px;font-weight:600;margin-top:var(--gap);}
-    label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
-    input[type="number"], select{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
+    input[type="number"], select{width:100%;}
     .field-row{display:grid;gap:10px;}
     .field-row.field-row--two{grid-template-columns:repeat(auto-fit,minmax(140px,1fr));}
     .field-row.field-row--three{grid-template-columns:repeat(auto-fit,minmax(100px,1fr));}
@@ -142,10 +92,6 @@
       justify-content:center;
       box-shadow:0 2px 8px rgba(0,0,0,.15);
     }
-    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
-    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
-    .btn:active{transform:translateY(1px);}
   </style>
   <link rel="stylesheet" href="split.css" />
 </head>

--- a/nkant.html
+++ b/nkant.html
@@ -5,61 +5,15 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Nkant – én SVG med flere figurer</title>
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; }
-    html,body { height: 100%; }
-    body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
-           color: #111827; background: #f7f8fb; padding: 20px; }
-    .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
-    .side { display:flex; flex-direction:column; gap:var(--gap); }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
-    .card { background: #fff; border: 1px solid #e5e7eb; border-radius: 14px; box-shadow: 0 1px 2px rgba(0,0,0,.04);
-            padding: 14px; display: flex; flex-direction: column; gap: 10px; }
-    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+    :root { --grid-side-width: 480px; }
     .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
     .figure svg { width: 100%; height: 360px; display: block; }
-    .toolbar { display: flex; gap: 10px; justify-content: flex-start; align-items: center; flex-wrap: wrap; }
     .specs-row { display:flex; gap:10px; align-items:flex-start; }
     .specs-row textarea { flex:1; width:auto; }
-    .btn { appearance: none; border: 1px solid #d1d5db; background: #fff; border-radius: 10px; padding: 8px 12px; font-size: 14px;
-           cursor: pointer; transition: box-shadow .2s, transform .02s; }
-    .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); } .btn:active { transform: translateY(1px); }
-    label { font-size: 13px; color: #4b5563; }
-    textarea, select, input[type="text"] { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; width: 100%; }
+    textarea, select, input[type="text"] { width: 100%; }
     .small { font-size: 12px; color: #6b7280; }
     .sep { height: 1px; background: #eef0f3; margin: 8px 0; }
     .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -5,80 +5,13 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Perlesnor</title>
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; }
-    html, body { height: 100%; }
-    body {
-      margin: 0;
-      font-family: system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans";
-      color: #111827;
-      background: #f7f8fb;
-      padding: 20px;
-    }
-    .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
-    .side { display:flex; flex-direction:column; gap:var(--gap); }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
-    .card {
-      background: #fff;
-      border: 1px solid #e5e7eb;
-      border-radius: 14px;
-      box-shadow: 0 1px 2px rgba(0,0,0,.04);
-      padding: 14px;
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-    }
-    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+    :root { --grid-side-width: 480px; }
     .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
     .figure svg { width: 100%; height: 360px; display: block; touch-action: none; }
-    .toolbar { display:flex; gap:10px; justify-content:flex-start; align-items:center; flex-wrap:wrap; }
-    .btn { appearance:none; border:1px solid #d1d5db; background:#fff; border-radius:10px; padding:8px 12px; font-size:14px; cursor:pointer; transition:box-shadow .2s, transform .02s; }
-    .btn:hover { box-shadow:0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform:translateY(1px); }
-    label { font-size: 13px; color: #4b5563; }
-    input[type="number"] {
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      padding: 8px 10px;
-      font-size: 14px;
-      background: #fff;
-      width: 100%;
-      box-sizing: border-box;
-    }
+    input[type="number"] { width: 100%; box-sizing: border-box; }
 
     .beadShadow{ filter: drop-shadow(0 1px 1px rgba(0,0,0,.25)); }
     .beadFallback.red{ fill:#d24a2c; stroke:#b23d22; stroke-width:2; }

--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -6,69 +6,11 @@
   <title>Prikk til prikk (beta)</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" />
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; }
-    html, body { height: 100%; }
-    body {
-      margin: 0;
-      font-family: system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans";
-      color: #111827;
-      background: #f7f8fb;
-      padding: 20px;
-    }
-    .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 420px; align-items: start; }
-    .side { display: flex; flex-direction: column; gap: var(--gap); }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
-    .card {
-      background: #fff;
-      border: 1px solid #e5e7eb;
-      border-radius: 14px;
-      box-shadow: 0 1px 2px rgba(0,0,0,.04);
-      padding: 16px;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
-    .card h2 {
-      margin: 0;
-      font-size: 16px;
-      font-weight: 600;
-      color: #374151;
-    }
+    :root { --grid-side-width: 420px; }
+    .card { padding: 16px; gap: 12px; }
     .card--board { gap: 16px; }
     .figure {
       border-radius: 10px;
@@ -179,19 +121,7 @@
     .settings-range--inline .settings-range__label { font-weight: 500; color: #4b5563; }
     .settings-pan { display: grid; gap: 10px; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
     .range-value { font-size: 12px; color: #6b7280; font-weight: 600; }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: 10px;
-      padding: 8px 14px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow .2s, transform .02s;
-      color: inherit;
-    }
-    .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform: translateY(1px); }
+    .btn { padding: 8px 14px; }
     .btn:disabled {
       opacity: .6;
       cursor: default;

--- a/tallinje.html
+++ b/tallinje.html
@@ -5,69 +5,10 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Tallinje</title>
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; }
-    html, body { height: 100%; }
-    body {
-      margin: 0;
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
-      color: #111827;
-      background: #f7f8fb;
-      padding: 20px;
-    }
-    .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 420px; align-items: start; }
-    .side { display: flex; flex-direction: column; gap: var(--gap); }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
-    .card {
-      background: #fff;
-      border: 1px solid #e5e7eb;
-      border-radius: 14px;
-      box-shadow: 0 1px 2px rgba(0,0,0,.04);
-      padding: 14px;
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-    }
-    .card h2 {
-      margin: 0 0 4px 2px;
-      font-size: 16px;
-      font-weight: 600;
-      color: #374151;
-    }
+    :root { --grid-side-width: 420px; }
     .figure {
       border-radius: 12px;
       background: #fafbfc;
@@ -75,26 +16,7 @@
       border: 1px solid #eef0f3;
     }
     .figure svg { width: 100%; height: 320px; display: block; }
-    .toolbar { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: 10px;
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow .2s, transform .02s;
-    }
-    .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform: translateY(1px); }
-    label { font-size: 13px; color: #4b5563; display: flex; flex-direction: column; gap: 6px; }
     input[type="number"], select {
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      padding: 8px 10px;
-      font-size: 14px;
-      background: #fff;
       width: 100%;
       box-sizing: border-box;
     }

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -6,63 +6,10 @@
   <title>Tenkeblokker</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap:18px; }
-    html,body{height:100%;}
-    body{
-      margin:0;
-      font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      color:#111827;
-      background:#f7f8fb;
-      padding:20px;
-    }
-    .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
-    .side{display:flex;flex-direction:column;gap:var(--gap);}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
-    .card{
-      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
-      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
-      display:flex;flex-direction:column;gap:12px;
-    }
-    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
-    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
-    .btn:active{transform:translateY(1px);}
+    :root { --grid-side-width: 360px; }
     .muted{font-size:13px;color:#6b7280;margin:0;}
 
     #blocks{display:flex;flex-wrap:wrap;justify-content:center;row-gap:20px;column-gap:0;}
@@ -70,6 +17,7 @@
     .tb-block{display:flex;border:2px solid #333;height:120px;width:360px;border-radius:12px;overflow:hidden;background:#fff;}
     .tb-segment{flex:1;display:flex;align-items:center;justify-content:center;border-right:1px dashed #777;background:#e8eedf;font-size:24px;font-variant-numeric:tabular-nums;}
     .tb-segment:last-child{border-right:none;}
+    .card{gap:12px;}
     .tb-stepper{display:flex;gap:10px;margin-top:4px;}
     .tb-stepper button{width:40px;height:36px;font-size:24px;border:1px solid #cfcfcf;border-radius:8px;background:#fff;cursor:pointer;}
     .tb-stepper button:active{transform:translateY(1px);}

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -6,60 +6,15 @@
   <title>Tenkeblokker</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
     :root {
-      --gap: 18px;
       --tb-stepper-gap: 0px;
       --tb-stepper-spacing: 6px;
+      --grid-side-width: 420px;
     }
-    html,body{height:100%;}
-    body{
-      margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      color:#111827; background:#f7f8fb; padding:20px;
-    }
-    .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:minmax(0,1fr) minmax(320px,420px);align-items:start;}
-    .side{display:flex;flex-direction:column;gap:var(--gap);}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
-    .card{
-      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
-      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
-      display:flex;flex-direction:column;gap:10px;
-    }
-    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    .grid{grid-template-columns:minmax(0,1fr) minmax(320px,var(--grid-side-width));}
     /* Figur */
     .tb-board{
       position:relative;
@@ -183,18 +138,13 @@
     .tb-stepper button:active{transform:translateY(1px)}
     .tb-inline-row{display:flex;align-items:center;gap:6px;font-size:13px;color:#4b5563;}
     .tb-inline-row label{font-size:13px;color:inherit;cursor:pointer;}
-    label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     input[type="number"],
-    select{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
+    select{width:100%;}
     .checkbox-row{display:flex;align-items:center;gap:6px;font-size:13px;color:#4b5563;}
     .checkbox-row input{margin:0;}
     .checkbox-row input:disabled{cursor:not-allowed;}
     .checkbox-row input:disabled + label{opacity:.6;cursor:not-allowed;}
     .checkbox-row label{display:inline;}
-    .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
-    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
-    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
-    .btn:active{transform:translateY(1px);}
     fieldset{border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;display:flex;flex-direction:column;gap:8px;}
     legend{font-weight:600;font-size:13px;color:#374151;padding:0 4px;}
   </style>

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -5,79 +5,11 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Trefigurer</title>
   <link rel="stylesheet" href="base.css" />
-  <style data-base-theme>
-    :root {
-      --surface-bg: #f7f8fb;
-      --text-color: #111827;
-      --control-radius: 10px;
-    }
-    body {
-      margin: 0;
-      background: var(--surface-bg);
-      color: var(--text-color);
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      padding: 20px;
-    }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: var(--control-radius);
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow 0.2s, transform 0.02s;
-      font-family: inherit;
-      color: inherit;
-    }
-    .btn:hover {
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-    .btn:active {
-      transform: translateY(1px);
-    }
-  </style>
+  
 
 <style>
-    :root { --gap: 18px; }
-    html, body { height: 100%; }
-    body {
-      margin: 0;
-      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
-      color: #111827;
-      background: #f7f8fb;
-      padding: 20px;
-    }
-    .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 420px; align-items: start; }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
-    .side { display: flex; flex-direction: column; gap: var(--gap); }
-    .card {
-      background: #fff;
-      border: 1px solid #e5e7eb;
-      border-radius: 14px;
-      box-shadow: 0 1px 2px rgba(0,0,0,.04);
-      padding: 14px;
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-    }
-    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
-    .toolbar { display: flex; gap: 10px; justify-content: flex-start; align-items: center; flex-wrap: wrap; }
-    .btn {
-      appearance: none;
-      border: 1px solid #d1d5db;
-      background: #fff;
-      border-radius: 10px;
-      padding: 8px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      transition: box-shadow .2s, transform .02s;
-    }
-    .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform: translateY(1px); }
-    label { font-size: 13px; color: #4b5563; }
-    textarea { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; width: 100%; }
+    :root { --grid-side-width: 420px; }
+    textarea { width: 100%; }
     .card--settings { gap: 16px; }
     .settings-group { display: grid; gap: 14px; }
     .settings-group--columns { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }


### PR DESCRIPTION
## Summary
- expand base.css with shared layout, grid and form styles and introduce a configurable sidebar width variable
- remove duplicated base styling blocks from each app’s HTML/CSS and keep only app specific rules
- align page specific layouts with the shared theme using CSS variables and targeted overrides

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e23af16f2c832488329db21bf2c331