### PR TITLE
Adjust deep link test to allow additional query parameters

### DIFF
--- a/tests/router-deep-links.spec.js
+++ b/tests/router-deep-links.spec.js
@@ -12,7 +12,7 @@ test.describe('deep links', () => {
 
   test('deep link with example segment keeps the example selection', async ({ page }) => {
     await page.goto('/fortegnsskjema-under-utvikling/eksempel2');
-    await expect(page.locator(IFRAME_SELECTOR)).toHaveAttribute('src', /fortegnsskjema\.html\?example=2/);
+    await expect(page.locator(IFRAME_SELECTOR)).toHaveAttribute('src', /fortegnsskjema\.html\?.*example=2/);
     await expect(page.locator(FORTEGN_NAV_SELECTOR)).toHaveAttribute('aria-current', 'page');
   });
 });


### PR DESCRIPTION
## Summary
- relax the router deep link iframe src assertion to permit additional query parameters while still enforcing the selected example

## Testing
- npx playwright test tests/router-deep-links.spec.js *(fails: missing system dependencies to launch browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68e40a63b0608324b7d2b462b672aa18