### PR TITLE
Add interactive macros to example descriptions

### DIFF
--- a/base.css
+++ b/base.css
@@ -380,6 +380,82 @@ select:disabled {
   margin: 10px 0;
 }
 
+.example-description-preview .example-task {
+  border: 1px solid #dbeafe;
+  border-radius: var(--control-radius);
+  background: #f8fafc;
+  padding: 12px 14px;
+  margin: 0 0 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.example-description-preview .example-task:last-child {
+  margin-bottom: 0;
+}
+
+.example-description-preview .example-task__header {
+  font-weight: 600;
+  color: var(--heading-color);
+}
+
+.example-description-preview .example-task__body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.example-description-preview .example-task__body > *:last-child {
+  margin-bottom: 0;
+}
+
+.example-description-preview .example-math {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 2px;
+  font-size: 1.05em;
+}
+
+.example-description-preview .example-answerbox {
+  min-width: 140px;
+  max-width: 100%;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  font: inherit;
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.example-description-preview textarea.example-answerbox {
+  resize: vertical;
+}
+
+.example-description-preview .example-answerbox:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+}
+
+.example-description-preview .example-answerbox.example-answerbox--correct,
+.example-description-preview .example-answerbox[aria-invalid="false"] {
+  border-color: #22c55e;
+  background: #dcfce7;
+}
+
+.example-description-preview .example-answerbox.example-answerbox--incorrect,
+.example-description-preview .example-answerbox[aria-invalid="true"] {
+  border-color: #ef4444;
+  background: #fee2e2;
+}
+
+.example-description-preview .example-answerbox:disabled,
+.example-description-preview .example-answerbox[readonly] {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+}
+
 .card--examples .example-description-preview th,
 .card--examples .example-description-preview td {
   border: 1px solid #d1d5db;

--- a/examples-viewer.js
+++ b/examples-viewer.js
@@ -414,11 +414,34 @@ async function renderExamples(options) {
       const wrap = document.createElement('div');
       wrap.className = 'example';
       if (ex && typeof ex.description === 'string' && ex.description.trim()) {
-        const description = document.createElement('p');
-        description.className = 'example-description';
-        description.textContent = ex.description;
-        description.style.whiteSpace = 'pre-wrap';
+        const description = document.createElement('div');
+        description.className = 'example-description-preview';
+        description.dataset.empty = 'true';
         description.style.margin = '0 0 8px';
+        const parser = globalScope && globalScope.__MATH_VISUALS_DESCRIPTION__;
+        if (parser && typeof parser.render === 'function') {
+          const { hasContent } = parser.render(ex.description, description, {
+            clear: false,
+            setEmptyState: true
+          });
+          if (!hasContent) {
+            description.textContent = ex.description;
+            description.style.whiteSpace = 'pre-wrap';
+          }
+        } else if (parser && typeof parser.parse === 'function') {
+          const fragment = parser.parse(ex.description);
+          const hasContent = fragment && fragment.childNodes && fragment.childNodes.length > 0;
+          if (hasContent) {
+            description.appendChild(fragment);
+            description.dataset.empty = 'false';
+          } else {
+            description.textContent = ex.description;
+            description.style.whiteSpace = 'pre-wrap';
+          }
+        } else {
+          description.textContent = ex.description;
+          description.style.whiteSpace = 'pre-wrap';
+        }
         wrap.appendChild(description);
       }
       const iframe = document.createElement('iframe');

--- a/split.css
+++ b/split.css
@@ -168,6 +168,82 @@ body[data-app-mode="task"] .grid.split-enabled {
   margin: 10px 0;
 }
 
+.example-description-preview .example-task {
+  border: 1px solid #dbeafe;
+  border-radius: 10px;
+  background: #f8fafc;
+  padding: 12px 14px;
+  margin: 0 0 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.example-description-preview .example-task:last-child {
+  margin-bottom: 0;
+}
+
+.example-description-preview .example-task__header {
+  font-weight: 600;
+  color: var(--heading-color, #374151);
+}
+
+.example-description-preview .example-task__body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.example-description-preview .example-task__body > *:last-child {
+  margin-bottom: 0;
+}
+
+.example-description-preview .example-math {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 2px;
+  font-size: 1.05em;
+}
+
+.example-description-preview .example-answerbox {
+  min-width: 140px;
+  max-width: 100%;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  font: inherit;
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.example-description-preview textarea.example-answerbox {
+  resize: vertical;
+}
+
+.example-description-preview .example-answerbox:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+}
+
+.example-description-preview .example-answerbox.example-answerbox--correct,
+.example-description-preview .example-answerbox[aria-invalid="false"] {
+  border-color: #22c55e;
+  background: #dcfce7;
+}
+
+.example-description-preview .example-answerbox.example-answerbox--incorrect,
+.example-description-preview .example-answerbox[aria-invalid="true"] {
+  border-color: #ef4444;
+  background: #fee2e2;
+}
+
+.example-description-preview .example-answerbox:disabled,
+.example-description-preview .example-answerbox[readonly] {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+}
+
 .card--examples .example-description-preview th,
 .card--examples .example-description-preview td {
   border: 1px solid #d1d5db;

--- a/tests/examples-description-macros.spec.js
+++ b/tests/examples-description-macros.spec.js
@@ -1,0 +1,40 @@
+const { test, expect } = require('@playwright/test');
+
+const ANSWERBOX_DESCRIPTION = '@task{Test svaret: @answerbox[answer=4 placeholder="Svar"]}';
+const MATH_DESCRIPTION = '@math{x^2 + 1}';
+
+test.describe('Oppgavetekst-makroer', () => {
+  test('answerbox viser og validerer brukerinput', async ({ page }) => {
+    await page.goto('/diagram/index.html');
+
+    const textarea = page.locator('#exampleDescription');
+    await textarea.fill(ANSWERBOX_DESCRIPTION);
+
+    const preview = page.locator('.example-description-preview');
+    await expect(preview).toHaveAttribute('data-empty', 'false');
+
+    const input = preview.locator('input.example-answerbox');
+    await expect(input).toHaveCount(1);
+    await expect(input).toHaveAttribute('placeholder', 'Svar');
+
+    await input.fill('5');
+    await expect(input).toHaveAttribute('aria-invalid', 'true');
+    await expect(input).toHaveClass(/example-answerbox--incorrect/);
+
+    await input.fill('4');
+    await expect(input).toHaveAttribute('aria-invalid', 'false');
+    await expect(input).toHaveClass(/example-answerbox--correct/);
+  });
+
+  test('math-makro faller tilbake til tekst når KaTeX mangler', async ({ page }) => {
+    await page.goto('/arealmodell.html');
+
+    const textarea = page.locator('#exampleDescription');
+    await textarea.fill(MATH_DESCRIPTION);
+
+    const math = page.locator('.example-description-preview .example-math');
+    await expect(math).toHaveCount(1);
+    await expect(math).toHaveText('x^2 + 1');
+    await expect(math.locator('.katex')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- expand the description parser to build task sections, answer boxes, and KaTeX math
- expose the shared parser to the examples viewer and add styling for interactive elements
- add Playwright coverage for answerbox validation and KaTeX fallback behaviour

## Testing
- npx playwright test tests/examples-description-macros.spec.js *(fails: missing system libraries for Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68e4261c7fe483249e7b67c783cac50c