### PR TITLE
Hide pie-inapplicable settings

### DIFF
--- a/diagram.js
+++ b/diagram.js
@@ -259,6 +259,22 @@ function setRowVisibility(row, visible) {
 function updateSettingsVisibilityForType(type) {
   const showAxisSettings = type !== 'pie';
   setRowVisibility(axisAndRangeRow, showAxisSettings);
+  const lockedField = document.getElementById('cfgLocked');
+  const snapField = document.getElementById('cfgSnap');
+  const toleranceField = document.getElementById('cfgTolerance');
+  const answerField = document.getElementById('cfgAnswer');
+  const answerField2 = document.getElementById('cfgAnswer2');
+  const lockedLabel = lockedField ? lockedField.closest('label') : null;
+  const snapLabel = snapField ? snapField.closest('label') : null;
+  const toleranceLabel = toleranceField ? toleranceField.closest('label') : null;
+  const answerLabel = answerField ? answerField.closest('label') : null;
+  const answerLabel2 = answerField2 ? answerField2.closest('label') : null;
+  const showCommonSettings = type !== 'pie';
+  setRowVisibility(lockedLabel, showCommonSettings);
+  setRowVisibility(snapLabel, showCommonSettings);
+  setRowVisibility(toleranceLabel, showCommonSettings);
+  setRowVisibility(answerLabel, showCommonSettings);
+  setRowVisibility(answerLabel2, showCommonSettings);
 }
 // skalaer
 let xBand = 0;


### PR DESCRIPTION
## Summary
- hide locked handles, snap, tolerance, and answer value inputs when pie charts are selected
- ensure axis settings remain hidden for pie charts while other types keep full controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b850068c83249ddf8fb7c0494d6c