### PR TITLE
Ensure Graftegner examples load on first render

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -381,7 +381,7 @@
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
   <script src="alt-text-ui.js"></script>
   <script defer src="graftegner.js"></script>
-  <script src="examples.js"></script>
+  <script defer src="examples.js"></script>
   <script src="split.js"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- ensure the Graftegner examples loader script runs after the app code so the initial example appears without re-selecting tabs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5932f59308324aafa15dd4f88fa79