### PR TITLE
Ensure app mode events fire on forced updates

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -203,7 +203,7 @@
     if (notifyParent && (changed || opts.alwaysNotify === true)) {
       postParentAppMode(normalized);
     }
-    if (changed && typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    if ((changed || force) && typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
       try {
         window.dispatchEvent(new CustomEvent('math-visuals:app-mode-changed', {
           detail: {


### PR DESCRIPTION
## Summary
- dispatch the math-visuals app mode change event even when forcing the current mode

## Testing
- npm test *(fails: Playwright browsers could not be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e637cc11ec8324b595dc008cc13d7c