### PR TITLE
Disable default zoom/pan interactions in Graftegner

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -281,7 +281,7 @@
                       </td>
                       <td>
                         <label class="checkbox-inline">
-                          <input id="cfgZoom" type="checkbox" checked>
+                          <input id="cfgZoom" type="checkbox">
                           <span>Tillat zoom</span>
                         </label>
                       </td>
@@ -290,7 +290,7 @@
                       <td>
                         <label class="checkbox-inline">
                           <input id="cfgPan" type="checkbox">
-                          <span>Flytt koordinatsystem</span>
+                          <span>Tillat panorering</span>
                         </label>
                       </td>
                       <td>

--- a/graftegner.js
+++ b/graftegner.js
@@ -168,7 +168,7 @@ const ADV = {
       needShift: false
     },
     zoom: {
-      enabled: params.has('zoom') ? paramBool('zoom') : true,
+      enabled: params.has('zoom') ? paramBool('zoom') : false,
       wheel: true,
       needShift: false,
       factorX: 1.2,


### PR DESCRIPTION
## Summary
- default the Graftegner zoom and pan interactions to disabled
- update the pan setting label to "Tillat panorering"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4096d22dc832496f21e2e8eb395b7