### PR TITLE
Adjust nkant styling for campus profile

### DIFF
--- a/nkant.html
+++ b/nkant.html
@@ -324,6 +324,7 @@ Rettvinklet trekant</textarea>
     </div>
   </div>
 
+  <script src="theme-profiles.js"></script>
   <script src="alt-text-ui.js"></script>
   <script src="nkant.js"></script>
   <script src="examples.js"></script>


### PR DESCRIPTION
## Summary
- apply theme-aware styling overrides so the campus profile matches the provided design
- load the shared theme profile script on the nkant page and re-render figures when the active profile changes

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e62dcbeef48324955c3cdce92c9fce