### PR TITLE
Handle deletion of provided examples in viewer

### DIFF
--- a/examples-viewer.js
+++ b/examples-viewer.js
@@ -640,13 +640,20 @@ async function renderExamples(options) {
       delBtn.textContent = 'Slett';
       delBtn.addEventListener('click', async () => {
         const updated = examples.slice();
-        updated.splice(idx, 1);
+        const removed = updated.splice(idx, 1);
         const deletedProvided = readDeletedProvided(path);
+        const builtinKey = removed && removed.length ? removed[0] && removed[0].__builtinKey : null;
+        if (typeof builtinKey === 'string') {
+          const normalized = builtinKey.trim();
+          if (normalized && !deletedProvided.includes(normalized)) {
+            deletedProvided.push(normalized);
+          }
+        }
         writeLocalEntry(path, {
           examples: updated,
           deletedProvided
         });
-        if (updated.length) {
+        if (updated.length || deletedProvided.length) {
           updateBackendCache(path, {
             path,
             examples: updated,


### PR DESCRIPTION
## Summary
- add tracking of deleted provided examples when removing them from the viewer
- keep cached backend entries when only deleted provided examples remain

## Testing
- not run (Playwright dependency installation was interrupted in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e68493734c8324b83580de623411b2