### PR TITLE
Fix deep cloning fallback for history state snapshots

### DIFF
--- a/examples-trash.js
+++ b/examples-trash.js
@@ -27,7 +27,11 @@
     }
     const tag = toString.call(value);
     if (tag === '[object Array]') {
-      return value.slice();
+      const clone = new Array(value.length);
+      for (let i = 0; i < value.length; i++) {
+        clone[i] = cloneState(value[i]);
+      }
+      return clone;
     }
     if (tag === '[object Date]') {
       return new Date(value.getTime());
@@ -60,12 +64,12 @@
       const clone = {};
       const keys = Object.keys(value);
       for (let i = 0; i < keys.length; i++) {
-        clone[keys[i]] = value[keys[i]];
+        clone[keys[i]] = cloneState(value[keys[i]]);
       }
       if (typeof Object.getOwnPropertySymbols === 'function') {
         const symbols = Object.getOwnPropertySymbols(value);
         for (let i = 0; i < symbols.length; i++) {
-          clone[symbols[i]] = value[symbols[i]];
+          clone[symbols[i]] = cloneState(value[symbols[i]]);
         }
       }
       return clone;

--- a/examples.js
+++ b/examples.js
@@ -345,7 +345,11 @@
     }
     const tag = toString.call(value);
     if (tag === '[object Array]') {
-      return value.slice();
+      const clone = new Array(value.length);
+      for (let i = 0; i < value.length; i++) {
+        clone[i] = cloneState(value[i]);
+      }
+      return clone;
     }
     if (tag === '[object Date]') {
       return new Date(value.getTime());
@@ -378,12 +382,12 @@
       const clone = {};
       const keys = Object.keys(value);
       for (let i = 0; i < keys.length; i++) {
-        clone[keys[i]] = value[keys[i]];
+        clone[keys[i]] = cloneState(value[keys[i]]);
       }
       if (typeof Object.getOwnPropertySymbols === 'function') {
         const symbols = Object.getOwnPropertySymbols(value);
         for (let i = 0; i < symbols.length; i++) {
-          clone[symbols[i]] = value[symbols[i]];
+          clone[symbols[i]] = cloneState(value[symbols[i]]);
         }
       }
       return clone;


### PR DESCRIPTION
## Summary
- recursively clone array elements in the history state helper when structuredClone is unavailable
- deep copy nested properties for plain objects in both examples viewers to keep cached history state immutable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67e2fec548324a1dc915574750954