### PR TITLE
Prevent polygon parsing from hijacking triangle prompts

### DIFF
--- a/nkant.js
+++ b/nkant.js
@@ -1060,6 +1060,10 @@ function detectPolygonSidesFromText(str) {
 }
 function parsePolygonSpecLine(str) {
   if (!str) return null;
+  const lower = str.toLowerCase();
+  if (/\btrekant/i.test(lower) || /\btriangel/i.test(lower)) {
+    return null;
+  }
   const sidesFromWord = detectPolygonSidesFromText(str);
   const hasKeyword = /mangekant/i.test(str);
   if (!hasKeyword && sidesFromWord == null) return null;


### PR DESCRIPTION
## Summary
- stop the regular polygon parser from triggering when the prompt mentions triangles so the triangle-specific logic can run instead

## Testing
- No tests were run (not requested).


------
https://chatgpt.com/codex/tasks/task_e_68e24b2e0c5483248762dd8523528ca8