### PR TITLE
Keep task mode description preview visible

### DIFF
--- a/base.css
+++ b/base.css
@@ -515,8 +515,11 @@ body[data-app-mode="task"] .card--examples {
 }
 
 body[data-app-mode="task"] .card--examples .toolbar,
-body[data-app-mode="task"] .card--examples .example-tabs,
-body[data-app-mode="task"] .card--examples .example-settings {
+body[data-app-mode="task"] .card--examples .example-tabs {
+  display: none !important;
+}
+
+body[data-app-mode="task"] .card--examples .example-settings > :not(.example-description) {
   display: none !important;
 }
 

--- a/split.css
+++ b/split.css
@@ -275,6 +275,15 @@ body[data-app-mode="task"] .card--examples {
   gap: 12px;
 }
 
+body[data-app-mode="task"] .card--examples .toolbar,
+body[data-app-mode="task"] .card--examples .example-tabs {
+  display: none !important;
+}
+
+body[data-app-mode="task"] .card--examples .example-settings > :not(.example-description) {
+  display: none !important;
+}
+
 body[data-app-mode="task"] .card--examples .example-description textarea {
   display: none;
   min-height: 0;


### PR DESCRIPTION
## Summary
- stop hiding the entire `.example-settings` container in task mode so the description preview remains rendered
- hide only the non-description children of `.example-settings` when the UI switches to task mode across both `base.css` and `split.css`

## Testing
- `npm test -- --project=chromium tests/task-mode-description.spec.js` *(fails: Playwright browser download blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e68bf7d8b083248bfeda7253e0276f