### PR TITLE
Cluster task mode buttons by visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,11 @@
       white-space: nowrap;
     }
 
+    .task-cluster {
+      display: inline-flex;
+      align-items: center;
+    }
+
     .task-node {
       appearance: none;
       border: 2px solid var(--profile-accent-border);
@@ -263,6 +268,16 @@
       flex: 0 0 auto;
       position: relative;
       transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    }
+
+    .task-cluster .task-node + .task-node {
+      margin-left: -8px;
+    }
+
+    .task-cluster .task-node:focus-visible,
+    .task-cluster .task-node:hover {
+      position: relative;
+      z-index: 1;
     }
 
     .task-node::after {

--- a/router.js
+++ b/router.js
@@ -592,7 +592,15 @@ function renderTaskStrip(tasks) {
     return;
   }
   const fragment = document.createDocumentFragment();
+  let currentCluster = null;
   tasks.forEach(task => {
+    if (!currentCluster || currentCluster.entry !== task.entry) {
+      const cluster = document.createElement('div');
+      cluster.className = 'task-cluster';
+      fragment.appendChild(cluster);
+      currentCluster = { entry: task.entry, element: cluster };
+    }
+
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'task-node';
@@ -609,7 +617,7 @@ function renderTaskStrip(tasks) {
       };
       applyRoute(task.entry, task.exampleNumber, options);
     });
-    fragment.appendChild(button);
+    currentCluster.element.appendChild(button);
     taskButtons.push(button);
   });
   taskStrip.appendChild(fragment);


### PR DESCRIPTION
## Summary
- group task mode task buttons into per-visualization clusters so related examples sit together
- add styling to visually join circles from the same cluster while keeping space between different apps

## Testing
- npm test *(fails: Playwright browser downloads are blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e41a5557808324b119a7b00fbdc38c