### PR TITLE
Add shared description renderer to examples viewer

### DIFF
--- a/base.css
+++ b/base.css
@@ -393,6 +393,90 @@ select:disabled {
   font-weight: 600;
 }
 
+.example-description,
+.example-description-preview {
+  --example-desc-border: #d1d5db;
+  --example-desc-surface: #f9fafb;
+  --example-desc-correct: #047857;
+  --example-desc-correct-bg: #ecfdf5;
+  --example-desc-incorrect: #b91c1c;
+  --example-desc-incorrect-bg: #fef2f2;
+  --example-desc-muted: #6b7280;
+  color: inherit;
+}
+
+.example-description .example-task,
+.example-description-preview .example-task {
+  border: 1px solid var(--example-desc-border);
+  border-radius: 10px;
+  background: var(--example-desc-surface);
+  padding: 12px 14px;
+  margin: 12px 0;
+}
+
+.example-description .example-task:first-child,
+.example-description-preview .example-task:first-child {
+  margin-top: 0;
+}
+
+.example-description .example-task__body,
+.example-description-preview .example-task__body {
+  display: block;
+}
+
+.example-description .example-answerbox,
+.example-description-preview .example-answerbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 4px;
+}
+
+.example-description .example-answerbox__input,
+.example-description-preview .example-answerbox__input {
+  font: inherit;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--example-desc-border);
+  background: #fff;
+  min-width: 5.5rem;
+}
+
+.example-description .example-answerbox__status,
+.example-description-preview .example-answerbox__status {
+  font-size: 0.85rem;
+  color: var(--example-desc-muted);
+  min-height: 1.2em;
+}
+
+.example-description .example-answerbox--correct .example-answerbox__input,
+.example-description-preview .example-answerbox--correct .example-answerbox__input {
+  border-color: var(--example-desc-correct);
+  background: var(--example-desc-correct-bg);
+}
+
+.example-description .example-answerbox--incorrect .example-answerbox__input,
+.example-description-preview .example-answerbox--incorrect .example-answerbox__input {
+  border-color: var(--example-desc-incorrect);
+  background: var(--example-desc-incorrect-bg);
+}
+
+.example-description .example-answerbox--correct .example-answerbox__status,
+.example-description-preview .example-answerbox--correct .example-answerbox__status {
+  color: var(--example-desc-correct);
+}
+
+.example-description .example-answerbox--incorrect .example-answerbox__status,
+.example-description-preview .example-answerbox--incorrect .example-answerbox__status {
+  color: var(--example-desc-incorrect);
+}
+
+.example-description .example-katex,
+.example-description-preview .example-katex {
+  display: inline-block;
+  margin: 0 2px;
+}
+
 .card--examples .example-description label {
   display: flex;
   align-items: center;

--- a/examples-viewer.html
+++ b/examples-viewer.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="no">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Eksempeloversikt</title>
+  <link rel="stylesheet" href="base.css" />
+  <link rel="stylesheet" href="split.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-ywTprUI1Q+mEFz1Ok5AR52lCstOEPCTpQJZMa2+pzSQPwXTwns32xERiqnnn6T5+" crossorigin="anonymous" />
+  <style>
+    body {
+      margin: 0;
+      font-family: system-ui, sans-serif;
+      background: #f8fafc;
+      color: #0f172a;
+    }
+    main {
+      max-width: 960px;
+      margin: 40px auto;
+      padding: 0 20px 60px;
+      display: flex;
+      flex-direction: column;
+      gap: 32px;
+    }
+    section {
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+      border: 1px solid rgba(15, 23, 42, 0.05);
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    section h2 {
+      margin: 0;
+      font-size: 1.2rem;
+      font-weight: 600;
+      color: #0f172a;
+    }
+    .example {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding: 16px;
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      border-radius: 12px;
+      background: rgba(248, 250, 252, 0.9);
+    }
+    .example iframe {
+      width: 100%;
+      min-height: 360px;
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      border-radius: 10px;
+      background: #fff;
+    }
+    .buttons {
+      display: flex;
+      gap: 12px;
+    }
+    .buttons button {
+      padding: 8px 14px;
+      border-radius: 8px;
+      border: 1px solid rgba(15, 109, 143, 0.35);
+      background: #0f6d8f;
+      color: #fff;
+      cursor: pointer;
+      font: inherit;
+    }
+    .buttons button:hover,
+    .buttons button:focus-visible {
+      background: #0c5974;
+      outline: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="grid">
+      <div class="card card--examples" style="width:100%;">
+        <main id="examples" aria-live="polite"></main>
+      </div>
+    </div>
+  </div>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" integrity="sha384-95pQhY9qsK0kGugHgdGXNqBJ38qRAjPR9U1FVLtZL1NVr7DiJ9N6byj1LxX+BPvk" crossorigin="anonymous"></script>
+  <script src="examples-viewer.js" defer></script>
+</body>
+</html>

--- a/examples.js
+++ b/examples.js
@@ -97,6 +97,403 @@
   });
 })();
 
