### PR TITLE
Ensure legacy examples survive backend sync and align 404 padding

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,7 +17,7 @@
       display: grid;
       place-items: center;
       min-height: 100vh;
-      padding: 32px;
+      padding: 20px;
       text-align: center;
     }
     main {

--- a/examples.js
+++ b/examples.js
@@ -811,9 +811,13 @@
     applyingBackendUpdate = true;
     try {
       const examples = data && Array.isArray(data.examples) ? data.examples : [];
-      store(examples, {
-        reason: 'backend-sync'
-      });
+      const localExamples = getExamples();
+      const hasLocalExamples = Array.isArray(localExamples) && localExamples.length > 0;
+      if (examples.length > 0 || !hasLocalExamples) {
+        store(examples, {
+          reason: 'backend-sync'
+        });
+      }
       const deletedProvided = data && Array.isArray(data.deletedProvided) ? data.deletedProvided : [];
       deletedProvidedExamples = new Set();
       deletedProvided.forEach(value => {


### PR DESCRIPTION
## Summary
- avoid replacing locally migrated examples when the backend responds with no examples
- align the 404 page body padding with the shared base layout spacing

## Testing
- npx playwright test tests/examples-legacy-keys.spec.js --project=chromium --grep Graftegner --reporter=list *(fails: missing Playwright browser dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2478cf90c832486ceb3d98102a2d7