### PR TITLE
Ensure thinking blocks keep uniform height

### DIFF
--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -135,11 +135,7 @@ function hasVisibleBlockBelow(block) {
 }
 function getRowSpanRatios(block) {
   const topRatio = clamp(TOP_RATIO, 0, 1);
-  let bottomRatio = clamp(BOTTOM_RATIO, topRatio, 1);
-  const hasBlockBelow = block && typeof block.hasVisibleBlockBelow === 'boolean' ? block.hasVisibleBlockBelow : hasVisibleBlockBelow(block);
-  if (hasBlockBelow) {
-    bottomRatio = 1;
-  }
+  const bottomRatio = clamp(BOTTOM_RATIO, topRatio, 1);
   return {
     topRatio,
     bottomRatio


### PR DESCRIPTION
## Summary
- keep all thinking blocks at a consistent height regardless of underlying rows by removing conditional stretching logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ebfc77a483249fc1f98908560479