### PR TITLE
Fix right angle fill for nkant height annotations

### DIFF
--- a/nkant.js
+++ b/nkant.js
@@ -2073,7 +2073,10 @@ function drawTriangleToGroup(g, rect, spec, adv, decorations) {
         x: vertex.x - heightPoint.x,
         y: vertex.y - heightPoint.y
       };
-      drawRightAngleMarker(g, heightPoint, baseDir, altDir);
+      const shouldDrawMarker = !(heightAngleMode.angleText || heightAngleMode.pointLabel);
+      if (shouldDrawMarker) {
+        drawRightAngleMarker(g, heightPoint, baseDir, altDir);
+      }
     }
   }
 
@@ -2099,9 +2102,9 @@ function drawTriangleToGroup(g, rect, spec, adv, decorations) {
   const Ares = parseAnglePointMode((_am$A = am.A) !== null && _am$A !== void 0 ? _am$A : am.default, angleAVal, at.A, "A");
   const Bres = parseAnglePointMode((_am$B = am.B) !== null && _am$B !== void 0 ? _am$B : am.default, angleBVal, at.B, "B");
   const Cres = parseAnglePointMode((_am$C = am.C) !== null && _am$C !== void 0 ? _am$C : am.default, angleCVal, at.C, "C");
-  if (activeHeight && heightAngleMode && (heightAngleMode.angleText || heightAngleMode.pointLabel)) {
+  if (activeHeight && heightAngleMode && (heightAngleMode.mark || heightAngleMode.angleText || heightAngleMode.pointLabel)) {
     renderAngle(g, heightPoint, baseForAngle, activeHeight.vertex, angleRadius(heightPoint, baseForAngle, activeHeight.vertex), {
-      mark: false,
+      mark: heightAngleMode.mark,
       angleText: heightAngleMode.angleText,
       pointLabel: heightAngleMode.pointLabel
     });


### PR DESCRIPTION
## Summary
- ensure the height angle rendering uses the mark flag so right angles get the same filled styling as other vertices
- avoid drawing the construction-style right-angle marker when text or labels are present to prevent duplicate outlines

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e50e497a208324a6209feb20be6347