### PR TITLE
Add coordinate axes with labels in prikk til prikk editor

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -22,6 +22,23 @@
     .grid-group { pointer-events: none; }
     .grid-line { stroke: #d1d5db; stroke-width: 1; opacity: .8; }
     .grid-line--major { stroke: #9ca3af; opacity: .9; }
+    .axis-group,
+    .axis-labels-group { pointer-events: none; }
+    .axis-line { stroke: #111827; stroke-width: 2; opacity: .85; }
+    .axis-line--x { }
+    .axis-line--y { }
+    .axis-tick { stroke: #111827; stroke-width: 1.5; opacity: .85; }
+    .axis-label {
+      fill: #1f2937;
+      font-size: 12px;
+      font-weight: 600;
+      paint-order: stroke;
+      stroke: #fff;
+      stroke-width: 3;
+      stroke-linejoin: round;
+    }
+    .axis-label--x { dominant-baseline: hanging; }
+    .axis-label--y { dominant-baseline: middle; }
     #dotBoard {
       width: 100%;
       height: clamp(320px, 60vh, 520px);


### PR DESCRIPTION
## Summary
- add dedicated SVG groups for axes and axis labels in the prikk til prikk editor
- render axis lines, ticks, and coordinate values alongside the existing grid to help place points
- style the new axis visuals so they stand out from the grid

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e40e6579448324bb1dcde01e2af6ca