### PR TITLE
Add theme profile helper and dynamic palette integration

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -11,7 +11,7 @@
   
 
 <style>
-    :root { --purple:#5B2AA5; --rim:#333; --dash:#000; --grid-side-width: 420px; }
+    :root { --grid-side-width: 420px; }
     body{ display:flex; flex-direction:column; }
     .wrap{
       flex:1;
@@ -182,12 +182,12 @@
               <input id="colorCount" class="input--digit" type="number" min="1" max="6" value="1" />
             </label>
             <div class="colors">
-              <input id="color_1" type="color" value="#6C1BA2" />
-              <input id="color_2" type="color" value="#534477" />
-              <input id="color_3" type="color" value="#BF4474" />
-              <input id="color_4" type="color" value="#B25FE3" />
-              <input id="color_5" type="color" value="#873E79" />
-              <input id="color_6" type="color" value="#E31C3D" />
+              <input id="color_1" type="color" />
+              <input id="color_2" type="color" />
+              <input id="color_3" type="color" />
+              <input id="color_4" type="color" />
+              <input id="color_5" type="color" />
+              <input id="color_6" type="color" />
             </div>
           </fieldset>
           <div id="figureSettings" class="figureSettings"></div>
@@ -202,6 +202,7 @@
       </div>
     </div>
   </div>
+  <script src="theme-profiles.js"></script>
   <script src="brøkfigurer.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>

--- a/brøkfigurer.js
+++ b/brøkfigurer.js
@@ -124,6 +124,40 @@
     if (!inp) break;
     colorInputs.push(inp);
   }
+  const LEGACY_COLOR_PALETTE = ['#B25FE3', '#6C1BA2', '#534477', '#873E79', '#BF4474', '#E31C3D'];
+  function getThemeApi() {
+    const theme = typeof window !== 'undefined' ? window.MathVisualsTheme : null;
+    return theme && typeof theme === 'object' ? theme : null;
+  }
+  function applyThemeToDocument() {
+    const theme = getThemeApi();
+    if (theme && typeof theme.applyToDocument === 'function') {
+      theme.applyToDocument(document);
+    }
+  }
+  applyThemeToDocument();
+  function getPaletteFromTheme(count) {
+    const theme = getThemeApi();
+    let palette = null;
+    if (theme && typeof theme.getPalette === 'function') {
+      palette = theme.getPalette('fractions', count, { fallbackKinds: ['figures'] });
+    }
+    const target = Number.isFinite(count) && count > 0 ? Math.trunc(count) : 0;
+    const base = Array.isArray(palette) && palette.length ? palette.slice() : LEGACY_COLOR_PALETTE.slice();
+    if (target <= 0) return base.slice();
+    if (base.length >= target) return base.slice(0, target);
+    const result = base.slice();
+    for (let i = base.length; i < target; i++) {
+      result.push(base[i % base.length]);
+    }
+    return result;
+  }
+  function getDefaultColorForIndex(index) {
+    if (!Number.isFinite(index) || index < 0) return LEGACY_COLOR_PALETTE[0];
+    const palette = getPaletteFromTheme(index + 1);
+    if (Array.isArray(palette) && palette[index]) return palette[index];
+    return LEGACY_COLOR_PALETTE[index % LEGACY_COLOR_PALETTE.length];
+  }
   const boardEl = document.getElementById('figureBoard');
   const gridEl = document.getElementById('figureGrid');
   const addColumnBtn = document.getElementById('figAddColumn');
@@ -148,7 +182,6 @@
     });
   }
   let autoPaletteEnabled = modifiedColorIndexes.size === 0;
-  let lastAppliedPaletteSize = null;
   if (!STATE.figures || typeof STATE.figures !== 'object') STATE.figures = {};
   let allowWrongGlobal;
   if (typeof STATE.allowWrong === 'boolean') {
@@ -266,48 +299,25 @@
       window.render();
     });
   }
