### PR TITLE
Hide task-mode figure controls for Figurtall

### DIFF
--- a/figurtall.html
+++ b/figurtall.html
@@ -102,6 +102,7 @@
     .cell--filled.cell--circle{background:var(--cell-fill,#fff);}
     .nameInput{width:100%;border:1px solid #d1d5db;border-radius:8px;padding:6px 8px;font-size:14px;box-sizing:border-box;}
     .nameDisplay{width:100%;border:1px solid #d1d5db;border-radius:8px;padding:6px 8px;font-size:14px;box-sizing:border-box;background:#f3f4f6;color:#374151;}
+    body[data-app-mode="task"] .nameDisplay{border:none;border-radius:0;padding:0;background:transparent;}
     .removeFigureBtn{
       align-self:flex-end;
       background:none;

--- a/figurtall.js
+++ b/figurtall.js
@@ -340,6 +340,7 @@
     const removeBtn = document.createElement('button');
     removeBtn.type = 'button';
     removeBtn.className = 'removeFigureBtn';
+    removeBtn.setAttribute('data-edit-only', '');
     removeBtn.textContent = 'Fjern figur';
     if (STATE.figures.length <= 1) {
       removeBtn.disabled = true;


### PR DESCRIPTION
## Summary
- hide the "Fjern figur" button in task mode by marking it as edit-only
- remove the border styling from figure captions when the app is shown in task mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e41d7e43308324ab3b62ca813c8100