### PR TITLE
Fix polygon outline corners in brøkfigurer

### DIFF
--- a/brøkfigurer.js
+++ b/brøkfigurer.js
@@ -797,8 +797,13 @@
       if (!polygon || !Array.isArray(polygon.borders)) return;
       for (const border of polygon.borders) {
         if (!border) continue;
-        markDivisionNode(border.rendNode);
-        if (border.rendNodeFront && border.rendNodeFront !== border.rendNode) markDivisionNode(border.rendNodeFront);
+        const nodes = [border.rendNode, border.rendNodeFront && border.rendNodeFront !== border.rendNode ? border.rendNodeFront : null];
+        for (const node of nodes) {
+          if (!node) continue;
+          node.setAttribute('stroke-linecap', 'butt');
+          node.setAttribute('stroke-linejoin', 'miter');
+          markDivisionNode(node);
+        }
       }
     }
     function createDivisionSegment(start, end, options = {}, extend = true) {


### PR DESCRIPTION
## Summary
- ensure fraction figure outline borders use butt linecaps and miter linejoins so corners render sharply
- continue tagging border render nodes for division handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e36eda97a8832498ad0cfc8d43df14