### PR TITLE
Update number line draggables to circular markers

### DIFF
--- a/tallinje.html
+++ b/tallinje.html
@@ -75,6 +75,12 @@
     .draggable-item.is-placed .draggable-item__bg { fill: #eef2ff; }
     .draggable-item.is-dragging, .draggable-item:active { cursor: grabbing; }
     .draggable-item__bg { fill: #fff; stroke: #6366f1; stroke-width: 2; }
+    .draggable-item__label {
+      border-radius: 999px;
+    }
+    .draggable-item__pointer { pointer-events: none; }
+    .draggable-item__pointer-line { stroke: #4f46e5; stroke-width: 3; stroke-linecap: round; }
+    .draggable-item__pointer-head { fill: #4f46e5; }
     .draggable-item__fo { pointer-events: none; }
     .draggable-item__label {
       width: 100%;


### PR DESCRIPTION
## Summary
- shrink draggable number line markers and render them as circles
- add a pointer indicator that links placed markers down to the number line
- adjust supporting styles so labels sit cleanly inside the new circular markers

## Testing
- not run (npm test) *(network restrictions while attempting to install Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e594752d7c8324bc5aa0cadc0da087