### PR TITLE
Remove polygon side count label

### DIFF
--- a/nkant.js
+++ b/nkant.js
@@ -1988,10 +1988,8 @@ function drawRegularPolygonToGroup(g, rect, spec) {
     const Q = pts[(bestIdx + 1) % count];
     sideLabelText(g, P, Q, sideText, true, ctr, 18);
   }
-  addHaloText(g, ctr.x, ctr.y, `n=${count}`, STYLE.angFS, {
-    "text-anchor": "middle",
-    "dominant-baseline": "middle"
-  });
+  // Previously the number of sides was annotated in the centre of the polygon
+  // (e.g. "n=10"). This visual label is no longer desired, so we omit it.
 }
 
 /* ---------- ORKESTRERING ---------- */


### PR DESCRIPTION
## Summary
- remove the centre annotation that displayed the polygon side count

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e24920eba48324b39b8ed2e14bdb4f