### PR TITLE
Add mixed and improper fraction options to number line

### DIFF
--- a/tallinje.html
+++ b/tallinje.html
@@ -120,7 +120,8 @@
               <select id="cfg-numberType">
                 <option value="integer">Heltall</option>
                 <option value="decimal">Desimaltall</option>
-                <option value="fraction">Brøk</option>
+                <option value="mixedFraction">Blandete tall</option>
+                <option value="improperFraction">Uekte brøk</option>
               </select>
             </label>
             <label>Antall desimaler


### PR DESCRIPTION
## Summary
- add UI support for choosing mixed or improper fraction labels on the number line
- render the selected fraction format with KaTeX and update alt-text reporting
- include an additional default example that demonstrates improper fraction labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2c3d1c82483248325ab7a17c363b9