### PR TITLE
Ensure fortegnsskjema scripts load after KaTeX

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -453,9 +453,9 @@
   </div>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/mathlive/dist/mathlive.min.js"></script>
-  <script src="alt-text-ui.js"></script>
-  <script src="fortegnsskjema.js"></script>
-  <script src="split.js"></script>
-  <script src="examples.js"></script>
+  <script defer src="alt-text-ui.js"></script>
+  <script defer src="fortegnsskjema.js"></script>
+  <script defer src="split.js"></script>
+  <script defer src="examples.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- defer local fortegnsskjema scripts so they run after KaTeX and MathLive
- ensure the initial expression display renders with KaTeX on page load

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2e25146d4832499054e0f00d16c06