### PR TITLE
Ensure Graftegner task mode shows description preview

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -200,6 +200,9 @@
     if (force || normalized !== lastAppliedAppMode) {
       applyAppMode(normalized);
     }
+    if (normalized === 'task') {
+      ensureTaskModeDescriptionRendered();
+    }
     if (notifyParent && (changed || opts.alwaysNotify === true)) {
       postParentAppMode(normalized);
     }
@@ -2199,6 +2202,20 @@
           renderLegacy();
         }
       });
+  }
+
+  function ensureTaskModeDescriptionRendered() {
+    const input = getDescriptionInput();
+    if (!input) return;
+    const value = typeof input.value === 'string' ? input.value : '';
+    if (!value || !value.trim()) return;
+    const preview = getDescriptionPreviewElement();
+    if (!preview) return;
+    const isEmpty = preview.getAttribute('data-empty') !== 'false';
+    const isHidden = preview.hasAttribute('hidden');
+    if (isEmpty || isHidden) {
+      renderDescriptionPreviewFromValue(value, { force: true });
+    }
   }
 
   function updateDescriptionCollapsedState(target) {


### PR DESCRIPTION
## Summary
- trigger a description preview refresh whenever the app switches into task mode
- add a helper that forces the preview to render when hidden but the textarea already has content

## Testing
- npx playwright test tests/task-mode-description.spec.js *(fails: host system missing Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e67479ecdc83249a3b5def130789ac