### PR TITLE
Prevent example saves from jumping to other tabs

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -2007,6 +2007,8 @@
     }
     if (applied) {
       currentExampleIndex = index;
+      pendingRequestedIndex = null;
+      initialLoadPerformed = true;
       updateTabSelection();
       triggerRefresh(index);
       notifyParentExampleChange(index);


### PR DESCRIPTION
## Summary
- clear the pending requested index and mark the initial load as completed when loading an example so manual saves stay on the current tab

## Testing
- npm test *(fails: Playwright browsers require additional system dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4cf69ca74832482afdaa4e6a36e5f