### PR TITLE
Add task check feedback for Tallinje

### DIFF
--- a/tallinje.html
+++ b/tallinje.html
@@ -116,6 +116,36 @@
     .btn--ghost:hover { background: #f3f4f6; }
     .btn--danger { border-color: #ef4444; color: #b91c1c; }
     .btn--danger:hover { background: #fee2e2; }
+    .btn--success { border-color: #34d399; color: #047857; background: #ecfdf5; }
+    .btn--success:hover { background: #d1fae5; }
+    .status {
+      display: none;
+      padding: 10px 12px;
+      border-radius: 12px;
+      border: 1px solid transparent;
+      font-size: 14px;
+      line-height: 1.4;
+    }
+    .status[hidden] { display: none; }
+    .status strong { display: block; margin-bottom: 4px; }
+    .status--success {
+      display: block;
+      background: #ecfdf5;
+      border-color: #a7f3d0;
+      color: #065f46;
+    }
+    .status--error {
+      display: block;
+      background: #fef2f2;
+      border-color: #fecaca;
+      color: #991b1b;
+    }
+    .status--info {
+      display: block;
+      background: #eff6ff;
+      border-color: #bfdbfe;
+      color: #1d4ed8;
+    }
   </style>
   <link rel="stylesheet" href="split.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-ywTprUI1Q+mEFz1Ok5AR52lCstOEPCTpQJZMa2+pzSQPwXTwns32xERiqnnn6T5+" crossorigin="anonymous" />
@@ -127,6 +157,10 @@
         <div class="figure">
           <svg id="numberLineSvg" viewBox="0 0 1000 260" preserveAspectRatio="xMidYMid meet" aria-label=""></svg>
         </div>
+        <div class="toolbar">
+          <button id="btnCheck" class="btn btn--success" type="button">Sjekk svar</button>
+        </div>
+        <div id="checkStatus" class="status" role="status" aria-live="polite" hidden></div>
       </div>
 
       <div class="side">


### PR DESCRIPTION
## Summary
- add a task-mode check button with success/error/info styling to the Tallinje app
- implement answer checking for draggable items, reporting missing and misplaced values

## Testing
- npm test *(fails: dependency installation was interrupted by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e596acc09883248fdc05c73d40c605