### PR TITLE
Force locking number line when clamped to range

### DIFF
--- a/tallinje.js
+++ b/tallinje.js
@@ -109,6 +109,9 @@
     STATE.clampToRange = Boolean(STATE.clampToRange);
     const lockValue = STATE.lockLine;
     STATE.lockLine = !(lockValue === false || lockValue === 'false' || lockValue === 0);
+    if (STATE.clampToRange) {
+      STATE.lockLine = true;
+    }
     if (typeof STATE.altText !== 'string') STATE.altText = '';
     STATE.altTextSource = STATE.altTextSource === 'manual' ? 'manual' : 'auto';
 
@@ -362,7 +365,10 @@
     }
     if (labelFontSizeInput) labelFontSizeInput.value = String(STATE.labelFontSize);
     if (clampLineInput) clampLineInput.checked = Boolean(STATE.clampToRange);
-    if (lockLineInput) lockLineInput.checked = Boolean(STATE.lockLine);
+    if (lockLineInput) {
+      lockLineInput.checked = Boolean(STATE.lockLine);
+      lockLineInput.disabled = Boolean(STATE.clampToRange);
+    }
     if (svg) {
       const isLocked = Boolean(STATE.lockLine);
       svg.classList.toggle('is-draggable', !isLocked);
@@ -962,6 +968,10 @@
   if (clampLineInput) {
     clampLineInput.addEventListener('change', () => {
       STATE.clampToRange = clampLineInput.checked;
+      if (STATE.clampToRange) {
+        if (!STATE.lockLine) stopActiveDrag();
+        STATE.lockLine = true;
+      }
       render();
     });
   }


### PR DESCRIPTION
## Summary
- ensure the number line locks automatically when it is clamped to its start and end points
- disable the lock toggle UI while the number line is clamped and stop any active drags when enabling the clamp

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2c5954b0883248939dd738b1a973a