### PR TITLE
Address non-root failure in Playwright dependency pretest script

### DIFF
--- a/scripts/ensure-playwright-deps.js
+++ b/scripts/ensure-playwright-deps.js
@@ -6,30 +6,70 @@ const path = require('path');
 const CACHE_DIR = path.join(__dirname, '..', '.cache');
 const SENTINEL = path.join(CACHE_DIR, 'playwright-deps-installed');
 
-if (process.env.SKIP_PLAYWRIGHT_DEPS_INSTALL) {
-  process.exit(0);
+async function markInstalled() {
+  await fs.promises.mkdir(CACHE_DIR, { recursive: true });
+  await fs.promises.writeFile(SENTINEL, String(Date.now()));
 }
 
-if (process.platform !== 'linux') {
-  process.exit(0);
+async function validateDependencies() {
+  try {
+    const { registry } = require('playwright-core/lib/server/registry');
+    const { getEmbedderName } = require('playwright-core/lib/server/utils/userAgent');
+    const executables = registry.defaultExecutables();
+    if (!executables.length) {
+      return { ok: true };
+    }
+    const { embedderName } = getEmbedderName();
+    await registry.validateHostRequirementsForExecutablesIfNeeded(executables, embedderName);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error };
+  }
 }
 
-if (fs.existsSync(SENTINEL)) {
-  process.exit(0);
+async function main() {
+  if (process.env.SKIP_PLAYWRIGHT_DEPS_INSTALL) {
+    return;
+  }
+
+  if (process.platform !== 'linux') {
+    return;
+  }
+
+  if (fs.existsSync(SENTINEL)) {
+    return;
+  }
+
+  const validationResult = await validateDependencies();
+  if (validationResult.ok) {
+    await markInstalled();
+    return;
+  }
+
+  const errorMessage = validationResult.error?.message?.trim() || validationResult.error?.toString();
+  if (errorMessage) {
+    console.error('[playwright] Unable to verify system dependencies automatically.');
+    console.error(errorMessage);
+  }
+
+  if (process.getuid && process.getuid() !== 0) {
+    console.error('[playwright] Missing browser system dependencies.');
+    console.error('Run `sudo npx playwright install-deps` (or manually install the dependencies) before running the tests.');
+    process.exit(1);
+  }
+
+  const result = spawnSync('npx', ['playwright', 'install-deps'], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.error('[playwright] Failed to install system dependencies automatically.');
+    console.error('Please run `npx playwright install-deps` manually to review the error output.');
+    process.exit(result.status ?? 1);
+  }
+
+  await markInstalled();
 }
 
-if (process.getuid && process.getuid() !== 0) {
-  console.error('[playwright] Missing browser system dependencies.');
-  console.error('Run `sudo npx playwright install-deps` (or manually install the dependencies) before running the tests.');
+main().catch((error) => {
+  const message = error?.message || error?.toString() || 'Unknown error';
+  console.error('[playwright] ensure-playwright-deps.js failed:', message);
   process.exit(1);
-}
-
-const result = spawnSync('npx', ['playwright', 'install-deps'], { stdio: 'inherit' });
-if (result.status !== 0) {
-  console.error('[playwright] Failed to install system dependencies automatically.');
-  console.error('Please run `npx playwright install-deps` manually to review the error output.');
-  process.exit(result.status ?? 1);
-}
-
-fs.mkdirSync(CACHE_DIR, { recursive: true });
-fs.writeFileSync(SENTINEL, String(Date.now()));
+});


### PR DESCRIPTION
## Summary
- fall back to Playwright's dependency validation before attempting installations
- mark the sentinel when validation succeeds so preinstalled dependencies skip the install step
- preserve automatic installation for root users while surfacing actionable errors for missing deps

## Testing
- not run (node executable is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e58f1a70308324b5d329aac7ede6cb