### PR TITLE
Reorder brøkpizza settings and disable denominator visibility toggle

### DIFF
--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -14,6 +14,7 @@
     .settings fieldset { flex:1; }
     legend { font-weight:600; font-size:13px; color:#374151; padding:0 4px; }
     .checkbox-row { display:flex; align-items:center; gap:6px; }
+    .checkbox-row--disabled { opacity:0.5; }
     .field-row { display:flex; gap:10px; flex-wrap:wrap; }
     .field-row .field { flex:1 1 140px; display:flex; flex-direction:column; gap:4px; }
     .input-stack { display:flex; flex-direction:column; gap:4px; }
@@ -206,9 +207,6 @@
                 <input id="p1N" type="number" value="10" min="1">
               </div>
             </div>
-            <div class="checkbox-row"><input id="p1LockN" type="checkbox"><label for="p1LockN">Mulighet for å endre nevner</label></div>
-            <div class="checkbox-row"><input id="p1HideNVal" type="checkbox"><label for="p1HideNVal">Vis verdien til nevner</label></div>
-            <div class="checkbox-row"><input id="p1LockT" type="checkbox"><label for="p1LockT">Mulighet for å endre teller</label></div>
             <label for="p1Text">Vis tekst over brøkpizza som:</label>
             <select id="p1Text">
               <option value="none" selected>Ingen tekst</option>
@@ -216,6 +214,9 @@
               <option value="decimal">Desimaltall</option>
               <option value="percent">prosent</option>
             </select>
+            <div class="checkbox-row"><input id="p1LockT" type="checkbox"><label for="p1LockT">Mulighet for å endre teller</label></div>
+            <div class="checkbox-row"><input id="p1LockN" type="checkbox"><label for="p1LockN">Mulighet for å endre nevner</label></div>
+            <div class="checkbox-row" data-denominator-visibility><input id="p1HideNVal" type="checkbox"><label for="p1HideNVal">Vis verdien til nevner</label></div>
             <div class="field-row">
               <div class="field">
                 <label for="p1MinN">Min n</label>
@@ -249,9 +250,6 @@
                 <input id="p2N" type="number" value="10" min="1">
               </div>
             </div>
-            <div class="checkbox-row"><input id="p2LockN" type="checkbox"><label for="p2LockN">Mulighet for å endre nevner</label></div>
-            <div class="checkbox-row"><input id="p2HideNVal" type="checkbox"><label for="p2HideNVal">Vis verdien til nevner</label></div>
-            <div class="checkbox-row"><input id="p2LockT" type="checkbox"><label for="p2LockT">Mulighet for å endre teller</label></div>
             <label for="p2Text">Vis tekst over brøkpizza som:</label>
             <select id="p2Text">
               <option value="none" selected>Ingen tekst</option>
@@ -259,6 +257,9 @@
               <option value="decimal">Desimaltall</option>
               <option value="percent">prosent</option>
             </select>
+            <div class="checkbox-row"><input id="p2LockT" type="checkbox"><label for="p2LockT">Mulighet for å endre teller</label></div>
+            <div class="checkbox-row"><input id="p2LockN" type="checkbox"><label for="p2LockN">Mulighet for å endre nevner</label></div>
+            <div class="checkbox-row" data-denominator-visibility><input id="p2HideNVal" type="checkbox"><label for="p2HideNVal">Vis verdien til nevner</label></div>
             <div class="field-row">
               <div class="field">
                 <label for="p2MinN">Min n</label>
@@ -292,9 +293,6 @@
                 <input id="p3N" type="number" value="10" min="1">
               </div>
             </div>
-            <div class="checkbox-row"><input id="p3LockN" type="checkbox"><label for="p3LockN">Mulighet for å endre nevner</label></div>
-            <div class="checkbox-row"><input id="p3HideNVal" type="checkbox"><label for="p3HideNVal">Vis verdien til nevner</label></div>
-            <div class="checkbox-row"><input id="p3LockT" type="checkbox"><label for="p3LockT">Mulighet for å endre teller</label></div>
             <label for="p3Text">Vis tekst over brøkpizza som:</label>
             <select id="p3Text">
               <option value="none" selected>Ingen tekst</option>
@@ -302,6 +300,9 @@
               <option value="decimal">Desimaltall</option>
               <option value="percent">prosent</option>
             </select>
+            <div class="checkbox-row"><input id="p3LockT" type="checkbox"><label for="p3LockT">Mulighet for å endre teller</label></div>
+            <div class="checkbox-row"><input id="p3LockN" type="checkbox"><label for="p3LockN">Mulighet for å endre nevner</label></div>
+            <div class="checkbox-row" data-denominator-visibility><input id="p3HideNVal" type="checkbox"><label for="p3HideNVal">Vis verdien til nevner</label></div>
             <div class="field-row">
               <div class="field">
                 <label for="p3MinN">Min n</label>

--- a/brøkpizza.js
+++ b/brøkpizza.js
@@ -1325,6 +1325,7 @@ function initFromHtml() {
   const cfg = readConfigFromHtml();
   SIMPLE.pizzas = cfg.pizzas;
   SIMPLE.ops = cfg.ops;
+  updateDenominatorValueToggles();
   let visibleCount = 0;
   REG.clear();
   PIZZA_DOM.forEach((map, i) => {
@@ -1370,6 +1371,7 @@ function initFromHtml() {
       displayEl.style.display = "none";
     }
   });
+  updateDenominatorValueToggles();
   scheduleCenterAlign();
   fitPizzasToLine();
   setupRemovePizzaButtons();
@@ -1406,6 +1408,17 @@ window.addEventListener("load", () => {
     el.addEventListener("change", initFromHtml);
   });
 });
+
+function updateDenominatorValueToggles() {
+  for (let i = 1; i <= 3; i++) {
+    const canChangeCheckbox = document.getElementById(`p${i}LockN`);
+    const showValueCheckbox = document.getElementById(`p${i}HideNVal`);
+    const row = showValueCheckbox === null || showValueCheckbox === void 0 ? void 0 : showValueCheckbox.closest('[data-denominator-visibility]');
+    const canChange = !!(canChangeCheckbox && canChangeCheckbox.checked);
+    if (showValueCheckbox) showValueCheckbox.disabled = !canChange;
+    if (row) row.classList.toggle('checkbox-row--disabled', !canChange);
+  }
+}
 function applySimpleConfigToInputs() {
   const pizzas = Array.isArray(SIMPLE.pizzas) ? SIMPLE.pizzas : [];
   const ops = Array.isArray(SIMPLE.ops) ? SIMPLE.ops : [];
@@ -1470,6 +1483,7 @@ function applySimpleConfigToInputs() {
     const textSel = document.getElementById(`p${i}Text`);
     if (textSel && cfg.text) textSel.value = cfg.text;
   }
+  updateDenominatorValueToggles();
   ops.forEach((op, idx) => {
     const wrapper = document.getElementById(`op${idx + 1}Wrapper`);
     const selectId = `op${idx + 1}`;


### PR DESCRIPTION
## Summary
- reorder the brøkpizza settings to show the text selector first followed by the requested checkbox order
- disable the "Vis verdien til nevner" checkbox when the denominator cannot be edited and style the disabled state

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e365049390832495b4e3bbe01af0fc