### PR TITLE
Fix fallback notice setup when storage quota errors occur

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -416,6 +416,11 @@
   let fallbackStorage = null;
   let fallbackStorageMode = 'memory';
   let fallbackStorageInitialized = false;
+  let memoryFallbackNoticePending = false;
+  let memoryFallbackNoticeRendered = false;
+  let memoryFallbackNoticeElement = null;
+  let memoryFallbackNoticeRenderTimeout = null;
+  let memoryFallbackNoticeDomReadyHandler = null;
   function applyFallbackStorage(store, mode) {
     fallbackStorage = store;
     fallbackStorageMode = mode === 'session' ? 'session' : 'memory';
@@ -2107,11 +2112,6 @@
   let defaultEnsureScheduled = false;
   let ensureDefaultsRunning = false;
   let tabsHostCard = null;
-  let memoryFallbackNoticePending = false;
-  let memoryFallbackNoticeRendered = false;
-  let memoryFallbackNoticeElement = null;
-  let memoryFallbackNoticeRenderTimeout = null;
-  let memoryFallbackNoticeDomReadyHandler = null;
 
   function resolveMemoryFallbackNoticeHost() {
     if (memoryFallbackNoticeElement && memoryFallbackNoticeElement.isConnected) {


### PR DESCRIPTION
## Summary
- move the example storage fallback notice state to be declared before the fallback storage initializer
- ensure the notice can be rendered when local/session storage immediately throws quota errors

## Testing
- npx playwright test tests/examples-fallback-storage.spec.js --project=chromium

------
https://chatgpt.com/codex/tasks/task_e_68e618af1c0883248c8294f08b7d470f