### PR TITLE
Ensure session fallback storage surfaces quota errors

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -393,17 +393,23 @@
       setItem(key, value) {
         try {
           sessionStorage.setItem(key, value);
-        } catch (_) {}
+        } catch (error) {
+          throw error;
+        }
       },
       removeItem(key) {
         try {
           sessionStorage.removeItem(key);
-        } catch (_) {}
+        } catch (error) {
+          throw error;
+        }
       },
       clear() {
         try {
           sessionStorage.clear();
-        } catch (_) {}
+        } catch (error) {
+          throw error;
+        }
       }
     };
   }


### PR DESCRIPTION
## Summary
- propagate errors from the session storage fallback wrapper so quota failures trigger a switch to in-memory storage

## Testing
- npm test -- --grep "Example storage fallback" *(fails: Playwright browsers could not be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6125da9fc8324b4efed8476f435a3