### PR TITLE
Support HTML-based task descriptions

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -1124,6 +1124,99 @@
   let descriptionContainer = null;
   let descriptionPreview = null;
 
+  const DESCRIPTION_FALLBACK_FIELDS = [
+    'descriptionHtml',
+    'descriptionHTML',
+    'description_html',
+    'descriptionRich',
+    'description_rich',
+    'descriptionRichText',
+    'description_rich_text',
+    'richDescription',
+    'taskDescription',
+    'task_description',
+    'taskText',
+    'task_text',
+    'task',
+    'oppgave',
+    'oppgavetekst',
+    'oppgaveTekst'
+  ];
+
+  function normalizeDescriptionString(value) {
+    if (typeof value !== 'string') return '';
+    const normalized = value
+      .replace(/\r\n?/g, '\n')
+      .replace(/\u00a0/g, ' ')
+      .replace(/[ \t]+\n/g, '\n')
+      .replace(/\n{3,}/g, '\n\n');
+    return normalized.trim();
+  }
+
+  function convertHtmlToPlainText(html) {
+    if (typeof html !== 'string') return '';
+    const trimmed = html.trim();
+    if (!trimmed) return '';
+    const sanitized = trimmed
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '');
+    const replaced = sanitized
+      .replace(/<\s*br\s*\/?>/gi, '\n')
+      .replace(/<\s*li\b[^>]*>/gi, '\n- ')
+      .replace(/<\/(?:p|div|section|article|li|tr|thead|tbody|tfoot|table|h[1-6])\s*>/gi, '\n');
+    if (typeof document !== 'undefined') {
+      const container = document.createElement('div');
+      container.innerHTML = replaced;
+      return normalizeDescriptionString(container.textContent || '');
+    }
+    const stripped = replaced.replace(/<[^>]+>/g, '');
+    return normalizeDescriptionString(stripped);
+  }
+
+  function extractDescriptionFromExample(example) {
+    if (!example || typeof example !== 'object') return '';
+    if (typeof example.description === 'string' && example.description.trim()) {
+      return normalizeDescriptionString(example.description);
+    }
+    for (const key of DESCRIPTION_FALLBACK_FIELDS) {
+      if (!Object.prototype.hasOwnProperty.call(example, key)) continue;
+      const value = example[key];
+      if (typeof value !== 'string') continue;
+      if (!value.trim()) continue;
+      const processed = /html|rich/i.test(key) ? convertHtmlToPlainText(value) : normalizeDescriptionString(value);
+      if (processed) return processed;
+    }
+    if (typeof example.description === 'string') {
+      return normalizeDescriptionString(example.description);
+    }
+    return '';
+  }
+
+  function normalizeExamplesForStorage(examples) {
+    const list = Array.isArray(examples) ? examples : [];
+    return list.map(example => {
+      const copy = cloneValue(example);
+      if (!copy || typeof copy !== 'object') {
+        return {};
+      }
+      const description = extractDescriptionFromExample(copy);
+      if (typeof description === 'string') {
+        copy.description = description;
+      }
+      if (copy.description == null) {
+        copy.description = '';
+      } else if (typeof copy.description === 'string') {
+        copy.description = normalizeDescriptionString(copy.description);
+      }
+      DESCRIPTION_FALLBACK_FIELDS.forEach(field => {
+        if (field !== 'description' && Object.prototype.hasOwnProperty.call(copy, field)) {
+          delete copy[field];
+        }
+      });
+      return copy;
+    });
+  }
+
   function getDescriptionContainer() {
     if (descriptionContainer && descriptionContainer.isConnected) return descriptionContainer;
     if (typeof document === 'undefined') return null;
@@ -1367,7 +1460,7 @@
     return cachedExamples;
   }
   function store(examples, options) {
-    const normalized = Array.isArray(examples) ? examples : [];
+    const normalized = normalizeExamplesForStorage(examples);
     const serialized = JSON.stringify(normalized);
     applyRawExamples(serialized, options);
   }
@@ -1628,7 +1721,10 @@
     };
     if (typeof example.svg === 'string') sanitized.svg = example.svg;
     if (typeof example.title === 'string') sanitized.title = example.title;
-    if (typeof example.description === 'string') sanitized.description = example.description;
+    const providedDescription = extractDescriptionFromExample(example);
+    if (typeof providedDescription === 'string') {
+      sanitized.description = providedDescription;
+    }
     if (typeof example.exampleNumber === 'string' || typeof example.exampleNumber === 'number') {
       sanitized.exampleNumber = String(example.exampleNumber).trim();
     } else if (typeof example.label === 'string') {

--- a/tests/task-mode-description.spec.js
+++ b/tests/task-mode-description.spec.js
@@ -1,0 +1,28 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('task mode description preview', () => {
+  test('shows description text when switching to task mode', async ({ page }) => {
+    await page.goto('/diagram/index.html', { waitUntil: 'load' });
+    const description = 'Dette er en testoppgave';
+    await page.fill('#exampleDescription', description);
+    await page.evaluate(() => window.mathVisuals.setAppMode('task', { force: true }));
+    const preview = page.locator('.example-description-preview');
+    await expect(preview).toBeVisible();
+    await expect(preview).toHaveText(description);
+
+    const cfg = await page.evaluate(() => window.CFG);
+    const htmlExample = [{
+      descriptionHtml: '<p>Oppgave med <strong>fet</strong> tekst</p>',
+      exampleNumber: '1',
+      isDefault: true,
+      config: { CFG: cfg }
+    }];
+    await page.evaluate(exampleData => {
+      localStorage.setItem('examples_/diagram', JSON.stringify(exampleData));
+    }, htmlExample);
+    await page.goto('/diagram/index.html?mode=oppgave', { waitUntil: 'load' });
+    const htmlPreview = page.locator('.example-description-preview');
+    await expect(htmlPreview).toBeVisible();
+    await expect(htmlPreview).toHaveText('Oppgave med fet tekst');
+  });
+});


### PR DESCRIPTION
## Summary
- normalize stored example descriptions by extracting text from HTML and alternate fields
- keep task descriptions visible in task mode by sanitizing data before persistence
- add a regression test that covers plain text and HTML-backed descriptions in task mode

## Testing
- npx playwright test tests/task-mode-description.spec.js --project=chromium *(fails: missing browser dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e42941b634832483041ff8c2bee0fc