### PR TITLE
Fix examples API origin fallback

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -496,8 +496,15 @@
       const value = String(window.MATH_VISUALS_EXAMPLES_API_URL).trim();
       if (value) return value;
     }
-    const origin = window.location && window.location.origin;
-    if (typeof origin === 'string' && /^https?:/i.test(origin)) {
+    const { location } = window;
+    if (!location || typeof location !== 'object') return null;
+    const origin = typeof location.origin === 'string' && location.origin ? location.origin : null;
+    if (origin && /^https?:/i.test(origin)) {
+      return '/api/examples';
+    }
+    const protocol = typeof location.protocol === 'string' ? location.protocol : '';
+    const host = typeof location.host === 'string' ? location.host : '';
+    if (protocol && /^https?:$/i.test(protocol) && host) {
       return '/api/examples';
     }
     return null;

--- a/tests/examples-api-base.spec.js
+++ b/tests/examples-api-base.spec.js
@@ -1,0 +1,46 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Examples API base detection', () => {
+  test('falls back to protocol/host when location.origin is unavailable', async ({ page, context }) => {
+    await context.addInitScript(() => {
+      try {
+        Object.defineProperty(Location.prototype, 'origin', {
+          configurable: true,
+          get() {
+            return undefined;
+          }
+        });
+      } catch (error) {
+        window.__ORIGIN_OVERRIDE_FAILED__ = true;
+      }
+
+      const recordedUrls = [];
+      window.__FETCH_URLS__ = recordedUrls;
+      const originalFetch = window.fetch;
+      window.fetch = (...args) => {
+        recordedUrls.push(args[0]);
+        return Promise.reject(new Error('fetch disabled for test'));
+      };
+      window.__RESTORE_FETCH__ = () => {
+        window.fetch = originalFetch;
+      };
+    });
+
+    const response = await page.goto('/nkant.html', { waitUntil: 'load' });
+    expect(response?.ok()).toBeTruthy();
+
+    const overrideFailed = await page.evaluate(() => window.__ORIGIN_OVERRIDE_FAILED__ === true);
+    expect(overrideFailed).toBe(false);
+
+    const fetchUrls = await page.evaluate(() => {
+      try {
+        if (typeof window.__RESTORE_FETCH__ === 'function') {
+          window.__RESTORE_FETCH__();
+        }
+      } catch (error) {}
+      return Array.isArray(window.__FETCH_URLS__) ? window.__FETCH_URLS__.slice() : [];
+    });
+
+    expect(fetchUrls.some(url => typeof url === 'string' && url.includes('/api/examples'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- update examples API base detection to fall back to protocol/host when `location.origin` is missing
- add a regression test that simulates missing `location.origin` and verifies a request to `/api/examples`

## Testing
- npm test (fails: description renderer interactions, task mode description preview)


------
https://chatgpt.com/codex/tasks/task_e_68e4f2971c5883249d61631d2a62534d