### PR TITLE
Add alt text generation to Brøkfigurer

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -191,7 +191,7 @@
             </div>
           </fieldset>
           <div id="figureSettings" class="figureSettings"></div>
-          <fieldset>
+          <fieldset id="exportCard">
             <legend>Eksport</legend>
             <div class="toolbar" id="exportToolbar">
               <button id="btnExportSvg" class="btn" type="button">Last ned SVG</button>
@@ -203,6 +203,7 @@
     </div>
   </div>
   <script src="theme-profiles.js"></script>
+  <script src="alt-text-ui.js"></script>
   <script src="brøkfigurer.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>


### PR DESCRIPTION
## Summary
- add the shared alt-text UI to the Brøkfigurer export tools
- generate descriptive alternative text for each Brøkfigurer layout and hook it into the UI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e50b88ca0483248f9adbb7b0a58230