### PR TITLE
Fix description renderer preview visibility

### DIFF
--- a/description-renderer.js
+++ b/description-renderer.js
@@ -665,11 +665,11 @@
     }
     const parsed = parse(typeof value === 'string' ? value : '');
     const { fragment, placeholders, answerBoxes } = parsed;
+    const hasContent = !!(fragment && fragment.childNodes && fragment.childNodes.length);
     if (fragment) {
       target.appendChild(fragment);
     }
     target.classList.add('math-vis-description-rendered');
-    const hasContent = !!(fragment && fragment.childNodes && fragment.childNodes.length);
     if (placeholders.length) {
       const schedule = () => {
         ensureKatexLoaded()


### PR DESCRIPTION
## Summary
- ensure the description renderer detects content before appending fragments so previews remain visible

## Testing
- npx playwright test tests/description-interactions.spec.js tests/task-mode-description.spec.js --reporter=line --workers=1 *(fails: missing Playwright browser dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ea23e430832499925105827d49e0