### PR TITLE
Fix initial sidebar placement in graftegner

### DIFF
--- a/base.css
+++ b/base.css
@@ -154,9 +154,29 @@ body {
   grid-template-columns: minmax(0, 1fr) minmax(var(--sidebar-min-width), var(--sidebar-width));
 }
 
+body[data-app="graftegner"] .layout--sidebar:not(.split-enabled) {
+  grid-template-columns: minmax(var(--sidebar-min-width), var(--sidebar-width)) minmax(0, 1fr);
+}
+
+body[data-app="graftegner"] .layout--sidebar:not(.split-enabled) > .side {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+body[data-app="graftegner"] .layout--sidebar:not(.split-enabled) > :not(.side) {
+  grid-column: 2;
+  grid-row: 1;
+}
+
 @media (max-width: 980px) {
   .layout--sidebar {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  body[data-app="graftegner"] .layout--sidebar:not(.split-enabled) > .side,
+  body[data-app="graftegner"] .layout--sidebar:not(.split-enabled) > :not(.side) {
+    grid-column: auto;
+    grid-row: auto;
   }
 }
 

--- a/graftegner.html
+++ b/graftegner.html
@@ -212,7 +212,7 @@
   <link rel="stylesheet" href="split.css" />
   <script defer src="https://cdn.jsdelivr.net/npm/mathlive/dist/mathlive.min.js"></script>
 </head>
-<body>
+<body data-app="graftegner">
   <div class="wrap">
     <div class="grid layout--sidebar">
       <div class="card">


### PR DESCRIPTION
## Summary
- ensure graftegner loads its settings sidebar on the left by default via a page-specific layout override
- tag the graftegner document body so the targeted styles apply without affecting other tools

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68e428e591248324b042bd7e000dc10f