### PR TITLE
Align graph point controls on graftegner

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -127,17 +127,32 @@
     .func-fields--first .func-row label{ width:100%; }
     .func-row--gliders label{ justify-self:start; }
     .func-row--gliders{
-      display:grid;
+      display:flex;
+      flex-wrap:wrap;
       gap:12px;
-      grid-template-columns:repeat(3,minmax(120px,1fr));
-      align-items:end;
+      align-items:flex-end;
+    }
+    .func-row--gliders label.points{
+      flex:1 1 120px;
+      max-width:220px;
     }
     .func-row--gliders .linepoints-row{
-      display:contents;
+      display:flex;
+      flex:2 1 260px;
+      gap:12px;
+      flex-wrap:wrap;
+      align-items:flex-end;
     }
-    .func-row--gliders label.points,
+    .func-row--gliders .linepoints-row label.linepoint{
+      flex:1 1 120px;
+      max-width:100%;
+    }
     .func-row--gliders label.linepoint{
       max-width:100%;
+    }
+    .func-row--gliders label.startx-label{
+      flex-basis:100%;
+      max-width:180px;
     }
     .func-row--gliders label.points select{
       width:100%;


### PR DESCRIPTION
## Summary
- arrange the point selectors in Graftegner so they share a row when there is space while still wrapping on small screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e249fd22448324b2f76244d31fee1f