### PR TITLE
Add shared sidebar layout helper

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -7,8 +7,6 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
 <style>
-    .grid { grid-template-columns: 1fr 360px; }
-    @media (max-width:980px){ .grid { grid-template-columns: 1fr; } }
     .card.card--canvas { position: relative; }
     .area-container { position: relative; }
     svg { width: 100%; height: auto; background: #fff; display: block; }
@@ -38,7 +36,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card card--canvas">
         <div class="area-container">
           <svg id="area" preserveAspectRatio="xMidYMid meet" aria-label="Arealmodell"></svg>

--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -10,7 +10,6 @@
   
 
 <style>
-    :root { --grid-side-width: 360px; }
     #box{width:clamp(280px,60vw,460px);aspect-ratio:1;margin:0 auto;position:relative;}
     .pairs-list{position:absolute;top:10px;right:10px;display:flex;gap:1.2em;text-align:right;pointer-events:none;font-size:16px;line-height:1.2;}
     .pairs-list .col{display:flex;flex-direction:column;gap:4px;}
@@ -26,7 +25,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="box" class="jxgbox" aria-label="Arealmodell rektangel"></div>
         <div class="toolbar">

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -9,7 +9,6 @@
   
 
 <style>
-    :root { --grid-side-width: 360px; }
     svg { width: 100%; height: auto; background: #fff; display: block; }
     .settings { display: flex; flex-direction: column; gap: 16px; }
     .settings-section { display:flex; flex-direction:column; gap:10px; }
@@ -51,7 +50,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <svg id="area" preserveAspectRatio="xMidYMid meet" aria-label="Arealmodell"></svg>
       </div>

--- a/base.css
+++ b/base.css
@@ -8,7 +8,7 @@
   --card-border: #e5e7eb;
   --card-radius: 14px;
   --control-radius: 10px;
-  --grid-side-width: 360px;
+  --sidebar-width: 360px;
 }
 
 html,
@@ -36,11 +36,16 @@ body {
   display: grid;
   gap: var(--gap);
   align-items: start;
-  grid-template-columns: minmax(0, 1fr) minmax(0, var(--grid-side-width));
+}
+
+.layout--sidebar {
+  --sidebar-width: 360px;
+  --sidebar-min-width: 0px;
+  grid-template-columns: minmax(0, 1fr) minmax(var(--sidebar-min-width), var(--sidebar-width));
 }
 
 @media (max-width: 980px) {
-  .grid {
+  .layout--sidebar {
     grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -9,8 +9,6 @@
 
 <style>
     :root { --purple:#5B2AA5; --rim:#333; --dash:#000; }
-    .grid { grid-template-columns:1fr 360px; }
-    @media (max-width:980px){ .grid { grid-template-columns:1fr; } }
     input[type="number"], select { width:100%; box-sizing:border-box; }
     fieldset { border:1px solid #e5e7eb; border-radius:10px; padding:10px; margin:0; display:flex; flex-direction:column; gap:8px; }
     .settings { display:flex; gap:var(--gap); }
@@ -114,7 +112,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
 
       <div class="card">
         <div class="grid2">

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -9,7 +9,7 @@
   
 
 <style>
-    :root { --purple:#5B2AA5; --grid-side-width: 360px; }
+    :root { --purple:#5B2AA5; }
     .card p { margin: 0; font-size: 13px; color: #4b5563; line-height: 1.5; }
     .btn:disabled { opacity: .6; cursor: not-allowed; }
     .btn.is-active {
@@ -165,7 +165,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card wallCard">
         <div class="wallToolbar" aria-label="Bytt visning for alle biter">
           <span class="wallToolbar__label">Standardvisning:</span>

--- a/diagram.css
+++ b/diagram.css
@@ -1,4 +1,4 @@
-:root { --grid-side-width: 480px; }
+:root { --sidebar-width: 480px; }
 .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
 .figure svg { width: 100%; height: auto; display: block; background: #fff; }
 .status {

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -17,7 +17,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <h2 id="chartTitle">Favorittidretter i 5B</h2>
         <div class="figure">

--- a/figurtall.html
+++ b/figurtall.html
@@ -9,8 +9,7 @@
   
 
 <style>
-    :root { --card-min:240px; --grid-side-width: clamp(260px,32vw,360px); }
-    .grid{grid-template-columns:minmax(0,1fr) var(--grid-side-width);}
+    :root { --card-min:240px; --sidebar-width: clamp(260px,32vw,360px); }
     .grid2{
       --panel-min:clamp(200px,22vw,260px);
       display:grid;
@@ -128,7 +127,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="figureContainer" class="grid2">
           <button id="addFigure" class="addFigureBtn" type="button" aria-label="Legg til figur">+</button>

--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -10,10 +10,7 @@
   
 
 <style>
-    :root { --grid-side-width: 380px; }
-    @media (max-width: 1000px) {
-      .grid { grid-template-columns: 1fr; }
-    }
+    :root { --sidebar-width: 380px; }
     .card { padding: 16px; gap: 16px; }
     .card h1 {
       margin: 0;
@@ -359,7 +356,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figure">
           <div id="chartExpression" class="chart-expression chart-expression--empty" aria-hidden="true"></div>

--- a/graftegner.html
+++ b/graftegner.html
@@ -13,12 +13,11 @@
   
 
 <style>
-    :root { --grid-side-width: 420px; }
+    :root { --sidebar-width: 420px; }
     html { scroll-behavior: smooth; }
     @media (prefers-reduced-motion: reduce) {
       html { scroll-behavior: auto; }
     }
-    @media (max-width:980px){ .grid{ grid-template-columns:1fr; } }
     .figure{ border-radius:10px; background:#fafbfc; overflow:hidden; border:1px solid #eef0f3; }
     #board{ width:100%; height:560px; background:#fff; }
     .toolbar{ gap:12px; justify-content:flex-start; }
@@ -209,7 +208,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figure">
           <div id="board" aria-label="JSXGraph-tavle"></div>

--- a/kuler.html
+++ b/kuler.html
@@ -9,9 +9,7 @@
   
 
 <style>
-    :root { --grid-side-width: 360px; }
     .wrap{max-width:1400px;}
-    .grid{grid-template-columns:1fr var(--grid-side-width);}
     .figureGrid{
       --figure-columns:1;
       display:grid;
@@ -30,7 +28,6 @@
     .figurePanel .btn{align-self:center;}
     .removeFigureBtn[disabled]{opacity:0.5;cursor:not-allowed;}
     .addFigureBtn{width:clamp(36px,8vw,56px);aspect-ratio:1;border:2px dashed #cfcfcf;border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;font-size:18px;color:#6b7280;cursor:pointer;justify-self:center;align-self:center;}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     @media(max-width:720px){.figureGrid{--figure-columns:1;justify-items:center;}.figurePanel{max-width:100%;}.figure{max-width:100%;}.addFigureBtn{width:clamp(36px,14vw,60px);}}
     .card{gap:10px;}
     .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;width:100%;max-width:680px;margin:0 auto;}
@@ -56,7 +53,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figureGrid">
           <div id="panel1" class="figurePanel">

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -8,7 +8,6 @@
   
 
 <style>
-    :root { --grid-side-width: 360px; }
     .figure-area{
       position:relative;
       width:min(80vmin,100%);
@@ -67,7 +66,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="figureArea" class="figure-area">
           <button id="playBtn" aria-label="Vis numbervisual">▶</button>

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -8,7 +8,6 @@
   
 
 <style>
-    :root { --grid-side-width: 360px; }
     .figure-area{
       position:relative;
       width:min(80vmin,100%);
@@ -97,7 +96,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="figureArea" class="figure-area">
           <button id="playBtn" aria-label="Vis kvikkbilde">▶</button>

--- a/nkant.html
+++ b/nkant.html
@@ -8,7 +8,7 @@
   
 
 <style>
-    :root { --grid-side-width: 480px; }
+    :root { --sidebar-width: 480px; }
     .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
     .figure svg { width: 100%; height: 360px; display: block; }
     .specs-row { display:flex; gap:10px; align-items:flex-start; }
@@ -28,7 +28,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figure">
           <svg id="paper" viewBox="0 0 600 420" preserveAspectRatio="xMidYMid meet" aria-label=""></svg>

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -8,7 +8,7 @@
   
 
 <style>
-    :root { --grid-side-width: 480px; }
+    :root { --sidebar-width: 480px; }
     .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
     .figure svg { width: 100%; height: 360px; display: block; touch-action: none; }
     input[type="number"] { width: 100%; box-sizing: border-box; }
@@ -24,7 +24,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figure">
           <svg id="beadSVG" viewBox="0 0 1400 460" role="img" aria-label="Perlesnor med klype"></svg>

--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -9,7 +9,7 @@
   
 
 <style>
-    :root { --grid-side-width: 420px; }
+    :root { --sidebar-width: 420px; }
     .card { padding: 16px; gap: 12px; }
     .card--board { gap: 16px; }
     .figure {
@@ -360,7 +360,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card card--board">
         <div class="toolbar toolbar--mode">
           <button id="btnToggleMode" class="btn btn--primary" type="button">Gå til oppgavemodus</button>

--- a/tallinje.html
+++ b/tallinje.html
@@ -8,7 +8,7 @@
   
 
 <style>
-    :root { --grid-side-width: 420px; }
+    :root { --sidebar-width: 420px; }
     .figure {
       border-radius: 12px;
       background: #fafbfc;
@@ -22,7 +22,7 @@
     }
     input[type="number"]:disabled { background: #f3f4f6; color: #9ca3af; }
     .field-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
-    @media (max-width: 600px) { .grid { grid-template-columns: 1fr; } .field-grid { grid-template-columns: 1fr; } }
+    @media (max-width: 600px) { .field-grid { grid-template-columns: 1fr; } }
     .hint {
       margin: 4px 2px 0;
       font-size: 12px;
@@ -75,7 +75,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figure">
           <svg id="numberLineSvg" viewBox="0 0 1000 260" preserveAspectRatio="xMidYMid meet" aria-label=""></svg>

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -9,7 +9,6 @@
   
 
 <style>
-    :root { --grid-side-width: 360px; }
     .muted{font-size:13px;color:#6b7280;margin:0;}
 
     #blocks{display:flex;flex-wrap:wrap;justify-content:center;row-gap:20px;column-gap:0;}
@@ -26,7 +25,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="blocks" aria-label="Tenkeblokker"></div>
         <div class="toolbar">

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -12,9 +12,9 @@
     :root {
       --tb-stepper-gap: 0px;
       --tb-stepper-spacing: 6px;
-      --grid-side-width: 420px;
+      --sidebar-width: 420px;
+      --sidebar-min-width: 320px;
     }
-    .grid{grid-template-columns:minmax(0,1fr) minmax(320px,var(--grid-side-width));}
     /* Figur */
     .tb-board{
       position:relative;
@@ -152,7 +152,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="tbBoard" class="tb-board">
           <div id="tbGrid" class="tb-grid" data-cols="1"></div>

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -8,7 +8,7 @@
   
 
 <style>
-    :root { --grid-side-width: 420px; }
+    :root { --sidebar-width: 420px; }
     textarea { width: 100%; }
     .card--settings { gap: 16px; }
     .settings-group { display: grid; gap: 14px; }
@@ -206,7 +206,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="figureGrid" class="figure-grid" data-figures="1">
           <div class="figure" data-figure-index="0">


### PR DESCRIPTION
## Summary
- add a reusable `.layout--sidebar` helper with configurable width variables to `base.css`
- switch sidebar apps to use the shared layout class and per-page `--sidebar-width` overrides instead of bespoke grid media queries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2400051908324861fc6cf6748566b