### PR TITLE
Add unlock toggle to pan the tallinje number line

### DIFF
--- a/tallinje.html
+++ b/tallinje.html
@@ -16,6 +16,8 @@
       border: 1px solid #eef0f3;
     }
     .figure svg { width: 100%; height: 320px; display: block; }
+    .figure svg.is-draggable { cursor: grab; touch-action: none; }
+    .figure svg.is-draggable.is-dragging { cursor: grabbing; }
     input[type="number"], select {
       width: 100%;
       box-sizing: border-box;
@@ -133,6 +135,10 @@
           <label class="checkbox-field">
             <input id="cfg-clampLine" type="checkbox" />
             Stopp tallinjen ved start- og sluttpunktet
+          </label>
+          <label class="checkbox-field">
+            <input id="cfg-lockLine" type="checkbox" />
+            Lås tallinje
           </label>
         </div>
 


### PR DESCRIPTION
## Summary
- add a new "Lås tallinje" checkbox and styling that signals when the axis can be dragged
- implement pointer-based panning so the number line can be shifted while unlocked and keep state in sync
- include the lock state in default example configurations for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2b4bc0d6c832489f8fbbc94b32e4b