### PR TITLE
Remove delete example confirmation dialog

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -2897,9 +2897,6 @@
     if (examples.length <= 1) {
       return;
     }
-    if (!window.confirm('Er du sikker på at du vil slette dette eksempelet for alle? Velg "Ja" eller "nei".')) {
-      return;
-    }
     let indexToRemove = Number.isInteger(currentExampleIndex) ? currentExampleIndex : NaN;
     if (!Number.isInteger(indexToRemove)) {
       var _tabsContainer;


### PR DESCRIPTION
## Summary
- remove the browser confirmation before deleting an example so the action completes immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e54e838c0883249ba932de9c4caa0a