### PR TITLE
Align prikk til prikk axis labels with coordinate settings

### DIFF
--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -905,15 +905,9 @@
     return Math.min(decimals + 1, 6);
   }
 
-  function formatAxisValue(value, decimals) {
+  function formatAxisValue(value) {
     if (!Number.isFinite(value)) return '0';
-    const precision = Number.isFinite(decimals) && decimals >= 0 ? Math.min(6, Math.max(0, Math.floor(decimals))) : 2;
-    const fixed = value.toFixed(precision);
-    const trimmed = fixed
-      .replace(/(\.\d*?[1-9])0+$/, '$1')
-      .replace(/\.0+$/, '')
-      .replace(/^-0$/, '0');
-    return trimmed;
+    return percentString(value);
   }
 
   function makeLineKey(a, b) {


### PR DESCRIPTION
## Summary
- update the axis label formatter to show percentage values so they match the coordinate controls

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68e524644cb48324a9b86ace6d19b680