### PR TITLE
Render KaTeX markup in task descriptions

### DIFF
--- a/base.css
+++ b/base.css
@@ -361,6 +361,36 @@ select:disabled {
   display: none;
 }
 
+.card--examples .example-description__preview {
+  display: none;
+  padding: 10px;
+  border-radius: var(--control-radius);
+  border: 1px solid var(--card-border);
+  background: #f9fafb;
+  color: var(--text-color);
+  font-size: 14px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.card--examples .example-description__preview:not([hidden]) {
+  display: block;
+}
+
+.card--examples .example-description__preview .example-description__math {
+  display: inline-block;
+  margin: 0 2px;
+}
+
+.card--examples .example-description__preview .example-description__math .katex {
+  font-size: 1em;
+}
+
+.card--examples .example-description__preview .example-description__math--fallback {
+  font-style: italic;
+  color: var(--muted-color);
+}
+
 .card--examples .example-description.example-description--collapsed {
   gap: 0;
   padding: 10px;

--- a/examples-viewer.js
+++ b/examples-viewer.js
@@ -416,9 +416,16 @@ async function renderExamples(options) {
       if (ex && typeof ex.description === 'string' && ex.description.trim()) {
         const description = document.createElement('p');
         description.className = 'example-description';
-        description.textContent = ex.description;
         description.style.whiteSpace = 'pre-wrap';
         description.style.margin = '0 0 8px';
+        const renderer = window.MathVisuals && window.MathVisuals.description && typeof window.MathVisuals.description.renderContent === 'function' ? window.MathVisuals.description.renderContent : null;
+        if (renderer) {
+          renderer(description, ex.description, {
+            ensureKatex: true
+          });
+        } else {
+          description.textContent = ex.description;
+        }
         wrap.appendChild(description);
       }
       const iframe = document.createElement('iframe');

--- a/split.css
+++ b/split.css
@@ -149,6 +149,36 @@ body[data-app-mode="task"] .grid.split-enabled {
   display: none;
 }
 
+.card--examples .example-description__preview {
+  display: none;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  color: #1f2937;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.card--examples .example-description__preview:not([hidden]) {
+  display: block;
+}
+
+.card--examples .example-description__preview .example-description__math {
+  display: inline-block;
+  margin: 0 2px;
+}
+
+.card--examples .example-description__preview .example-description__math .katex {
+  font-size: 1em;
+}
+
+.card--examples .example-description__preview .example-description__math--fallback {
+  font-style: italic;
+  color: #4b5563;
+}
+
 .card--examples .example-description textarea {
   border: 1px solid #d1d5db;
   border-radius: 10px;


### PR DESCRIPTION
## Summary
- add a shared KaTeX loader and description renderer to convert `@math{...}` markers into rendered math
- surface a live math preview under the oppgavetekst textarea and style it for both layout themes
- reuse the renderer when showing saved examples so stored descriptions display KaTeX math

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e41ac41cac83248d622d3adb2eee53