+
+
+const DESCRIPTION_RENDERER = (() => {
+  const globalScope = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
+  if (globalScope && globalScope.__EXAMPLES_DESCRIPTION__) {
+    return globalScope.__EXAMPLES_DESCRIPTION__;
+  }
+
+  const MAX_KATEX_ATTEMPTS = 8;
+
+  function normalizeLineBreaks(value) {
+    return typeof value === 'string' ? value.replace(/\r\n?/g, '\n') : '';
+  }
+
+  function createParagraphNode() {
+    return { type: 'paragraph', children: [] };
+  }
+
+  function appendTextSegment(paragraph, text) {
+    if (!paragraph || typeof text !== 'string' || !text) return;
+    const normalized = normalizeLineBreaks(text);
+    const lines = normalized.split('\n');
+    lines.forEach((line, index) => {
+      if (line) {
+        paragraph.children.push({ type: 'text', value: line });
+      }
+      if (index < lines.length - 1) {
+        paragraph.children.push({ type: 'linebreak' });
+      }
+    });
+  }
+
+  function findCommand(source, startIndex) {
+    let index = source.indexOf('@', startIndex);
+    while (index !== -1) {
+      const match = /^@([a-zA-Z]+)\s*\{/.exec(source.slice(index));
+      if (!match) {
+        index = source.indexOf('@', index + 1);
+        continue;
+      }
+      const name = match[1];
+      let depth = 1;
+      let cursor = index + match[0].length;
+      while (cursor < source.length && depth > 0) {
+        const char = source[cursor];
+        if (char === '{') {
+          depth++;
+        } else if (char === '}') {
+          depth--;
+        }
+        cursor++;
+      }
+      if (depth !== 0) {
+        index = source.indexOf('@', index + 1);
+        continue;
+      }
+      const contentStart = index + match[0].length;
+      return {
+        index,
+        name,
+        content: source.slice(contentStart, cursor - 1),
+        endIndex: cursor
+      };
+    }
+    return null;
+  }
+
+  function parseTable(content) {
+    const normalized = normalizeLineBreaks(content).trim();
+    if (!normalized) return null;
+    const lines = normalized
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line);
+    if (!lines.length) return null;
+    const rows = lines.map(line => line.split('|').map(cell => cell.trim())) || [];
+    const columnCount = rows.reduce((max, row) => (row.length > max ? row.length : max), 0);
+    if (!columnCount) return null;
+    const [headerRow, ...bodyRows] = rows;
+    return {
+      headers: headerRow,
+      rows: bodyRows.length ? bodyRows : [headerRow]
+    };
+  }
+
+  function parseDescriptionToAst(value) {
+    const source = normalizeLineBreaks(String(value != null ? value : ''));
+    const nodes = [];
+    let paragraph = createParagraphNode();
+
+    const ensureParagraph = () => {
+      if (!paragraph) paragraph = createParagraphNode();
+      return paragraph;
+    };
+
+    const commitParagraph = () => {
+      if (!paragraph) return;
+      const hasContent = paragraph.children.some(child => {
+        if (child.type === 'text') return child.value.trim().length > 0;
+        return child.type !== 'linebreak';
+      });
+      if (hasContent) {
+        nodes.push(paragraph);
+      }
+      paragraph = createParagraphNode();
+    };
+
+    const appendText = text => {
+      if (!text) return;
+      const normalized = normalizeLineBreaks(text);
+      const parts = normalized.split(/\n{2,}/);
+      parts.forEach((part, index) => {
+        if (part) {
+          appendTextSegment(ensureParagraph(), part);
+        }
+        if (index < parts.length - 1) {
+          commitParagraph();
+        }
+      });
+    };
+
+    let cursor = 0;
+    while (cursor < source.length) {
+      const command = findCommand(source, cursor);
+      if (!command) {
+        appendText(source.slice(cursor));
+        break;
+      }
+      if (command.index > cursor) {
+        appendText(source.slice(cursor, command.index));
+      }
+      const { name, content, endIndex } = command;
+      const lowerName = name.toLowerCase();
+      if (lowerName === 'task') {
+        commitParagraph();
+        nodes.push({ type: 'task', children: parseDescriptionToAst(content) });
+      } else if (lowerName === 'table') {
+        commitParagraph();
+        const table = parseTable(content);
+        if (table) {
+          nodes.push({ type: 'table', headers: table.headers, rows: table.rows });
+        } else {
+          appendText(`@${name}{${content}}`);
+        }
+      } else if (lowerName === 'answerbox') {
+        ensureParagraph().children.push({ type: 'answerbox', value: content });
+      } else {
+        appendText(`@${name}{${content}}`);
+      }
+      cursor = endIndex;
+    }
+
+    commitParagraph();
+    return nodes;
+  }
+
+  function normalizeAnswer(value) {
+    const raw = typeof value === 'string' ? value.trim() : '';
+    if (!raw) return { type: 'empty', value: '' };
+    const numericCandidate = raw.replace(',', '.');
+    if (/^[+-]?\d+(?:[.,]\d+)?$/.test(raw)) {
+      const num = Number(numericCandidate);
+      if (Number.isFinite(num)) {
+        return { type: 'number', value: num.toFixed(10).replace(/\.0+$/, '').replace(/0+$/, '').replace(/\.$/, '') };
+      }
+    }
+    return { type: 'text', value: raw.toLowerCase() };
+  }
+
+  function answersMatch(input, expected) {
+    const a = normalizeAnswer(input);
+    const b = normalizeAnswer(expected);
+    if (a.type === 'empty') return false;
+    if (a.type === 'number' && b.type === 'number') {
+      return a.value === b.value;
+    }
+    return a.value === b.value;
+  }
+
+  function parseAnswerSpec(value) {
+    if (typeof value !== 'string') return [];
+    return value
+      .split('|')
+      .map(part => part.trim())
+      .filter(Boolean);
+  }
+
+  function appendTextWithMath(container, text, context) {
+    if (!text) return;
+    const doc = container.ownerDocument || (globalScope && globalScope.document);
+    if (!doc) return;
+    const pattern = /\$(.+?)\$/g;
+    let lastIndex = 0;
+    let match;
+    while ((match = pattern.exec(text)) !== null) {
+      const before = text.slice(lastIndex, match.index);
+      if (before) container.appendChild(doc.createTextNode(before));
+      const latex = match[1];
+      const span = doc.createElement('span');
+      span.className = 'example-katex';
+      span.textContent = latex;
+      span.dataset.katex = latex;
+      context.katexElements.push(span);
+      container.appendChild(span);
+      lastIndex = pattern.lastIndex;
+    }
+    const after = text.slice(lastIndex);
+    if (after) container.appendChild(doc.createTextNode(after));
+  }
+
+  function createAnswerBox(value, context) {
+    const doc = (context && context.doc) || (globalScope && globalScope.document);
+    if (!doc) return null;
+    const answers = parseAnswerSpec(value);
+    const wrapper = doc.createElement('span');
+    wrapper.className = 'example-answerbox';
+    const input = doc.createElement('input');
+    input.type = 'text';
+    input.autocomplete = 'off';
+    input.spellcheck = false;
+    input.className = 'example-answerbox__input';
+    input.setAttribute('aria-label', 'Svar');
+    const status = doc.createElement('span');
+    status.className = 'example-answerbox__status';
+    status.setAttribute('aria-live', 'polite');
+    status.textContent = '';
+    wrapper.appendChild(input);
+    wrapper.appendChild(status);
+    context.answerBoxes.push({ box: wrapper, input, status, answers });
+    return wrapper;
+  }
+
+  function renderAstNodes(nodes, context) {
+    const doc = context.doc;
+    const fragment = doc.createDocumentFragment();
+    nodes.forEach(node => {
+      if (!node) return;
+      if (node.type === 'paragraph') {
+        const p = doc.createElement('p');
+        node.children.forEach(child => {
+          if (!child) return;
+          if (child.type === 'text') {
+            appendTextWithMath(p, child.value, context);
+          } else if (child.type === 'linebreak') {
+            p.appendChild(doc.createElement('br'));
+          } else if (child.type === 'answerbox') {
+            const box = createAnswerBox(child.value, context);
+            if (box) p.appendChild(box);
+          }
+        });
+        if (p.childNodes.length) {
+          fragment.appendChild(p);
+        }
+      } else if (node.type === 'task') {
+        const task = doc.createElement('div');
+        task.className = 'example-task';
+        const body = doc.createElement('div');
+        body.className = 'example-task__body';
+        const inner = renderAstNodes(node.children || [], context);
+        body.appendChild(inner);
+        task.appendChild(body);
+        fragment.appendChild(task);
+      } else if (node.type === 'table') {
+        const table = doc.createElement('table');
+        table.className = 'example-description-table';
+        const columnCount = Math.max(node.headers.length, ...(node.rows || []).map(row => row.length));
+        if (node.headers && node.headers.length) {
+          const thead = doc.createElement('thead');
+          const tr = doc.createElement('tr');
+          for (let i = 0; i < columnCount; i++) {
+            const th = doc.createElement('th');
+            const value = node.headers[i] != null ? node.headers[i] : '';
+            appendTextWithMath(th, value, context);
+            tr.appendChild(th);
+          }
+          thead.appendChild(tr);
+          table.appendChild(thead);
+        }
+        const tbody = doc.createElement('tbody');
+        (node.rows || []).forEach(row => {
+          const tr = doc.createElement('tr');
+          for (let i = 0; i < columnCount; i++) {
+            const td = doc.createElement('td');
+            const value = row[i] != null ? row[i] : '';
+            appendTextWithMath(td, value, context);
+            tr.appendChild(td);
+          }
+          tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+        fragment.appendChild(table);
+      }
+    });
+    return fragment;
+  }
+
+  function attachAnswerHandlers(answerBoxes) {
+    answerBoxes.forEach(item => {
+      if (!item || !item.input) return;
+      const { input, box, status, answers } = item;
+      const update = () => {
+        const value = input.value || '';
+        if (!value.trim()) {
+          box.classList.remove('example-answerbox--correct', 'example-answerbox--incorrect');
+          if (status) status.textContent = '';
+          return;
+        }
+        const isCorrect = answers.length ? answers.some(answer => answersMatch(value, answer)) : false;
+        box.classList.toggle('example-answerbox--correct', isCorrect);
+        box.classList.toggle('example-answerbox--incorrect', !isCorrect);
+        if (status) status.textContent = isCorrect ? 'Riktig!' : 'Prøv igjen';
+      };
+      item.update = update;
+      input.addEventListener('input', update);
+      input.addEventListener('change', update);
+      update();
+    });
+  }
+
+  function renderKatexElements(elements, attempt = 0) {
+    if (!elements || !elements.length) return;
+    const katex = globalScope && globalScope.katex;
+    if (!katex || typeof katex.render !== 'function') {
+      if (globalScope && typeof globalScope.setTimeout === 'function' && attempt < MAX_KATEX_ATTEMPTS) {
+        globalScope.setTimeout(() => renderKatexElements(elements, attempt + 1), 100 * (attempt + 1));
+      }
+      return;
+    }
+    elements.forEach(element => {
+      if (!element || !element.dataset) return;
+      const latex = element.dataset.katex;
+      const fallback = element.textContent || '';
+      try {
+        katex.render(latex || '', element, { throwOnError: false });
+      } catch (error) {
+        element.textContent = fallback;
+      }
+    });
+  }
+
+  function renderDescription(value, options) {
+    const doc = (options && options.document) || (globalScope && globalScope.document);
+    if (!doc) {
+      return {
+        fragment: null,
+        meta: { answerBoxes: [], katexElements: [] },
+        hasContent: false
+      };
+    }
+    const ast = parseDescriptionToAst(value);
+    const context = {
+      doc,
+      answerBoxes: [],
+      katexElements: []
+    };
+    const fragment = renderAstNodes(ast, context);
+    const hasContent = fragment && fragment.childNodes && fragment.childNodes.length > 0;
+    return { fragment, meta: context, hasContent };
+  }
+
+  function renderInto(container, value, options) {
+    if (!container) {
+      return renderDescription(value, options);
+    }
+    const result = renderDescription(value, { document: container.ownerDocument });
+    while (container.firstChild) {
+      container.removeChild(container.firstChild);
+    }
+    if (result.fragment) {
+      container.appendChild(result.fragment);
+    }
+    const enableKatex = !options || options.enableKatex !== false;
+    const enableAnswers = !options || options.enableAnswers !== false;
+    if (enableKatex) {
+      renderKatexElements(result.meta.katexElements || []);
+    }
+    if (enableAnswers) {
+      attachAnswerHandlers(result.meta.answerBoxes || []);
+    }
+    return result;
+  }
+
+  const helpers = {
+    parseToAst: parseDescriptionToAst,
+    render: renderDescription,
+    renderInto,
+    attachAnswerHandlers,
+    renderKatexElements
+  };
+
+  if (globalScope) {
+    globalScope.__EXAMPLES_DESCRIPTION__ = helpers;
+  }
+
+  return helpers;
+})();
+
 (function () {
   const globalScope = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
   const DEFAULT_APP_MODE = 'default';
@@ -1159,105 +1556,15 @@
     }
   }
 
-  function appendDescriptionText(fragment, text) {
-    if (!fragment || typeof fragment.appendChild !== 'function') return;
-    if (typeof text !== 'string') return;
-    const normalized = text.replace(/\r\n?/g, '\n');
-    const paragraphs = normalized.split(/\n{2,}/);
-    paragraphs.forEach(paragraph => {
-      if (!paragraph.trim()) return;
-      const lines = paragraph.split('\n');
-      const p = document.createElement('p');
-      lines.forEach((line, index) => {
-        p.appendChild(document.createTextNode(line));
-        if (index < lines.length - 1) {
-          p.appendChild(document.createElement('br'));
-        }
-      });
-      fragment.appendChild(p);
-    });
-  }
-
-  function createDescriptionTable(content) {
-    if (typeof content !== 'string') return null;
-    const normalized = content.replace(/\r\n?/g, '\n').trim();
-    if (!normalized) return null;
-    const lines = normalized
-      .split('\n')
-      .map(line => line.trim())
-      .filter(line => line);
-    if (!lines.length) return null;
-    const rows = lines.map(line => line.split('|').map(cell => cell.trim()));
-    const columnCount = rows.reduce((max, row) => (row.length > max ? row.length : max), 0);
-    if (!columnCount) return null;
-    const table = document.createElement('table');
-    table.className = 'example-description-table';
-    let bodyStartIndex = 0;
-    if (rows.length > 1) {
-      const thead = document.createElement('thead');
-      const headRow = document.createElement('tr');
-      for (let i = 0; i < columnCount; i++) {
-        const th = document.createElement('th');
-        th.textContent = rows[0][i] != null ? rows[0][i] : '';
-        headRow.appendChild(th);
-      }
-      thead.appendChild(headRow);
-      table.appendChild(thead);
-      bodyStartIndex = 1;
-    }
-    const tbody = document.createElement('tbody');
-    const appendRow = row => {
-      const tr = document.createElement('tr');
-      for (let i = 0; i < columnCount; i++) {
-        const cell = document.createElement('td');
-        cell.textContent = row && row[i] != null ? row[i] : '';
-        tr.appendChild(cell);
-      }
-      tbody.appendChild(tr);
-    };
-    if (rows.length === 1) {
-      appendRow(rows[0]);
-    } else {
-      for (let i = bodyStartIndex; i < rows.length; i++) {
-        appendRow(rows[i]);
-      }
-    }
-    table.appendChild(tbody);
-    return table;
-  }
-
-  function buildDescriptionPreview(value) {
-    const fragment = document.createDocumentFragment();
-    if (typeof value !== 'string') return fragment;
-    const normalized = value.replace(/\r\n?/g, '\n');
-    const pattern = /@table\s*\{([\s\S]*?)\}/gi;
-    let lastIndex = 0;
-    let match = null;
-    while ((match = pattern.exec(normalized)) !== null) {
-      const before = normalized.slice(lastIndex, match.index);
-      appendDescriptionText(fragment, before);
-      const table = createDescriptionTable(match[1]);
-      if (table) {
-        fragment.appendChild(table);
-      } else {
-        appendDescriptionText(fragment, match[0]);
-      }
-      lastIndex = pattern.lastIndex;
-    }
-    const after = normalized.slice(lastIndex);
-    appendDescriptionText(fragment, after);
-    return fragment;
-  }
-
   function renderDescriptionPreviewFromValue(value) {
     const preview = getDescriptionPreviewElement();
     if (!preview) return;
-    clearChildren(preview);
-    const fragment = buildDescriptionPreview(typeof value === 'string' ? value : '');
-    const hasContent = fragment && fragment.childNodes && fragment.childNodes.length > 0;
-    if (hasContent) {
-      preview.appendChild(fragment);
-    }
+    const renderer = DESCRIPTION_RENDERER;
+    const result = renderer.renderInto(preview, typeof value === 'string' ? value : '', {
+      enableKatex: true,
+      enableAnswers: true
+    });
+    const hasContent = !!(result && result.hasContent);
     preview.dataset.empty = hasContent ? 'false' : 'true';
     preview.hidden = !hasContent;
     preview.setAttribute('aria-hidden', hasContent ? 'false' : 'true');
@@ -1778,8 +2085,10 @@
         return window.parent;
       } catch (_) {
         return null;
-      }
-    })();
+  }
+})();
+
+
     const normalizedIndex = Number.isInteger(index) && index >= 0 ? index : null;
     const exampleNumber = normalizedIndex != null ? normalizedIndex + 1 : null;
     try {

--- a/split.css
+++ b/split.css
@@ -181,6 +181,90 @@ body[data-app-mode="task"] .grid.split-enabled {
   font-weight: 600;
 }
 
+.example-description,
+.example-description-preview {
+  --example-desc-border: #d1d5db;
+  --example-desc-surface: #f9fafb;
+  --example-desc-correct: #047857;
+  --example-desc-correct-bg: #ecfdf5;
+  --example-desc-incorrect: #b91c1c;
+  --example-desc-incorrect-bg: #fef2f2;
+  --example-desc-muted: #6b7280;
+  color: inherit;
+}
+
+.example-description .example-task,
+.example-description-preview .example-task {
+  border: 1px solid var(--example-desc-border);
+  border-radius: 10px;
+  background: var(--example-desc-surface);
+  padding: 12px 14px;
+  margin: 12px 0;
+}
+
+.example-description .example-task:first-child,
+.example-description-preview .example-task:first-child {
+  margin-top: 0;
+}
+
+.example-description .example-task__body,
+.example-description-preview .example-task__body {
+  display: block;
+}
+
+.example-description .example-answerbox,
+.example-description-preview .example-answerbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 4px;
+}
+
+.example-description .example-answerbox__input,
+.example-description-preview .example-answerbox__input {
+  font: inherit;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--example-desc-border);
+  background: #fff;
+  min-width: 5.5rem;
+}
+
+.example-description .example-answerbox__status,
+.example-description-preview .example-answerbox__status {
+  font-size: 0.85rem;
+  color: var(--example-desc-muted);
+  min-height: 1.2em;
+}
+
+.example-description .example-answerbox--correct .example-answerbox__input,
+.example-description-preview .example-answerbox--correct .example-answerbox__input {
+  border-color: var(--example-desc-correct);
+  background: var(--example-desc-correct-bg);
+}
+
+.example-description .example-answerbox--incorrect .example-answerbox__input,
+.example-description-preview .example-answerbox--incorrect .example-answerbox__input {
+  border-color: var(--example-desc-incorrect);
+  background: var(--example-desc-incorrect-bg);
+}
+
+.example-description .example-answerbox--correct .example-answerbox__status,
+.example-description-preview .example-answerbox--correct .example-answerbox__status {
+  color: var(--example-desc-correct);
+}
+
+.example-description .example-answerbox--incorrect .example-answerbox__status,
+.example-description-preview .example-answerbox--incorrect .example-answerbox__status {
+  color: var(--example-desc-incorrect);
+}
+
+.example-description .example-katex,
+.example-description-preview .example-katex {
+  display: inline-block;
+  margin: 0 2px;
+}
+
 .card--examples .example-description label {
   display: flex;
   align-items: center;

--- a/tests/examples-description.spec.js
+++ b/tests/examples-description.spec.js
@@ -1,0 +1,70 @@
+const { test, expect } = require('@playwright/test');
+
+const AUTHOR_PATH = '/diagram/index.html';
+const VIEWER_PATH = '/examples-viewer.html';
+const STORAGE_KEY = 'examples_/diagram/index.html';
+const SAMPLE_DESCRIPTION = `
+@task{Regn ut $2+2$ og skriv svaret: @answerbox{4|04}}
+@task{Skriv brøken som desimal: @answerbox{1/2|0.5|0,5}}
+@table{
+Oppgave|Fasit
+1|4
+2|1/2
+}
+`;
+
+test.describe('Description renderer parity', () => {
+  test('viewer matches author preview rendering and behaviour', async ({ page }) => {
+    await page.goto(AUTHOR_PATH, { waitUntil: 'load' });
+
+    const descriptionField = page.locator('#exampleDescription');
+    await descriptionField.fill(SAMPLE_DESCRIPTION.trim());
+
+    const preview = page.locator('.example-description-preview');
+    await expect(preview).toHaveAttribute('data-empty', 'false');
+    await expect(preview.locator('.example-task')).toHaveCount(2);
+    await expect(preview.locator('.example-answerbox__input')).toHaveCount(2);
+    await expect(preview.locator('.katex')).toHaveCount(1);
+
+    const previewHTML = await preview.evaluate(el => el.innerHTML);
+
+    // Validate behaviour in the author preview
+    const previewFirstAnswer = preview.locator('.example-answerbox').first();
+    const previewSecondAnswer = preview.locator('.example-answerbox').nth(1);
+    await previewFirstAnswer.locator('.example-answerbox__input').fill('4');
+    await expect(previewFirstAnswer).toHaveClass(/example-answerbox--correct/);
+    await previewSecondAnswer.locator('.example-answerbox__input').fill('0,5');
+    await expect(previewSecondAnswer).toHaveClass(/example-answerbox--correct/);
+
+    // Prepare viewer with the same stored example
+    const viewerPage = await page.context().newPage();
+    await viewerPage.addInitScript(({ key, value }) => {
+      try {
+        window.localStorage.clear();
+      } catch (error) {}
+      if (window.__EXAMPLES_STORAGE__ && window.__EXAMPLES_STORAGE__ !== window.localStorage) {
+        try {
+          window.__EXAMPLES_STORAGE__.clear();
+        } catch (error) {}
+      }
+      window.localStorage.setItem(key, value);
+    }, { key: STORAGE_KEY, value: JSON.stringify([{ description: SAMPLE_DESCRIPTION.trim() }]) });
+
+    await viewerPage.goto(VIEWER_PATH, { waitUntil: 'load' });
+    const viewerDescription = viewerPage.locator('section .example-description').first();
+    await expect(viewerDescription).toHaveCount(1);
+    await expect(viewerDescription.locator('.example-task')).toHaveCount(2);
+    await expect(viewerDescription.locator('.example-answerbox__input')).toHaveCount(2);
+    await expect(viewerDescription.locator('.katex')).toHaveCount(1);
+
+    const viewerHTML = await viewerDescription.evaluate(el => el.innerHTML);
+    expect(viewerHTML).toBe(previewHTML);
+
+    const viewerFirstAnswer = viewerDescription.locator('.example-answerbox').first();
+    const viewerSecondAnswer = viewerDescription.locator('.example-answerbox').nth(1);
+    await viewerFirstAnswer.locator('.example-answerbox__input').fill('4');
+    await expect(viewerFirstAnswer).toHaveClass(/example-answerbox--correct/);
+    await viewerSecondAnswer.locator('.example-answerbox__input').fill('0.5');
+    await expect(viewerSecondAnswer).toHaveClass(/example-answerbox--correct/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared description renderer that parses @task/@answerbox/@table markup with answer checking and KaTeX support
- integrate the renderer in both the author preview and the examples viewer and update styles for the new task layout
- create a standalone viewer page and an automated Playwright regression test covering author/viewer parity

## Testing
- `npm test` *(fails: Playwright browsers require system libraries in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e4261d7dc48324bb283f56eb8e0cd1