### PR TITLE
Fix Tallinje settings checkbox layout

### DIFF
--- a/tallinje.html
+++ b/tallinje.html
@@ -30,8 +30,6 @@
       font-size: 12px;
       color: #6b7280;
     }
-    .checkbox-field { flex-direction: row; align-items: center; gap: 8px; font-weight: 500; }
-    .checkbox-field input[type="checkbox"] { width: auto; height: auto; margin: 0; }
     .number-line-base { stroke: #0f172a; stroke-width: 4; stroke-linecap: round; }
     .major-tick { stroke: #0f172a; stroke-width: 3; stroke-linecap: round; }
     .minor-tick { stroke: #4b5563; stroke-width: 2; stroke-linecap: round; opacity: 0.75; }
@@ -212,13 +210,13 @@
               <input id="cfg-labelFontSize" type="number" min="8" max="72" />
             </label>
           </div>
-          <label class="checkbox-field">
+          <label class="checkbox">
             <input id="cfg-clampLine" type="checkbox" />
-            Stopp tallinjen ved start- og sluttpunktet
+            <span>Stopp tallinjen ved start- og sluttpunktet</span>
           </label>
-          <label class="checkbox-field">
+          <label class="checkbox">
             <input id="cfg-lockLine" type="checkbox" />
-            Lås tallinje
+            <span>Lås tallinje</span>
           </label>
         </div>
 


### PR DESCRIPTION
## Summary
- update the Tallinje settings checkboxes to use the shared `.checkbox` markup so the input appears before its label text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e62a7c364883248e470325a4848735