### PR TITLE
Swap sidebar position for figure and settings in both modes

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -118,7 +118,6 @@
     editor: DEFAULT_APP_MODE
   };
   const originalSplitSideWidths = new WeakMap();
-  const originalSplitterDisplays = new WeakMap();
   let currentAppMode = DEFAULT_APP_MODE;
   let lastAppliedAppMode = null;
   let splitterObserver = null;
@@ -158,26 +157,6 @@
         }
       } else {
         grid.style.removeProperty('--side-width');
-      }
-    });
-    const splitters = document.querySelectorAll('.splitter');
-    splitters.forEach(splitter => {
-      if (!(splitter instanceof HTMLElement)) return;
-      if (isTaskMode) {
-        if (!originalSplitterDisplays.has(splitter)) {
-          originalSplitterDisplays.set(splitter, splitter.style.display || '');
-        }
-        splitter.style.display = 'none';
-      } else if (originalSplitterDisplays.has(splitter)) {
-        const prev = originalSplitterDisplays.get(splitter);
-        originalSplitterDisplays.delete(splitter);
-        if (prev) {
-          splitter.style.display = prev;
-        } else {
-          splitter.style.removeProperty('display');
-        }
-      } else {
-        splitter.style.removeProperty('display');
       }
     });
   }

--- a/split.css
+++ b/split.css
@@ -1,8 +1,16 @@
 .grid.split-enabled {
+  --side-max: 420px;
   gap: 0 !important;
-  grid-template-columns: 1fr var(--gap) var(--side-width, 420px) !important;
+  grid-template-columns: minmax(
+      var(--side-min, 200px),
+      min(var(--side-width, var(--side-max, 420px)), var(--side-max, 420px))
+    )
+    var(--gap)
+    minmax(0, 1fr) !important;
+  grid-template-areas: "side splitter main";
 }
 .grid.split-enabled > .splitter {
+  grid-area: splitter;
   width: var(--gap);
   cursor: col-resize;
   position: relative;
@@ -21,10 +29,25 @@
   background: #e5e7eb;
   border-radius: 3px;
 }
+.grid.split-enabled > .side {
+  grid-area: side;
+  min-width: 0;
+}
+.grid.split-enabled > :not(.splitter):not(.side) {
+  grid-area: main;
+  min-width: 0;
+}
 @media (max-width:980px){
   .grid.split-enabled {
     grid-template-columns: 1fr !important;
+    grid-template-areas:
+      "main"
+      "side";
     gap: var(--gap) !important;
+  }
+  .grid.split-enabled > .side,
+  .grid.split-enabled > :not(.splitter):not(.side) {
+    grid-area: auto;
   }
   .grid.split-enabled > .splitter {
     display: none;
@@ -32,17 +55,7 @@
 }
 
 body[data-app-mode="task"] .grid.split-enabled {
-  grid-template-columns: minmax(0, 1fr) !important;
-  gap: var(--gap) !important;
-  --side-width: min(360px, 100%);
-}
-
-body[data-app-mode="task"] .grid.split-enabled > .splitter {
-  display: none !important;
-}
-
-body[data-app-mode="task"] .grid.split-enabled > .side {
-  width: min(360px, 100%);
+  --side-max: 360px;
 }
 
 /* Shared styling for settings panels */


### PR DESCRIPTION
## Summary
- reverse the split layout so the sidebar appears before the main figure area
- keep the draggable splitter active in task mode while constraining the text column width
- stop the examples helper from hiding the splitter when switching modes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e40d6edbe48324911fce99758c8d45