-  const DEFAULT_COLOR_SETS = {
-    1: ['#6C1BA2'],
-    2: ['#BF4474', '#534477'],
-    3: ['#B25FE3', '#6C1BA2', '#BF4474'],
-    4: ['#B25FE3', '#6C1BA2', '#534477', '#BF4474'],
-    5: ['#B25FE3', '#6C1BA2', '#534477', '#873E79', '#BF4474'],
-    6: ['#B25FE3', '#6C1BA2', '#534477', '#873E79', '#BF4474', '#E31C3D']
-  };
   function ensureColorDefaults(count) {
-    const palette = DEFAULT_COLOR_SETS[count] || DEFAULT_COLOR_SETS[maxColors] || ['#6C1BA2'];
-    const fillPalette = DEFAULT_COLOR_SETS[maxColors] || palette;
-    if (autoPaletteEnabled) {
-      if (lastAppliedPaletteSize !== count || !Array.isArray(STATE.colors)) {
-        STATE.colors = palette.slice();
-      }
-    } else if (!Array.isArray(STATE.colors)) {
-      STATE.colors = [];
-    }
-    if (!Array.isArray(STATE.colors)) STATE.colors = [];
     const required = Math.max(count, maxColors);
+    const palette = getPaletteFromTheme(required);
+    if (!Array.isArray(STATE.colors)) STATE.colors = [];
+    if (autoPaletteEnabled) {
+      STATE.colors = palette.slice(0, required);
+    }
     for (let i = 0; i < required; i++) {
-      const withinCount = i < count;
-      const source = withinCount ? palette : fillPalette;
-      let defaultColor = '#6C1BA2';
-      if (Array.isArray(source) && source.length > 0) {
-        var _source$Math$min;
-        defaultColor = (_source$Math$min = source[Math.min(i, source.length - 1)]) !== null && _source$Math$min !== void 0 ? _source$Math$min : '#6C1BA2';
-      } else if (Array.isArray(palette) && palette.length > 0) {
-        var _palette$Math$min;
-        defaultColor = (_palette$Math$min = palette[Math.min(withinCount ? i : palette.length - 1, palette.length - 1)]) !== null && _palette$Math$min !== void 0 ? _palette$Math$min : '#6C1BA2';
-      }
+      const defaultColor = palette[i] || getDefaultColorForIndex(i);
       const hasColor = typeof STATE.colors[i] === 'string' && STATE.colors[i];
       const shouldUseDefault = autoPaletteEnabled || !modifiedColorIndexes.has(i);
       if (shouldUseDefault || !hasColor) {
-        STATE.colors[i] = defaultColor || '#6C1BA2';
+        STATE.colors[i] = defaultColor;
       }
       if (typeof STATE.colors[i] !== 'string' || !STATE.colors[i]) {
-        STATE.colors[i] = '#6C1BA2';
+        STATE.colors[i] = defaultColor || LEGACY_COLOR_PALETTE[i % LEGACY_COLOR_PALETTE.length];
       }
     }
     if (STATE.colors.length > required) STATE.colors.length = required;
-    lastAppliedPaletteSize = count;
   }
   function getColors() {
     ensureColorDefaults(colorCount);
@@ -1608,5 +1618,15 @@
     }
     (_window$render4 = (_window4 = window).render) === null || _window$render4 === void 0 || _window$render4.call(_window4);
   });
+  function handleThemeProfileChange(event) {
+    const data = event && event.data;
+    const type = typeof data === 'string' ? data : data && data.type;
+    if (type !== 'math-visuals:profile-change') return;
+    applyThemeToDocument();
+    if (typeof window.render === 'function') window.render();
+  }
+  if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    window.addEventListener('message', handleThemeProfileChange);
+  }
   window.render();
 })();

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -7,7 +7,13 @@
   <link rel="stylesheet" href="base.css" />
 
 <style>
