### PR TITLE
Fix toolbar layout in fortegnsskjema

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -217,12 +217,14 @@
       display: block;
       touch-action: none;
     }
-    .toolbar,
     .controls,
     .rows-list,
     .points-list {
       display: flex;
       flex-direction: column;
+      gap: 12px;
+    }
+    .toolbar {
       gap: 12px;
     }
     .toolbar-row {


### PR DESCRIPTION
## Summary
- ensure the example toolbar keeps its horizontal layout so the action buttons sit side-by-side
- keep the original column layout for the other control lists while widening the toolbar gap for spacing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e67f29ffc48324990b65be185f2efc