### PR TITLE
Fix example tabs initialization when fallback storage is used

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -417,6 +417,11 @@
   let fallbackStorageMode = 'memory';
   let fallbackStorageInitialized = false;
   let suppressMemoryFallbackNotice = false;
+  let memoryFallbackNoticePending = false;
+  let memoryFallbackNoticeRendered = false;
+  let memoryFallbackNoticeElement = null;
+  let memoryFallbackNoticeRenderTimeout = null;
+  let memoryFallbackNoticeDomReadyHandler = null;
   function applyFallbackStorage(store, mode) {
     fallbackStorage = store;
     fallbackStorageMode = mode === 'session' ? 'session' : 'memory';
@@ -2121,11 +2126,6 @@
   let defaultEnsureScheduled = false;
   let ensureDefaultsRunning = false;
   let tabsHostCard = null;
-  let memoryFallbackNoticePending = false;
-  let memoryFallbackNoticeRendered = false;
-  let memoryFallbackNoticeElement = null;
-  let memoryFallbackNoticeRenderTimeout = null;
-  let memoryFallbackNoticeDomReadyHandler = null;
 
   function hideMemoryFallbackNotice() {
     if (memoryFallbackNoticeRenderTimeout) {


### PR DESCRIPTION
## Summary
- declare memory fallback notice state before fallback storage initialization runs
- prevent the examples UI from crashing so the saved example tabs render again

## Testing
- npm test *(fails: Playwright browser download blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e628e5a88c83249fe0e4e784adb75a