-    :root { --purple:#5B2AA5; --rim:#333; --dash:#000; }
+    :root {
+      --pizza-fill:#5B2AA5;
+      --pizza-rim:#333333;
+      --pizza-dash:#000000;
+      --pizza-handle:#e9e6f7;
+      --pizza-handle-stroke:var(--pizza-rim, #333333);
+    }
     input[type="number"], select { width:100%; box-sizing:border-box; }
     fieldset { border:1px solid #e5e7eb; border-radius:10px; padding:10px; margin:0; display:flex; flex-direction:column; gap:8px; }
     .settings { display:flex; gap:var(--gap); }
@@ -90,12 +96,12 @@
     .frac .num { display:block; border-bottom:2px solid #000; margin-bottom:4px; }
     .frac .den { display:block; }
     svg.pizza { width:100%; max-width:420px; height:auto; background:#fff; }
-    .rim { fill:none; stroke:var(--rim); stroke-width:6; }
+    .rim { fill:none; stroke:var(--pizza-rim, #333333); stroke-width:6; }
     .sector { stroke:#fff; stroke-width:6; }
-    .sector-fill  { fill:var(--purple); }
+    .sector-fill  { fill:var(--pizza-fill, #5B2AA5); }
     .sector-empty { fill:#fff; }
-    .dash { stroke:var(--dash); stroke-dasharray:4 4; stroke-width:2; }
-    .handle { fill:#e9e6f7; stroke:#333; stroke-width:2; cursor:pointer; }
+    .dash { stroke:var(--pizza-dash, #000000); stroke-dasharray:4 4; stroke-width:2; }
+    .handle { fill:var(--pizza-handle, #e9e6f7); stroke:var(--pizza-handle-stroke, var(--pizza-rim, #333333)); stroke-width:2; cursor:pointer; }
     .stepper {
       display:flex; align-items:center; gap:12px;
       padding:6px 10px; border:1px solid #cfcfcf; border-radius:12px;
@@ -330,6 +336,7 @@
     </div>
     </div>
 
+    <script src="theme-profiles.js"></script>
     <script src="alt-text-ui.js"></script>
     <script src="brøkpizza.js"></script>
   <script src="examples.js"></script>

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -8,7 +8,6 @@
   
 
 <style>
-    :root { --purple:#5B2AA5; }
     .card p { margin: 0; font-size: 13px; color: #4b5563; line-height: 1.5; }
     .btn:disabled { opacity: .6; cursor: not-allowed; }
     .btn.is-active {
@@ -235,6 +234,7 @@
     </div>
   </div>
 
+  <script src="theme-profiles.js"></script>
   <script src="alt-text-ui.js"></script>
   <script src="brøkvegg.js"></script>
   <script src="examples.js"></script>

--- a/figurtall.html
+++ b/figurtall.html
@@ -227,12 +227,12 @@
               <input id="colorCount" class="input--digit" type="number" min="1" max="6" value="1" />
             </label>
             <div class="colors">
-              <input id="color_1" type="color" value="#6C1BA2" />
-              <input id="color_2" type="color" value="#534477" />
-              <input id="color_3" type="color" value="#BF4474" />
-              <input id="color_4" type="color" value="#B25FE3" />
-              <input id="color_5" type="color" value="#873E79" />
-              <input id="color_6" type="color" value="#E31C3D" />
+              <input id="color_1" type="color" />
+              <input id="color_2" type="color" />
+              <input id="color_3" type="color" />
+              <input id="color_4" type="color" />
+              <input id="color_5" type="color" />
+              <input id="color_6" type="color" />
             </div>
           </fieldset>
           <div class="toolbar">
@@ -249,6 +249,7 @@
       </div>
     </div>
   </div>
+  <script src="theme-profiles.js"></script>
   <script src="alt-text-ui.js"></script>
   <script src="figurtall.js"></script>
   <script src="examples.js"></script>

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -52,8 +52,8 @@
       height:160px;
       border-radius:50%;
       border:none;
-      background:#10b981;
-      color:#fff;
+      background:var(--play-button, #10b981);
+      color:var(--play-button-text, #fff);
       font-size:64px;
       display:flex;
       align-items:center;
@@ -61,6 +61,7 @@
       cursor:pointer;
       box-shadow:0 2px 8px rgba(0,0,0,.15);
     }
+    #playBtn:hover{background:var(--play-button-hover, #059669);}
   </style>
   <link rel="stylesheet" href="split.css" />
 </head>
@@ -128,6 +129,7 @@
       </div>
     </div>
   </div>
+  <script src="theme-profiles.js"></script>
   <script src="kvikkbilder-monster.js"></script>
   <script src="split.js"></script>
   <script src="examples.js"></script>

--- a/kvikkbilder-monster.js
+++ b/kvikkbilder-monster.js
@@ -13,6 +13,26 @@
   const expression = document.getElementById('expression');
   const btnSvg = document.getElementById('btnSvg');
   const btnPng = document.getElementById('btnPng');
+  const DOT_FALLBACK = '#534477';
+  function getThemeApi() {
+    const theme = typeof window !== 'undefined' ? window.MathVisualsTheme : null;
+    return theme && typeof theme === 'object' ? theme : null;
+  }
+  function applyThemeToDocument() {
+    const theme = getThemeApi();
+    if (theme && typeof theme.applyToDocument === 'function') {
+      theme.applyToDocument(document);
+    }
+  }
+  function getDotColor() {
+    const theme = getThemeApi();
+    if (theme && typeof theme.getColor === 'function') {
+      const color = theme.getColor('dots.default', DOT_FALLBACK);
+      if (typeof color === 'string' && color) return color;
+    }
+    return DOT_FALLBACK;
+  }
+  applyThemeToDocument();
   const MONSTER_POINT_RADIUS_MIN = 1;
   const MONSTER_POINT_RADIUS_MAX = 60;
   const DEFAULT_CIRCLE_RADIUS = 10;
@@ -235,7 +255,7 @@
       c.setAttribute('cx', x + offsetX);
       c.setAttribute('cy', y + offsetY);
       c.setAttribute('r', radius);
-      c.setAttribute('fill', '#534477');
+      c.setAttribute('fill', getDotColor());
       svg.appendChild(c);
     });
     return svg;
@@ -359,6 +379,17 @@
   updateVisibility();
   render();
   applyExpressionVisibility();
+  function handleThemeProfileChange(event) {
+    const data = event && event.data;
+    const type = typeof data === 'string' ? data : data && data.type;
+    if (type !== 'math-visuals:profile-change') return;
+    applyThemeToDocument();
+    render();
+    applyExpressionVisibility();
+  }
+  if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    window.addEventListener('message', handleThemeProfileChange);
+  }
   function svgToString(svgEl) {
     const clone = svgEl.cloneNode(true);
     const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -84,12 +84,15 @@
       height:160px;
       border:none;
       border-radius:50%;
-      background:#10b981;
-      color:#fff;
+      background:var(--play-button, #10b981);
+      color:var(--play-button-text, #fff);
       display:flex;
       align-items:center;
       justify-content:center;
       box-shadow:0 2px 8px rgba(0,0,0,.15);
+    }
+    #playBtn:hover{
+      background:var(--play-button-hover, #059669);
     }
   </style>
   <link rel="stylesheet" href="split.css" />
@@ -232,6 +235,7 @@
       </div>
     </div>
   </div>
+  <script src="theme-profiles.js"></script>
   <script src="alt-text-ui.js"></script>
   <script src="kvikkbilder.js"></script>
   <script src="split.js"></script>

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -33,6 +33,32 @@
   const btnPng = document.getElementById('btnPng');
   const cfgAntallWrapper = document.getElementById('cfg-antall-wrapper');
   const exportCard = document.getElementById('exportCard');
+  const DOT_FALLBACKS = {
+    default: '#534477',
+    monster: '#534477',
+    rectangles: '#534477',
+    klosser: '#534477'
+  };
+  function getThemeApi() {
+    const theme = typeof window !== 'undefined' ? window.MathVisualsTheme : null;
+    return theme && typeof theme === 'object' ? theme : null;
+  }
+  function applyThemeToDocument() {
+    const theme = getThemeApi();
+    if (theme && typeof theme.applyToDocument === 'function') {
+      theme.applyToDocument(document);
+    }
+  }
+  function getDotColor(kind) {
+    const fallback = DOT_FALLBACKS[kind] || DOT_FALLBACKS.default;
+    const theme = getThemeApi();
+    if (theme && typeof theme.getColor === 'function') {
+      const color = theme.getColor('dots.default', fallback);
+      if (typeof color === 'string' && color) return color;
+    }
+    return fallback;
+  }
+  applyThemeToDocument();
   let BRICK_SRC;
   let altTextManager = null;
   let autoAltText = '';
@@ -716,7 +742,7 @@
       c.setAttribute('cx', x + offsetX);
       c.setAttribute('cy', y + offsetY);
       c.setAttribute('r', radius);
-      c.setAttribute('fill', '#534477');
+      c.setAttribute('fill', getDotColor('monster'));
       svg.appendChild(c);
     });
     return svg;
@@ -755,7 +781,7 @@
         circle.setAttribute('cx', cx);
         circle.setAttribute('cy', cy);
         circle.setAttribute('r', radius);
-        circle.setAttribute('fill', '#534477');
+        circle.setAttribute('fill', getDotColor('rectangles'));
         svg.appendChild(circle);
       }
     }
@@ -1155,6 +1181,16 @@
     renderView();
   }
   window.render = render;
+  function handleThemeProfileChange(event) {
+    const data = event && event.data;
+    const type = typeof data === 'string' ? data : data && data.type;
+    if (type !== 'math-visuals:profile-change') return;
+    applyThemeToDocument();
+    render();
+  }
+  if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    window.addEventListener('message', handleThemeProfileChange);
+  }
   function bindNumberInput(input, targetGetter, key, min = 0) {
     if (!input) return;
     input.addEventListener('input', () => {

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -8,14 +8,20 @@
   
 
 <style>
-    :root { --sidebar-width: 480px; }
+    :root {
+      --sidebar-width: 480px;
+      --bead-primary: #d24a2c;
+      --bead-primary-stroke: #b23d22;
+      --bead-secondary: #3f7dc0;
+      --bead-secondary-stroke: #2a5e91;
+    }
     .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
     .figure svg { width: 100%; height: 360px; display: block; touch-action: none; }
     input[type="number"] { width: 100%; box-sizing: border-box; }
 
     .beadShadow{ filter: drop-shadow(0 1px 1px rgba(0,0,0,.25)); }
-    .beadFallback.red{ fill:#d24a2c; stroke:#b23d22; stroke-width:2; }
-    .beadFallback.blue{ fill:#3f7dc0; stroke:#2a5e91; stroke-width:2; }
+    .beadFallback.red{ fill:var(--bead-primary, #d24a2c); stroke:var(--bead-primary-stroke, var(--bead-primary, #d24a2c)); stroke-width:2; }
+    .beadFallback.blue{ fill:var(--bead-secondary, #3f7dc0); stroke:var(--bead-secondary-stroke, var(--bead-secondary, #3f7dc0)); stroke-width:2; }
     .clip{ cursor:grab; }
     .clip:active{ cursor:grabbing; }
     .slider:focus{ outline:none; stroke:#1e88e5; stroke-width:3; }
@@ -64,6 +70,7 @@
     </div>
   </div>
 
+  <script src="theme-profiles.js"></script>
   <script src="alt-text-ui.js"></script>
   <script src="perlesnor.js"></script>
   <script src="examples.js"></script>

--- a/perlesnor.js
+++ b/perlesnor.js
@@ -56,6 +56,17 @@ const ADV = {
     rightColorClass: "blue"
   }
 };
+function getThemeApi() {
+  const theme = typeof window !== 'undefined' ? window.MathVisualsTheme : null;
+  return theme && typeof theme === 'object' ? theme : null;
+}
+function applyThemeToDocument() {
+  const theme = getThemeApi();
+  if (theme && typeof theme.applyToDocument === 'function') {
+    theme.applyToDocument(document);
+  }
+}
+applyThemeToDocument();
 
 /* ============ DERIVERT KONFIG FOR RENDER (IKKE REDIGER) ============ */
 function makeCFG() {
@@ -131,6 +142,14 @@ btnPng === null || btnPng === void 0 || btnPng.addEventListener('click', () => d
 setupSettingsUI();
 applyConfig();
 initAltTextManager();
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('message', event => {
+    const data = event && event.data;
+    const type = typeof data === 'string' ? data : data && data.type;
+    if (type !== 'math-visuals:profile-change') return;
+    applyThemeToDocument();
+  });
+}
 
 /* ============ INTERAKSJON ============ */
 let dragging = false;

--- a/theme-profiles.js
+++ b/theme-profiles.js
@@ -1,0 +1,242 @@
+(function () {
+  const LEGACY_FRACTION_PALETTE = ['#B25FE3', '#6C1BA2', '#534477', '#873E79', '#BF4474', '#E31C3D'];
+  const PROFILES = {
+    kikora: {
+      id: 'kikora',
+      label: 'Kikora',
+      palettes: {
+        fractions: LEGACY_FRACTION_PALETTE,
+        figures: LEGACY_FRACTION_PALETTE
+      },
+      colors: {
+        ui: {
+          primary: '#6C1BA2',
+          secondary: '#534477',
+          hover: '#873E79',
+          playButton: '#10b981',
+          playButtonHover: '#059669',
+          playButtonText: '#ffffff'
+        },
+        dots: {
+          default: '#534477',
+          highlight: '#BF4474'
+        },
+        beads: {
+          primary: {
+            fill: '#d24a2c',
+            stroke: '#b23d22'
+          },
+          secondary: {
+            fill: '#3f7dc0',
+            stroke: '#2a5e91'
+          }
+        },
+        pizza: {
+          fill: '#5B2AA5',
+          rim: '#333333',
+          dash: '#000000',
+          handle: '#e9e6f7',
+          handleStroke: '#333333'
+        }
+      }
+    },
+    campus: {
+      id: 'campus',
+      label: 'Campus',
+      palettes: {
+        fractions: ['#2C395B', '#C5E5E9', '#F6E5BC', '#F1D0D9', '#E2DFF1', '#E3B660'],
+        figures: ['#2C395B', '#C5E5E9', '#F6E5BC', '#F1D0D9', '#E2DFF1', '#E3B660']
+      },
+      colors: {
+        ui: {
+          primary: '#2C395B',
+          secondary: '#C5E5E9',
+          hover: '#E3B660',
+          playButton: '#E3B660',
+          playButtonHover: '#2C395B',
+          playButtonText: '#2C395B'
+        },
+        dots: {
+          default: '#2C395B',
+          highlight: '#E3B660'
+        },
+        beads: {
+          primary: {
+            fill: '#E3B660',
+            stroke: '#C0902F'
+          },
+          secondary: {
+            fill: '#C5E5E9',
+            stroke: '#8CB0B4'
+          }
+        },
+        pizza: {
+          fill: '#F6E5BC',
+          rim: '#2C395B',
+          dash: '#2C395B',
+          handle: '#C5E5E9',
+          handleStroke: '#2C395B'
+        }
+      }
+    }
+  };
+  const DEFAULT_PROFILE = 'campus';
+  function getStoredProfileName() {
+    try {
+      return typeof window !== 'undefined' && window.localStorage ? window.localStorage.getItem('mathVisuals:themeProfile') : null;
+    } catch (err) {
+      return null;
+    }
+  }
+  function storeProfileName(name) {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem('mathVisuals:themeProfile', name);
+      }
+    } catch (err) {
+    }
+  }
+  function resolveProfileName(name) {
+    if (typeof name !== 'string') return DEFAULT_PROFILE;
+    const lower = name.toLowerCase();
+    if (PROFILES[lower]) return lower;
+    return DEFAULT_PROFILE;
+  }
+  function ensurePalette(base, count) {
+    const palette = Array.isArray(base) && base.length ? base.slice() : LEGACY_FRACTION_PALETTE.slice();
+    if (!Number.isFinite(count) || count <= 0) return palette.slice();
+    if (palette.length >= count) return palette.slice(0, count);
+    const result = palette.slice();
+    for (let i = palette.length; i < count; i++) {
+      result.push(palette[i % palette.length]);
+    }
+    return result;
+  }
+  function readColorToken(profile, token) {
+    if (!profile || typeof profile !== 'object') return undefined;
+    if (!token || typeof token !== 'string') return undefined;
+    const direct = profile.colors && typeof profile.colors === 'object' ? profile.colors[token] : undefined;
+    if (typeof direct === 'string' && direct) return direct;
+    const parts = token.split('.');
+    let current = profile.colors;
+    for (const part of parts) {
+      if (!current || typeof current !== 'object') return undefined;
+      current = current[part];
+    }
+    return typeof current === 'string' && current ? current : undefined;
+  }
+  let activeProfileName = resolveProfileName(getStoredProfileName());
+  function getProfile(name) {
+    return PROFILES[resolveProfileName(name)] || PROFILES[DEFAULT_PROFILE];
+  }
+  function getActiveProfile() {
+    return getProfile(activeProfileName);
+  }
+  function setProfile(name, options) {
+    const resolved = resolveProfileName(name);
+    const force = options && options.force;
+    if (!force && resolved === activeProfileName) return activeProfileName;
+    activeProfileName = resolved;
+    storeProfileName(activeProfileName);
+    return activeProfileName;
+  }
+  function listProfiles() {
+    return Object.keys(PROFILES);
+  }
+  function buildPalette(kind, count, opts) {
+    const profile = getActiveProfile();
+    const requested = typeof kind === 'string' ? kind : 'fractions';
+    const fallbackKinds = Array.isArray(opts && opts.fallbackKinds) ? opts.fallbackKinds : [];
+    const seen = new Set();
+    const queue = [requested, ...fallbackKinds, 'figures', 'fractions', 'default'];
+    for (const item of queue) {
+      if (typeof item !== 'string') continue;
+      const key = item.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const base = profile && profile.palettes ? profile.palettes[key] : undefined;
+      if (Array.isArray(base) && base.length) {
+        return ensurePalette(base, count);
+      }
+    }
+    return ensurePalette(LEGACY_FRACTION_PALETTE, count);
+  }
+  function getColor(token, fallback) {
+    const profile = getActiveProfile();
+    const value = readColorToken(profile, token);
+    if (typeof value === 'string' && value) return value;
+    if (typeof fallback === 'string' && fallback) return fallback;
+    return undefined;
+  }
+  function applyToDocument(doc) {
+    const targetDoc = doc || (typeof document !== 'undefined' ? document : null);
+    if (!targetDoc || !targetDoc.documentElement) return;
+    const profile = getActiveProfile();
+    const root = targetDoc.documentElement;
+    const style = root.style;
+    root.setAttribute('data-theme-profile', profile && profile.id ? profile.id : activeProfileName);
+    const map = {
+      '--ui-primary': 'ui.primary',
+      '--ui-secondary': 'ui.secondary',
+      '--ui-hover': 'ui.hover',
+      '--bead-primary': 'beads.primary.fill',
+      '--bead-primary-stroke': 'beads.primary.stroke',
+      '--bead-secondary': 'beads.secondary.fill',
+      '--bead-secondary-stroke': 'beads.secondary.stroke',
+      '--pizza-fill': 'pizza.fill',
+      '--pizza-rim': 'pizza.rim',
+      '--pizza-dash': 'pizza.dash',
+      '--pizza-handle': 'pizza.handle',
+      '--pizza-handle-stroke': 'pizza.handleStroke',
+      '--dot-fill': 'dots.default',
+      '--dot-highlight': 'dots.highlight',
+      '--play-button': 'ui.playButton',
+      '--play-button-hover': 'ui.playButtonHover',
+      '--play-button-text': 'ui.playButtonText'
+    };
+    Object.entries(map).forEach(([cssVar, token]) => {
+      const color = getColor(token);
+      if (typeof color === 'string' && color) {
+        style.setProperty(cssVar, color);
+      } else {
+        style.removeProperty(cssVar);
+      }
+    });
+  }
+  const api = {
+    getActiveProfileName() {
+      return activeProfileName;
+    },
+    getActiveProfile,
+    getProfile,
+    setProfile,
+    listProfiles,
+    getPalette(kind, count, opts) {
+      const size = Number.isFinite(count) && count > 0 ? Math.trunc(count) : undefined;
+      return buildPalette(kind, size, opts);
+    },
+    getColor,
+    applyToDocument
+  };
+  if (typeof window !== 'undefined') {
+    window.MathVisualsTheme = api;
+  }
+  applyToDocument(typeof document !== 'undefined' ? document : null);
+  function handleProfileMessage(event) {
+    const data = event && event.data;
+    let type = undefined;
+    let profileName = undefined;
+    if (typeof data === 'string') {
+      type = data;
+    } else if (data && typeof data === 'object') {
+      type = data.type;
+      profileName = data.profile || data.name || data.value;
+    }
+    if (type !== 'math-visuals:profile-change') return;
+    if (profileName) setProfile(profileName);
+    applyToDocument(typeof document !== 'undefined' ? document : null);
+  }
+  if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    window.addEventListener('message', handleProfileMessage);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a shared theme helper that exposes Kikora and Campus palettes with CSS variable support
- refactor visualization scripts to pull colors from the active theme and refresh on profile change
- update HTML wrappers to load the helper and delegate hard-coded fallback colors to theme variables

## Testing
- [ ] Not run

------
https://chatgpt.com/codex/tasks/task_e_68e3908b8fec832483e0990995e88db1