### PR TITLE
Add axis number and grid toggles to Graftegner

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -317,6 +317,20 @@
                       </td>
                     </tr>
                     <tr>
+                      <td>
+                        <label class="checkbox-inline">
+                          <input id="cfgShowAxisNumbers" type="checkbox" checked>
+                          <span>Vis tall på aksene</span>
+                        </label>
+                      </td>
+                      <td>
+                        <label class="checkbox-inline">
+                          <input id="cfgShowGrid" type="checkbox" checked>
+                          <span>Vis ruter</span>
+                        </label>
+                      </td>
+                    </tr>
+                    <tr>
                       <td colspan="2">
                         <label class="checkbox-inline">
                           <input id="cfgForceTicks" type="checkbox" checked>


### PR DESCRIPTION
## Summary
- add settings checkboxes to toggle axis numbers and grid visibility in Graftegner
- respect the new settings throughout board initialization, tick rendering, and grid rebuilding logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e390e7b0908324a3f09343e35c47ab