### PR TITLE
Ensure task description appears above figure on small screens

### DIFF
--- a/base.css
+++ b/base.css
@@ -178,6 +178,19 @@ body[data-app="graftegner"] .layout--sidebar:not(.split-enabled) > :not(.side) {
     grid-column: auto;
     grid-row: auto;
   }
+
+  body[data-app-mode="task"] .layout--sidebar {
+    display: flex;
+    flex-direction: column;
+  }
+
+  body[data-app-mode="task"] .layout--sidebar > .side {
+    order: 1;
+  }
+
+  body[data-app-mode="task"] .layout--sidebar > :not(.side) {
+    order: 2;
+  }
 }
 
 .side {


### PR DESCRIPTION
## Summary
- adjust the layout for task mode on narrow screens so the task description column renders before the visualization card

## Testing
- PW_DISABLE_CLI_PROGRESS_BAR=1 npm test *(fails: Playwright cannot download/launch Chromium because required system dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68e542be24588324b10a8179ccf1dc54