### PR TITLE
Avoid forcing default example query when navigating

### DIFF
--- a/router.js
+++ b/router.js
@@ -1127,9 +1127,23 @@ window.addEventListener('message', event => {
     return;
   }
   const parsedNumber = Number(data.exampleNumber);
-  const exampleNumber = Number.isFinite(parsedNumber) && parsedNumber > 0 ? parsedNumber : null;
+  const exampleNumber = Number.isFinite(parsedNumber) && parsedNumber > 0 ? Math.trunc(parsedNumber) : null;
+  const previousExampleWasExplicit = currentExampleIsExplicit === true;
+  let defaultExampleNumber = null;
+  if (
+    currentEntry &&
+    Number.isFinite(currentEntry.defaultExampleNumber) &&
+    currentEntry.defaultExampleNumber > 0
+  ) {
+    defaultExampleNumber = Math.trunc(currentEntry.defaultExampleNumber);
+  }
+  const matchesDefaultFallback =
+    exampleNumber != null &&
+    defaultExampleNumber != null &&
+    exampleNumber === defaultExampleNumber &&
+    !previousExampleWasExplicit;
   currentExampleNumber = exampleNumber;
-  currentExampleIsExplicit = Number.isFinite(exampleNumber);
+  currentExampleIsExplicit = exampleNumber != null && !matchesDefaultFallback;
   updateHistoryState(currentEntry, exampleNumber, { replaceHistory: true, force: true });
   updateActiveTaskIndicator();
   if (currentMode === 'task') {


### PR DESCRIPTION
## Summary
- treat default example fallbacks as non-explicit so navigation no longer forces `example=1` on iframe loads or history updates
- track whether the current example was explicitly requested to keep refresh flows from reintroducing the query parameter
- guard the example-change listener from marking default fallbacks as explicit after iframe messages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67e3068e08324b921062b8172e003