### PR TITLE
Add app filter dropdown to examples archive

### DIFF
--- a/examples-trash.html
+++ b/examples-trash.html
@@ -49,6 +49,45 @@
       gap: 10px;
       align-items: center;
     }
+    .trash-filter {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-items: center;
+      padding: 6px 10px;
+      border: 1px solid rgba(15, 109, 143, 0.25);
+      border-radius: 12px;
+      background: #fff;
+      color: #0f172a;
+      font-size: 0.95rem;
+    }
+    .trash-filter__label {
+      font-weight: 600;
+    }
+    .trash-filter__select {
+      appearance: none;
+      border: 1px solid rgba(148, 163, 184, 0.6);
+      background: #f9fafb;
+      border-radius: 10px;
+      padding: 6px 24px 6px 10px;
+      font: inherit;
+      font-size: 0.95rem;
+      color: inherit;
+      cursor: pointer;
+      background-image: linear-gradient(45deg, transparent 50%, #0f6d8f 50%),
+        linear-gradient(135deg, #0f6d8f 50%, transparent 50%),
+        linear-gradient(to right, rgba(148, 163, 184, 0.6), rgba(148, 163, 184, 0.6));
+      background-position: calc(100% - 18px) calc(50% - 3px), calc(100% - 12px) calc(50% - 3px), calc(100% - 2.4em) 50%;
+      background-size: 6px 6px, 6px 6px, 1px 70%;
+      background-repeat: no-repeat;
+    }
+    .trash-filter__select:focus-visible {
+      outline: 2px solid #0f6d8f;
+      outline-offset: 2px;
+    }
+    .trash-filter__select option {
+      color: #0f172a;
+    }
     .trash-toolbar__button {
       appearance: none;
       border: 1px solid rgba(15, 109, 143, 0.25);
@@ -290,6 +329,12 @@
             eller slette dem permanent.
           </p>
           <div class="trash-toolbar">
+            <label class="trash-filter">
+              <span class="trash-filter__label">App:</span>
+              <select class="trash-filter__select" data-filter>
+                <option value="all">Alle apper</option>
+              </select>
+            </label>
             <button type="button" class="trash-toolbar__button" data-refresh>
               <span aria-hidden="true">⟳</span>
               Oppdater liste


### PR DESCRIPTION
## Summary
- add a toolbar dropdown that filters archived examples by app
- update the trash view to preserve filter selections, status messages, and empty state text
- keep the filter options in sync with storage changes so it always reflects available apps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e62ed636ac8324be4748ce426fcd82