### PR TITLE
Ensure Playwright dependencies are installed before tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 playwright-report/
 test-results/
+.cache/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "arealmodell0.js",
   "scripts": {
+    "pretest": "node scripts/ensure-playwright-deps.js",
     "test": "node tests/check-shared-styles.js && playwright test",
     "start": "npx http-server -c-1"
   },

--- a/scripts/ensure-playwright-deps.js
+++ b/scripts/ensure-playwright-deps.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const CACHE_DIR = path.join(__dirname, '..', '.cache');
+const SENTINEL = path.join(CACHE_DIR, 'playwright-deps-installed');
+
+if (process.env.SKIP_PLAYWRIGHT_DEPS_INSTALL) {
+  process.exit(0);
+}
+
+if (process.platform !== 'linux') {
+  process.exit(0);
+}
+
+if (fs.existsSync(SENTINEL)) {
+  process.exit(0);
+}
+
+if (process.getuid && process.getuid() !== 0) {
+  console.error('[playwright] Missing browser system dependencies.');
+  console.error('Run `sudo npx playwright install-deps` (or manually install the dependencies) before running the tests.');
+  process.exit(1);
+}
+
+const result = spawnSync('npx', ['playwright', 'install-deps'], { stdio: 'inherit' });
+if (result.status !== 0) {
+  console.error('[playwright] Failed to install system dependencies automatically.');
+  console.error('Please run `npx playwright install-deps` manually to review the error output.');
+  process.exit(result.status ?? 1);
+}
+
+fs.mkdirSync(CACHE_DIR, { recursive: true });
+fs.writeFileSync(SENTINEL, String(Date.now()));


### PR DESCRIPTION
## Summary
- add a pretest hook that installs Playwright browser system dependencies before running the suite
- cache the installation with a sentinel file so the setup runs only once per environment
- ignore the generated cache directory

## Testing
- npm test (fails: Example storage fallback notice did not appear in tests/examples-fallback-storage.spec.js)


------
https://chatgpt.com/codex/tasks/task_e_68e54563ec948324801da4940610aa65