### PR TITLE
Handle Playwright dependency installs without root

### DIFF
--- a/scripts/ensure-playwright-deps.js
+++ b/scripts/ensure-playwright-deps.js
@@ -19,9 +19,10 @@ if (fs.existsSync(SENTINEL)) {
 }
 
 if (process.getuid && process.getuid() !== 0) {
-  console.error('[playwright] Missing browser system dependencies.');
-  console.error('Run `sudo npx playwright install-deps` (or manually install the dependencies) before running the tests.');
-  process.exit(1);
+  console.warn('[playwright] Missing browser system dependencies.');
+  console.warn('[playwright] Skipping automatic installation because this process does not have root privileges.');
+  console.warn('[playwright] Run `sudo npx playwright install-deps` manually if browser tests fail to launch.');
+  process.exit(0);
 }
 
 const env = { ...process.env };


### PR DESCRIPTION
## Summary
- avoid failing the Playwright dependency helper when the process lacks root privileges
- emit guidance to install the dependencies manually instead of exiting with an error

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e550e724848324adc3ff8550ee5376