### PR TITLE
Improve example description preview visibility

### DIFF
--- a/base.css
+++ b/base.css
@@ -351,7 +351,7 @@ select:disabled {
 }
 
 .card--examples .example-description-preview {
-  display: none;
+  display: block;
   border: 1px solid var(--card-border);
   border-radius: var(--control-radius);
   padding: 12px 14px;
@@ -360,10 +360,25 @@ select:disabled {
   color: var(--text-color);
   background: #fff;
   overflow-x: auto;
+  margin-top: 4px;
+}
+
+.card--examples .example-description-preview[hidden] {
+  display: none;
 }
 
 .card--examples .example-description-preview[data-empty="true"] {
   display: none;
+}
+
+.card--examples .example-description-preview .katex {
+  display: inline-block;
+  font-size: 1.05em;
+}
+
+.card--examples .example-description-preview .katex-display {
+  overflow-x: auto;
+  padding-bottom: 2px;
 }
 
 .card--examples .example-description-preview p {

--- a/split.css
+++ b/split.css
@@ -139,7 +139,7 @@ body[data-app-mode="task"] .grid.split-enabled {
 }
 
 .card--examples .example-description-preview {
-  display: none;
+  display: block;
   border: 1px solid #e5e7eb;
   border-radius: 10px;
   padding: 12px 14px;
@@ -148,10 +148,25 @@ body[data-app-mode="task"] .grid.split-enabled {
   color: #111827;
   background: #fff;
   overflow-x: auto;
+  margin-top: 4px;
+}
+
+.card--examples .example-description-preview[hidden] {
+  display: none;
 }
 
 .card--examples .example-description-preview[data-empty="true"] {
   display: none;
+}
+
+.card--examples .example-description-preview .katex {
+  display: inline-block;
+  font-size: 1.05em;
+}
+
+.card--examples .example-description-preview .katex-display {
+  overflow-x: auto;
+  padding-bottom: 2px;
 }
 
 .card--examples .example-description-preview p {


### PR DESCRIPTION
## Summary
- show example description previews by default in the base theme while still hiding empty/hidden states and adding KaTeX display support
- apply matching preview spacing and KaTeX tweaks to the split theme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e426a003dc83248ba20f9757826a2e