### PR TITLE
Restore placeholder text for example descriptions

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -48,8 +48,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -34,8 +34,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -56,8 +56,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -163,8 +163,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -190,8 +190,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -181,8 +181,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -40,8 +40,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
             <div class="task-check-host" data-task-check-host hidden>
               <button id="btnCheck" class="btn" type="button">Sjekk</button>
               <div id="status" class="status" role="status" aria-live="polite" hidden></div>

--- a/figurtall.html
+++ b/figurtall.html
@@ -136,8 +136,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -392,8 +392,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
             <div class="task-check-host" data-task-check-host hidden>
               <button class="btn" id="btnCheck" type="button">Sjekk fortegnsskjema</button>
               <div id="checkStatus" class="status status--info" hidden></div>

--- a/graftegner.html
+++ b/graftegner.html
@@ -240,8 +240,7 @@
       <div class="side">
         <div class="card card--examples" id="examplesCard">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
             <div id="checkArea" class="checkbar" data-task-check-host hidden></div>
           </div>
           <div class="toolbar">

--- a/kuler.html
+++ b/kuler.html
@@ -85,8 +85,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -78,8 +78,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -112,8 +112,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/nkant.html
+++ b/nkant.html
@@ -82,8 +82,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -44,8 +44,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -412,8 +412,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
             <div class="task-check-host" data-task-check-host hidden>
               <button id="btnCheck" class="btn btn--success" type="button">Sjekk svar</button>
               <div id="statusMessage" class="status" role="status" aria-live="polite" hidden></div>

--- a/tallinje.html
+++ b/tallinje.html
@@ -173,8 +173,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
             <div class="task-check-host" data-task-check-host hidden>
               <button id="btnCheck" class="btn btn--success" type="button">Sjekk svar</button>
               <div id="checkStatus" class="status" role="status" aria-live="polite" hidden></div>

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -34,8 +34,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -169,8 +169,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -220,8 +220,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
-            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+            <textarea id="exampleDescription" aria-label="Oppgavetekst (valgfritt)" placeholder="Oppgavetekst (valgfritt)"></textarea>
           </div>
           <div class="toolbar">
             <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>


### PR DESCRIPTION
## Summary
- restore the in-field "Oppgavetekst (valgfritt)" placeholder for example description textareas while keeping the aria-label for accessibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e65839d2548324855f4b318e6eb673