### PR TITLE
Ensure Graftegner navigation links to example 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@
     </div>
     <ul id="nav-list">
       <li>
-        <a href="graftegner.html" target="content" data-label="Graftegner" aria-label="Graftegner">
+        <a href="graftegner.html" target="content" data-label="Graftegner" aria-label="Graftegner" data-default-example="1" data-include-example-in-path="true">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M6.5 8.5Q12 21 17.5 8.5" />


### PR DESCRIPTION
## Summary
- flag the Graftegner navigation entry with its default example and request an explicit example segment in the URL
- update the router to honor default example numbers and keep example 1 in both iframe src and history paths when requested

## Testing
- npm test *(fails: Playwright browser download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e651fde3a883249074f154817618ca