### PR TITLE
Revise example management buttons to support updates

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -52,8 +52,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -38,8 +38,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -60,8 +60,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -167,8 +167,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -194,8 +194,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
 

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -185,8 +185,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
 

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -48,8 +48,9 @@
             </div>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
 

--- a/figurtall.html
+++ b/figurtall.html
@@ -140,8 +140,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -400,8 +400,9 @@
             </div>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
 

--- a/graftegner.html
+++ b/graftegner.html
@@ -245,8 +245,9 @@
             <div id="checkArea" class="checkbar" data-task-check-host hidden></div>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
 

--- a/kuler.html
+++ b/kuler.html
@@ -89,8 +89,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempler</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slette eksempler</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -82,8 +82,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -116,8 +116,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/nkant.html
+++ b/nkant.html
@@ -86,8 +86,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
 

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -48,8 +48,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
 

--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -420,8 +420,9 @@
             </div>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/tallinje.html
+++ b/tallinje.html
@@ -182,8 +182,9 @@
           </div>
           <div class="toolbar">
             <span class="badge badge--beta" aria-label="Tallinje er i betaversjon">Beta</span>
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
 

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -38,8 +38,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -172,8 +172,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div class="card" id="exportCard">

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -224,8 +224,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
           </div>
         </div>
         <div id="exportCard" class="card card--export">


### PR DESCRIPTION
## Summary
- add an "Oppdater eksempel" button alongside the existing toolbar actions on example-enabled pages and rename the other buttons to "Lag nytt eksempel" and "Arkiver eksempel"
- update the example management script to support updating the active example, track manual updates, and disable buttons when appropriate

## Testing
- npx playwright test tests/examples-persistence.spec.js *(fails: missing system dependencies for browser launch)*

------
https://chatgpt.com/codex/tasks/task_e_68e634f74d488324a0cc2b6a9052ecc5