### PR TITLE
Ensure nkant alt text follows saved examples

### DIFF
--- a/nkant.js
+++ b/nkant.js
@@ -3356,6 +3356,23 @@ window.addEventListener("DOMContentLoaded", async () => {
   initAltTextManager();
   await renderCombined();
 });
+
+window.addEventListener("examples:loaded", () => {
+  applyStateToUI();
+  if (!altTextManager) {
+    initAltTextManager();
+  }
+  if (altTextManager) {
+    altTextManager.applyCurrent();
+    maybeRefreshAltText("examples");
+  }
+});
+
+window.addEventListener("examples:collect", () => {
+  if (altTextManager) {
+    altTextManager.applyCurrent();
+  }
+});
 function applyStateToUI() {
   var _STATE$specsText;
   const specInput = document.getElementById("inpSpecs");


### PR DESCRIPTION
## Summary
- refresh nkant UI and alt-text manager when switching between saved examples
- reapply current alt text before saving to keep descriptions aligned with figures

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4eb6598b883248fd5f4b17f497a27