### PR TITLE
Add zoom and pan controls to graph settings

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -281,19 +281,27 @@
                       </td>
                       <td>
                         <label class="checkbox-inline">
-                          <input id="cfgPan" type="checkbox">
-                          <span>Tillat panorering</span>
+                          <input id="cfgZoom" type="checkbox" checked>
+                          <span>Tillat zoom</span>
                         </label>
                       </td>
                     </tr>
                     <tr>
                       <td>
                         <label class="checkbox-inline">
+                          <input id="cfgPan" type="checkbox">
+                          <span>Flytt koordinatsystem</span>
+                        </label>
+                      </td>
+                      <td>
+                        <label class="checkbox-inline">
                           <input id="cfgLock" type="checkbox" checked>
                           <span>Lås aksene 1:1</span>
                         </label>
                       </td>
-                      <td>
+                    </tr>
+                    <tr>
+                      <td colspan="2">
                         <label class="checkbox-inline">
                           <input id="cfgSnap" type="checkbox" checked>
                           <span>Fest punkter til rutenett</span>

--- a/graftegner.js
+++ b/graftegner.js
@@ -158,7 +158,7 @@ const ADV = {
       needShift: false
     },
     zoom: {
-      enabled: true,
+      enabled: params.has('zoom') ? paramBool('zoom') : true,
       wheel: true,
       needShift: false,
       factorX: 1.2,
@@ -4036,7 +4036,8 @@ function setupSettingsForm() {
   g('cfgLock').checked = params.has('lock') ? paramBool('lock') : true;
   g('cfgAxisX').value = paramStr('xName', 'x');
   g('cfgAxisY').value = paramStr('yName', 'y');
-  g('cfgPan').checked = paramBool('pan');
+  g('cfgZoom').checked = ADV.interactions.zoom.enabled;
+  g('cfgPan').checked = ADV.interactions.pan.enabled;
   g('cfgQ1').checked = paramBool('q1');
   if (showNamesInput) {
     showNamesInput.checked = !!ADV.curveName.showName;
@@ -4089,6 +4090,12 @@ function setupSettingsForm() {
     }
     if ((ADV.axis.labels.y || '') !== axisYValue) {
       ADV.axis.labels.y = axisYValue;
+      needsRebuild = true;
+    }
+    const zoomInput = g('cfgZoom');
+    const zoomChecked = !!(zoomInput && zoomInput.checked);
+    if (ADV.interactions.zoom.enabled !== zoomChecked) {
+      ADV.interactions.zoom.enabled = zoomChecked;
       needsRebuild = true;
     }
     const panInput = g('cfgPan');
@@ -4176,6 +4183,9 @@ function setupSettingsForm() {
     if (lockChecked) p.set('lock', '1');else p.set('lock', '0');
     if (axisXValue && axisXValue !== 'x') p.set('xName', axisXValue);
     if (axisYValue && axisYValue !== 'y') p.set('yName', axisYValue);
+    if (zoomInput) {
+      p.set('zoom', zoomChecked ? '1' : '0');
+    }
     if (panChecked) p.set('pan', '1');
     if (showNamesInput) {
       p.set('showNames', showNamesChecked ? '1' : '0');


### PR DESCRIPTION
## Summary
- add a checkbox for enabling zoom in the Graftegner settings panel
- rename the pan option to "Flytt koordinatsystem" and keep it with the true/false options
- persist the zoom preference through the settings form and URL parameters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2c7cab72483249afddfd23ab89250